### PR TITLE
fix typos in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 #---------------------------------------------------------
 # PlexAPI core requirements.
-# pip install -r requirments.txt
+# pip install -r requirements.txt
 #---------------------------------------------------------
 requests
 tqdm

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 #---------------------------------------------------------
 # PlexAPI requirements to run py.test.
-# pip install -r requirments_dev.txt
+# pip install -r requirements_dev.txt
 #---------------------------------------------------------
 coveralls
 flake8


### PR DESCRIPTION
requirements.txt & requirements_dev.txt had typos in the "pip install" command 