### PR TITLE
Add enable_fast_connect configuration parameter

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,6 +55,15 @@ Section [plexapi] Options
     Timeout in seconds to use when making requests to the Plex Media Server or Plex Client
     resources (default: 30).
 
+**enable_fast_connect**
+    By default Plex will be trying to connect with all available connection methods simultaneously,
+    combining local and remote addresses, http and https, and be waiting for all connection to
+    establish (or fail due to timeout / any other error), this can take long time when you're trying
+    to connect to your Plex Server outside of your home network.
+
+    When the options is set to `true` the connection procedure will be aborted with first successfully
+    established connection.
+
 
 Section [auth] Options
 ----------------------

--- a/plexapi/__init__.py
+++ b/plexapi/__init__.py
@@ -17,6 +17,7 @@ PROJECT = 'PlexAPI'
 VERSION = '3.0.6'
 TIMEOUT = CONFIG.get('plexapi.timeout', 30, int)
 X_PLEX_CONTAINER_SIZE = CONFIG.get('plexapi.container_size', 100, int)
+X_PLEX_ENABLE_FAST_CONNECT = CONFIG.get('plexapi.enable_fast_connect', False, bool)
 
 # Plex Header Configuation
 X_PLEX_PROVIDES = CONFIG.get('header.provides', 'controller')

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -7,7 +7,7 @@ import time
 import zipfile
 from datetime import datetime
 from getpass import getpass
-from threading import Thread
+from threading import Thread, Event
 from tqdm import tqdm
 from plexapi import compat
 from plexapi.exceptions import NotFound
@@ -145,22 +145,26 @@ def searchType(libtype):
 
 def threaded(callback, listargs):
     """ Returns the result of <callback> for each set of \*args in listargs. Each call
-        to <callback. is called concurrently in their own separate threads.
+        to <callback> is called concurrently in their own separate threads.
 
         Parameters:
             callback (func): Callback function to apply to each set of \*args.
             listargs (list): List of lists; \*args to pass each thread.
     """
     threads, results = [], []
+    job_is_done_event = Event()
     for args in listargs:
         args += [results, len(results)]
         results.append(None)
-        threads.append(Thread(target=callback, args=args))
+        threads.append(Thread(target=callback, args=args, kwargs=dict(job_is_done_event=job_is_done_event)))
         threads[-1].setDaemon(True)
         threads[-1].start()
-    for thread in threads:
-        thread.join()
-    return results
+    while not job_is_done_event.is_set():
+        if all([not t.is_alive() for t in threads]):
+            break
+        time.sleep(0.05)
+
+    return [r for r in results if r is not None]
 
 
 def toDatetime(value, format=None):


### PR DESCRIPTION
Most times I run the my things outside my home network, when the local IP of the server is not available, and it takes annoyingly long time to establish the connection. With this option set you don't have to wait until all available connection methods will be established.

Moved from #282.