### PR TITLE
update plexurl

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -29,7 +29,7 @@ class MyPlexAccount(PlexObject):
             timeout (int): timeout in seconds on initial connect to myplex (default config.TIMEOUT).
 
         Attributes:
-            SIGNIN (str): 'https://my.plexapp.com/users/sign_in.xml'
+            SIGNIN (str): 'https://plex.tv/users/sign_in.xml'
             key (str): 'https://plex.tv/users/account'
             authenticationToken (str): Unknown.
             certificateVersion (str): Unknown.
@@ -67,7 +67,7 @@ class MyPlexAccount(PlexObject):
     REMOVEINVITE = 'https://plex.tv/api/invites/requested/{userId}?friend=0&server=1&home=0'    # delete
     REQUESTED = 'https://plex.tv/api/invites/requested'                                         # get
     REQUESTS = 'https://plex.tv/api/invites/requests'                                           # get
-    SIGNIN = 'https://my.plexapp.com/users/sign_in.xml'                                         # get with auth
+    SIGNIN = 'https://plex.tv/users/sign_in.xml'                                                # get with auth
     WEBHOOKS = 'https://plex.tv/api/v2/user/webhooks'                                           # get, post with data
     # Key may someday switch to the following url. For now the current value works.
     # https://plex.tv/api/v2/user?X-Plex-Token={token}&X-Plex-Client-Identifier={clientId}


### PR DESCRIPTION
It appears plex is doing away with the plexapp.com url.
It no longer has a valid SAN cert for that domain as it redirects to plex.tv now.
Update myplex.py to reflect new signin URL.