### PR TITLE
Fix issue #272 (No authToken) and adding getToken program

### DIFF
--- a/tools/plex-download.py
+++ b/tools/plex-download.py
@@ -63,8 +63,7 @@ def get_item_from_url(url):
         raise SystemExit('Unknown or ambiguous client id: %s' % clientid)
     server = servers[0].connect()
     return server.fetchItem(key)
-
-
+	
 if __name__ == '__main__':
     # Command line parser
     from plexapi import CONFIG
@@ -74,7 +73,7 @@ if __name__ == '__main__':
                         default=CONFIG.get('auth.myplex_username'))
     parser.add_argument('-p', '--password', help='Your Plex password',
                         default=CONFIG.get('auth.myplex_password'))
-    parser.add_argument('--url', default=None, help='Download from URL (only paste after !)')
+    parser.add_argument('--url', default=None, help='Download from URL (only paste after !)')	
     opts = parser.parse_args()
     # Search item to download
     account = utils.getMyPlexAccount(opts)
@@ -84,8 +83,7 @@ if __name__ == '__main__':
             # We do this manually since we dont want to add a progress to Episode etc
             filename = '%s.%s' % (item._prettyfilename(), part.container)
             url = item._server.url('%s?download=1' % part.key)
-            filepath = utils.download(url, filename=filename, savepath=os.getcwd(),
+            filepath = utils.download(url, token=account.authenticationToken, filename=filename, savepath=os.getcwd(),
                                       session=item._server._session, showstatus=True)
             #print('  %s' % filepath)
-
 

--- a/tools/plex-gettoken.py
+++ b/tools/plex-gettoken.py
@@ -1,0 +1,17 @@
+import requests
+
+url = "https://plex.tv/users/sign_in.json"
+
+username = input("Plex username: ")
+password = input("Plex password: ")
+
+payload = "user%5Blogin%5D=" +  username + "&user%5Bpassword%5D=" + password
+headers = {
+    'x-plex-client-identifier': "plexapi",
+    'x-plex-product': "plexapi",
+    }
+
+data = requests.request("POST", url, data=payload, headers=headers)
+data = str(data.text)
+token = data[(data.find("authToken")+12):((data.find("authToken")+12)+20)]
+print(token)


### PR DESCRIPTION
Fix Issue with plex-download.py by adding authToken.

Add plex-gettoken.py as a simple way to get authToken. Useable as standalone or as part of a larger program with slight modification.