### PR TITLE
Library section id for all

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -145,7 +145,12 @@ class PlexObject(object):
             on how this is used.
         """
         data = self._server.query(ekey)
-        return self.findItems(data, cls, ekey, **kwargs)
+        items = self.findItems(data, cls, ekey, **kwargs)
+        librarySectionID = data.attrib.get('librarySectionID')
+        if librarySectionID:
+            for item in items:
+                item.librarySectionID = librarySectionID
+        return items
 
     def findItems(self, data, cls=None, initpath=None, **kwargs):
         """ Load the specified data to find and build all items with the specified tag
@@ -159,13 +164,10 @@ class PlexObject(object):
             kwargs['type'] = cls.TYPE
         # loop through all data elements to find matches
         items = []
-        librarySectionID = data.attrib.get('librarySectionID')
         for elem in data:
             if self._checkAttrs(elem, **kwargs):
                 item = self._buildItemOrNone(elem, cls, initpath)
                 if item is not None:
-                    if librarySectionID:
-                        item.librarySectionID = librarySectionID
                     items.append(item)
         return items
 

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -159,10 +159,13 @@ class PlexObject(object):
             kwargs['type'] = cls.TYPE
         # loop through all data elements to find matches
         items = []
+        librarySectionID = data.attrib.get('librarySectionID')
         for elem in data:
             if self._checkAttrs(elem, **kwargs):
                 item = self._buildItemOrNone(elem, cls, initpath)
                 if item is not None:
+                    if librarySectionID:
+                        item.librarySectionID = librarySectionID
                     items.append(item)
         return items
 

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from plexapi import media, utils
 from plexapi.base import PlexPartialObject
-from plexapi.exceptions import NotFound
+from plexapi.exceptions import NotFound, BadRequest
 
 
 @utils.registerPlexObject
@@ -122,4 +122,9 @@ class Photo(PlexPartialObject):
 
     def section(self):
         """ Returns the :class:`~plexapi.library.LibrarySection` this item belongs to. """
-        return self._server.library.sectionByID(self.photoalbum().librarySectionID)
+        if hasattr(self, 'librarySectionID'):
+            return self._server.library.sectionByID(self.librarySectionID)
+        elif self.parentKey:
+            return self._server.library.sectionByID(self.photoalbum().librarySectionID)
+        else:
+            raise BadRequest('Unable to get section for photo, can`t find librarySectionID')


### PR DESCRIPTION
It's a quite controversial change, but for now I have no idea how to do this thing better. Basically `librarySectionID` field should be added automatically for any item if the field exists in metadata, and that's what I'm trying to achieve here.