### PR TITLE
Add a method to request a claim token

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -479,9 +479,9 @@ class MyPlexAccount(PlexObject):
         return SyncItem(self, data, None, clientIdentifier=client.clientIdentifier)
 
     def claimToken(self):
-        """
-        Returns a str, a new "claim-token", which you can use to register your new Plex Server instance to your account
-        See: https://hub.docker.com/r/plexinc/pms-docker/, https://www.plex.tv/claim/
+        """ Returns a str, a new "claim-token", which you can use to register your new Plex Server instance to your
+            account.
+            See: https://hub.docker.com/r/plexinc/pms-docker/, https://www.plex.tv/claim/
         """
         response = self._session.get('https://plex.tv/api/claim/token.json', headers=self._headers(), timeout=TIMEOUT)
         if response.status_code not in (200, 201, 204):  # pragma: no cover

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -478,6 +478,19 @@ class MyPlexAccount(PlexObject):
 
         return SyncItem(self, data, None, clientIdentifier=client.clientIdentifier)
 
+    def claimToken(self):
+        """
+        Returns a str, a new "claim-token", which you can use to register your new Plex Server instance to your account
+        See: https://hub.docker.com/r/plexinc/pms-docker/, https://www.plex.tv/claim/
+        """
+        response = self._session.get('https://plex.tv/api/claim/token.json', headers=self._headers(), timeout=TIMEOUT)
+        if response.status_code not in (200, 201, 204):  # pragma: no cover
+            codename = codes.get(response.status_code)[0]
+            errtext = response.text.replace('\n', ' ')
+            log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
+            raise BadRequest('(%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
+        return response.json()['token']
+
 
 class MyPlexUser(PlexObject):
     """ This object represents non-signed in users such as friends and linked

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -165,3 +165,7 @@ def test_myplex_plexpass_attributes(account_plexpass):
     assert 'premium_music_metadata' in account_plexpass.subscriptionFeatures
     assert 'plexpass' in account_plexpass.roles
     assert set(account_plexpass.entitlements) == utils.ENTITLEMENTS
+
+
+def test_myplex_claimToken(account):
+    assert account.claimToken().startswith('claim-')


### PR DESCRIPTION
With ability to request a "[claim token](https://www.plex.tv/claim/)" we could be able to dynamically create Plex instances.

In theory, with this we can automatically create a Plex instance (all thanks to [official docker image](https://hub.docker.com/r/plexinc/pms-docker/)), run the tests, and destroy it.