### PR TITLE
added userRating property to Track

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -251,7 +251,8 @@ class Track(Audio, Playable):
             parentThumb (str): URL to album thumbnail image.
             parentTitle (str): Name of the album for this track.
             primaryExtraKey (str): Unknown
-            ratingCount (int): Rating of this track (1-10?)
+            ratingCount (int): Unknown
+            userRating (float): Rating of this track (0.0 - 10.0) equaling (0 stars - 5 stars)
             viewOffset (int): Unknown
             year (int): Year this track was released.
             sessionKey (int): Session Key (active sessions only).
@@ -284,6 +285,7 @@ class Track(Audio, Playable):
         self.parentTitle = data.attrib.get('parentTitle')
         self.primaryExtraKey = data.attrib.get('primaryExtraKey')
         self.ratingCount = utils.cast(int, data.attrib.get('ratingCount'))
+        self.userRating = utils.cast(float, data.attrib.get('userRating', 0))
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.year = utils.cast(int, data.attrib.get('year'))
         self.media = self.findItems(data, media.Media)


### PR DESCRIPTION
I figured that using `float `is better than `int`, even though it is an integer right now. This should make it ready for any changes in the future if Plex starts implementing continuous ratings.

I still couldn't figure out what the `ratingCount` property is supposed to express. I ran an analysis on many files in my server. Approx. half of them do not have a value assigned to this property. The other half seems to have random positive values that do not correlate with the (start) rating they have. Also it is not related to the play count.