### PR TITLE
Fixed regression involving invalid token requirement

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -171,8 +171,8 @@ class PlexClient(PlexObject):
 
     def url(self, key):
         """ Build a URL string with proper token argument. """
-        if not self._baseurl or not self._token:
-            raise BadRequest('PlexClient object missing baseurl or token.')
+        if not self._baseurl:
+            raise BadRequest('PlexClient object missing baseurl.')
         if self._token:
             delim = '&' if '?' in key else '?'
             return '%s%s%sX-Plex-Token=%s' % (self._baseurl, key, delim, self._token)

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -208,7 +208,7 @@ class PlexServer(PlexObject):
         for elem in self.query('/clients'):
             if elem.attrib.get('name').lower() == name.lower():
                 baseurl = 'http://%s:%s' % (elem.attrib['host'], elem.attrib['port'])
-                return PlexClient(baseurl, server=self, data=elem)
+                return PlexClient(baseurl=baseurl, server=self, data=elem)
         raise NotFound('Unknown client name: %s' % name)
 
     def createPlaylist(self, title, items):


### PR DESCRIPTION
I found what appear to be two small regressions in client.py and server.py when compared to the 2.0 branch.  The url function in client.py requires the optional token preventing tokenless operation.  This pull request reverts the behavior to allow the token to be optional once more.  In addition, the client function in server.py was updated to explicitly name the baseurl parameter as it is no longer the first argument of the constructor.