### PR TITLE
[WIP] Sync support

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -92,6 +92,11 @@ class MediaPart(PlexObject):
         self.indexes = data.attrib.get('indexes')
         self.key = data.attrib.get('key')
         self.size = cast(int, data.attrib.get('size'))
+        self.decision = data.attrib.get('decision')
+        self.optimizedForStreaming = cast(bool, data.attrib.get('optimizedForStreaming'))
+        self.syncItemId = cast(int, data.attrib.get('syncItemId'))
+        self.syncState = data.attrib.get('syncState')
+        self.videoProfile = data.attrib.get('videoProfile')
         self.streams = self._buildStreams(data)
 
     def _buildStreams(self, data):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -3,7 +3,7 @@ import copy
 import requests
 import time
 from requests.status_codes import _codes as codes
-from plexapi import BASE_HEADERS, CONFIG, TIMEOUT
+from plexapi import BASE_HEADERS, CONFIG, TIMEOUT, X_PLEX_IDENTIFIER
 from plexapi import log, logfilter, utils
 from plexapi.base import PlexObject
 from plexapi.exceptions import BadRequest, NotFound
@@ -11,6 +11,7 @@ from plexapi.client import PlexClient
 from plexapi.compat import ElementTree
 from plexapi.library import LibrarySection
 from plexapi.server import PlexServer
+from plexapi.sync import SyncList
 from plexapi.utils import joinArgs
 
 
@@ -377,6 +378,14 @@ class MyPlexAccount(PlexObject):
             params['optOutLibraryStats'] = int(library)
         url = 'https://plex.tv/api/v2/user/privacy'
         return self.query(url, method=self._session.put, params=params)
+
+    def syncItems(self, clientId=None):
+        if clientId is None:
+            clientId = X_PLEX_IDENTIFIER
+
+        data = self.query(SyncList.key.format(clientId=clientId))
+
+        return SyncList(self, data)
 
 
 class MyPlexUser(PlexObject):

--- a/plexapi/sync.py
+++ b/plexapi/sync.py
@@ -1,31 +1,53 @@
 # -*- coding: utf-8 -*-
 import requests
-from plexapi import utils
+import plexapi
 from plexapi.exceptions import NotFound
+from plexapi.base import PlexObject
 
 
-class SyncItem(object):
-    """ Sync Item. This doesn't current work. """
-    def __init__(self, device, data, servers=None):
-        self._device = device
-        self._servers = servers
-        self._loadData(data)
+def init(replace_provides=False):
+    if replace_provides or not plexapi.X_PLEX_PROVIDES:
+        plexapi.X_PLEX_PROVIDES = 'sync-target'
+    else:
+        plexapi.X_PLEX_PROVIDES += ',sync-target'
+
+    plexapi.BASE_HEADERS['X-Plex-Sync-Version'] = '2'
+    plexapi.BASE_HEADERS['X-Plex-Provides'] = plexapi.X_PLEX_PROVIDES
+
+    # mimic iPhone SE
+    plexapi.X_PLEX_PLATFORM = 'iOS'
+    plexapi.X_PLEX_PLATFORM_VERSION = '11.4.1'
+    plexapi.X_PLEX_DEVICE = 'iPhone'
+
+    plexapi.BASE_HEADERS['X-Plex-Platform'] = plexapi.X_PLEX_PLATFORM
+    plexapi.BASE_HEADERS['X-Plex-Platform-Version'] = plexapi.X_PLEX_PLATFORM_VERSION
+    plexapi.BASE_HEADERS['X-Plex-Device'] = plexapi.X_PLEX_DEVICE
+    plexapi.BASE_HEADERS['X-Plex-Model'] = '8,4'
+    plexapi.BASE_HEADERS['X-Plex-Vendor'] = 'Apple'
+
+
+class SyncItem(PlexObject):
+    TAG = 'SyncItem'
+
+    def __init__(self, server, data, initpath=None, clientIdentifier=None):
+        super().__init__(server, data, initpath)
+        self.clientIdentifier = clientIdentifier
 
     def _loadData(self, data):
         self._data = data
-        self.id = utils.cast(int, data.attrib.get('id'))
-        self.version = utils.cast(int, data.attrib.get('version'))
+        self.id = plexapi.utils.cast(int, data.attrib.get('id'))
+        self.version = plexapi.utils.cast(int, data.attrib.get('version'))
         self.rootTitle = data.attrib.get('rootTitle')
         self.title = data.attrib.get('title')
         self.metadataType = data.attrib.get('metadataType')
         self.machineIdentifier = data.find('Server').get('machineIdentifier')
-        self.status = data.find('Status').attrib.copy()
+        self.status = Status(self._server, data.find('Status'))
         self.MediaSettings = data.find('MediaSettings').attrib.copy()
         self.policy = data.find('Policy').attrib.copy()
         self.location = data.find('Location').attrib.copy()
 
     def server(self):
-        server = list(filter(lambda x: x.machineIdentifier == self.machineIdentifier, self._servers))
+        server = list(filter(lambda x: x.clientIdentifier == self.machineIdentifier, self._server.resources()))
         if 0 == len(server):
             raise NotFound('Unable to find server with uuid %s' % self.machineIdentifier)
         return server[0]
@@ -35,8 +57,37 @@ class SyncItem(object):
         key = '/sync/items/%s' % self.id
         return server.fetchItems(key)
 
-    def markAsDone(self, sync_id):
+    def markAsDone(self):
         server = self.server().connect()
         url = '/sync/%s/%s/files/%s/downloaded' % (
-            self._device.clientIdentifier, server.machineIdentifier, sync_id)
+            self.clientIdentifier, server.machineIdentifier, self.id)
         server.query(url, method=requests.put)
+
+
+class SyncList(PlexObject):
+    key = 'https://plex.tv/devices/{clientId}/sync_items'
+    TAG = 'SyncList'
+
+    def _loadData(self, data):
+        self._data = data
+        self.clientId = data.attrib.get('clientIdentifier')
+
+        for elem in data:
+            if elem.tag == 'SyncItems':
+                self.items = self.findItems(elem, SyncItem)
+
+
+class Status(PlexObject):
+    TAG = 'Status'
+
+    def _loadData(self, data):
+        self._data = data
+        self.failureCode = data.attrib.get('failureCode')
+        self.failure = data.attrib.get('failure')
+        self.state = data.attrib.get('complete')
+        self.itemsCount = plexapi.utils.cast(int, data.attrib.get('itemsCount'))
+        self.itemsCompleteCount = plexapi.utils.cast(int, data.attrib.get('itemsCompleteCount'))
+        self.totalSize = plexapi.utils.cast(int, data.attrib.get('totalSize'))
+        self.itemsDownloadedCount = plexapi.utils.cast(int, data.attrib.get('itemsDownloadedCount'))
+        self.itemsReadyCount = plexapi.utils.cast(int, data.attrib.get('itemsReadyCount'))
+        self.itemsSuccessfulCount = plexapi.utils.cast(int, data.attrib.get('itemsSuccessfulCount'))


### PR DESCRIPTION
Hi there! I've started working on Mobile Sync support. If anybody has any comments on the code, or just any feature requests — feel free to tell :)

At the beginning the code can do few useful things:

1. Initialise the "sync" env: tell the plex.tv that the client supports syncing, and the client can be used as sync-target
2. Unfortunately I have to "fake" used platform/device info, because transcoding is depends on this values
3. And finally you can download converted files, by iterating over media parts and looking for ones with required `syncItemId`

The reason why I'm started this is simple: I have a WD My Passport Pro which has the Plex onboard and I'd like to have my "travel" library in sync with the main one. I've already started the project for this (andrey-yantsen/plexiglas) but for now there is nothing to see there.

fix #134