### PR TITLE
Improvements in tests process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
     --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG
 
 script:
-  - py.test tests -rxXsaR --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
+  - py.test tests -rxXs --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
   - PLEXAPI_HEADER_PROVIDES='controller,sync-target' PLEXAPI_HEADER_PLATFORM=iOS PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1
-    PLEXAPI_HEADER_DEVICE=iPhone py.test tests/test_sync.py -rxXsaR --tb=native --verbose --cov-config .coveragerc
+    PLEXAPI_HEADER_DEVICE=iPhone py.test tests/test_sync.py -rxXs --tb=native --verbose --cov-config .coveragerc
     --cov=plexapi --cov-append
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ install:
     --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG
 
 script:
-  - py.test tests --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
+  - py.test tests -rxXs --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
   - PLEXAPI_HEADER_PROVIDES='controller,sync-target' PLEXAPI_HEADER_PLATFORM=iOS PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1
-    PLEXAPI_HEADER_DEVICE=iPhone py.test tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
-    --cov-append
+    PLEXAPI_HEADER_DEVICE=iPhone py.test tests/test_sync.py -rxXs --tb=native --verbose --cov-config .coveragerc
+    --cov=plexapi --cov-append
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ after_script:
 jobs:
   include:
     - python: 3.6
+      env:
+        - PLEX_CONTAINER_TAG=1.3.2.3112-1751929
+    - python: 3.6
       name: "Flake8"
       install:
         - pip install -r requirements_dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
       after_script: true
       env:
         - PLEX_CONTAINER_TAG=latest
+        - TEST_ACCOUNT_ONCE=1
     - stage: deploy
       name: "Deploy to PyPi"
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
     - python: 3.6
       env:
         - PLEX_CONTAINER_TAG=1.3.2.3112-1751929
+        - TEST_ACCOUNT_ONCE=1
     - python: 3.6
       name: "Flake8"
       install:
@@ -56,7 +57,6 @@ jobs:
       after_script: true
       env:
         - PLEX_CONTAINER_TAG=latest
-        - TEST_ACCOUNT_ONCE=1
     - stage: deploy
       name: "Deploy to PyPi"
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 install:
   - pip install -r requirements_dev.txt
   - PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-bootstraptest.py --destination plex --advertise-ip=127.0.0.1
-    --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG --accept-eula
+    --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG
 
 script:
   - py.test tests --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ python:
 env:
   global:
     - PLEXAPI_AUTH_SERVER_BASEURL=http://127.0.0.1:32400
-    - PLEXAPI_PLEXAPI_TIMEOUT=10
   matrix:
     - PLEX_CONTAINER_TAG=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
     --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG
 
 script:
-  - py.test tests -rxXs --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
+  - py.test tests -rxXsaR --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
   - PLEXAPI_HEADER_PROVIDES='controller,sync-target' PLEXAPI_HEADER_PLATFORM=iOS PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1
-    PLEXAPI_HEADER_DEVICE=iPhone py.test tests/test_sync.py -rxXs --tb=native --verbose --cov-config .coveragerc
+    PLEXAPI_HEADER_DEVICE=iPhone py.test tests/test_sync.py -rxXsaR --tb=native --verbose --cov-config .coveragerc
     --cov=plexapi --cov-append
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 install:
   - pip install -r requirements_dev.txt
   - PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-bootstraptest.py --destination plex --advertise-ip=127.0.0.1
-    --without-album --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG --accept-eula
+    --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG --accept-eula
 
 script:
   - py.test tests --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ stages:
   - name: deploy
     if: tag IS present
 
-cache: pip
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,70 @@
-language:
-- python
+language: python
+
+stages:
+  - test
+  - name: deploy
+    if: tag IS present
+
+cache: pip
+sudo: required
+services:
+  - docker
+
 python:
-- '2.7'
-- '3.4'
-- '3.6'
+  - 2.7
+  - 3.4
+  - 3.6
+
+env:
+  global:
+    - PLEXAPI_AUTH_SERVER_BASEURL=http://127.0.0.1:32400
+    - PLEXAPI_PLEXAPI_TIMEOUT=10
+  matrix:
+    - PLEX_CONTAINER_TAG=latest
+
 before_install:
-- pip install --upgrade pip
-- pip install --upgrade setuptools
-- pip install --upgrade pytest pytest-cov coveralls
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
+  - pip install --upgrade pytest pytest-cov coveralls
 install:
-- pip install -r requirements_dev.txt
+  - pip install -r requirements_dev.txt
+  - PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-bootstraptest.py --destination plex --advertise-ip=127.0.0.1
+    --without-album --bootstrap-timeout 300 --docker-tag $PLEX_CONTAINER_TAG --accept-eula
+
 script:
-- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then py.test tests --tb=native --verbose
-  --cov-config .coveragerc --cov=plexapi; fi
-- flake8 plexapi --exclude=compat.py --max-line-length=120 --ignore=E128,E701,E702,E731,W293
+  - py.test tests --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
+  - PLEXAPI_HEADER_PROVIDES='controller,sync-target' PLEXAPI_HEADER_PLATFORM=iOS PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1
+    PLEXAPI_HEADER_DEVICE=iPhone py.test tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
+    --cov-append
+
 after_success:
-- coveralls
-matrix:
-  fast_finish: true
-deploy:
-  provider: pypi
-  user: mjs7231
-  password:
-    secure: UhuEN9GAp9zMEXdVTxSrbhfYf4HjTcj47l093Qh1HYKmZACxJM/+JkQCm7+oHPJpo7YDLk2we9oEsQ41maZBr9WgZI1lwR6m590M12vPhPI7NCVzINxJqebc0uZhCFsAFFKA3kzpRQbDfsBUG4yL/AzeMcvJMgIg3m07KRVhBywnnRhQ77trbBI0Io5MBzfW9PYDeGJqlNDBM7SbB4tK0udGZQT9wmFwvIoJODPDnM15Ry4vpkVNww/vVgyHklmnYlPzQgvhSMOXk0+MWlYtaKmu6uuLAiRccT1Fsmi1POKuFEq8S0Z7w4LmwxCVRaCvsZdNW5eXWgPDhZXNcLrKMwjgJt9Vj3VcD+NCywux/C1hTq7tecBocA13kzbgg4fd2sATOjQT5iaRPGrDtKm8e00hxr125n0StDxXdYGl2W5sH0LCkZE6Vq1GjXYjKFXZeTk3Fzav/3N8IxHBX3CliJB/vbloJ2mpz1kXL4UTORl9pghPyGOOq2yJPYSSWly/RsAD7UDrL1/lezaPSJGKbZJ0CMyfA83kd82/hgZflOuBuTcPHCZSU3zMCs0fsImZZxr6Qm1tbff+iyNS/ufoYgeVfsWhlEl9FoLv1g4HG6oA+uDHz+jKz9uSRHcGqD6P4JJK+H+yy0PeYfo7b6eSqFxgt8q8QfifUaCrVoCiY+c=
-  on:
-    tags: true
+  - coveralls
+
+after_script:
+  - PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-teardowntest.py
+
+jobs:
+  include:
+    - python: 3.6
+      name: "Flake8"
+      install:
+        - pip install -r requirements_dev.txt
+      script: flake8 plexapi --exclude=compat.py --max-line-length=120 --ignore=E128,E701,E702,E731,W293
+      after_success: true
+      after_script: true
+      env:
+        - PLEX_CONTAINER_TAG=latest
+    - stage: deploy
+      name: "Deploy to PyPi"
+      python: 3.6
+      install: true
+      script: true
+      env:
+        - PLEX_CONTAINER_TAG=latest
+      deploy:
+        provider: pypi
+        user: mjs7231
+        password:
+          secure: UhuEN9GAp9zMEXdVTxSrbhfYf4HjTcj47l093Qh1HYKmZACxJM/+JkQCm7+oHPJpo7YDLk2we9oEsQ41maZBr9WgZI1lwR6m590M12vPhPI7NCVzINxJqebc0uZhCFsAFFKA3kzpRQbDfsBUG4yL/AzeMcvJMgIg3m07KRVhBywnnRhQ77trbBI0Io5MBzfW9PYDeGJqlNDBM7SbB4tK0udGZQT9wmFwvIoJODPDnM15Ry4vpkVNww/vVgyHklmnYlPzQgvhSMOXk0+MWlYtaKmu6uuLAiRccT1Fsmi1POKuFEq8S0Z7w4LmwxCVRaCvsZdNW5eXWgPDhZXNcLrKMwjgJt9Vj3VcD+NCywux/C1hTq7tecBocA13kzbgg4fd2sATOjQT5iaRPGrDtKm8e00hxr125n0StDxXdYGl2W5sH0LCkZE6Vq1GjXYjKFXZeTk3Fzav/3N8IxHBX3CliJB/vbloJ2mpz1kXL4UTORl9pghPyGOOq2yJPYSSWly/RsAD7UDrL1/lezaPSJGKbZJ0CMyfA83kd82/hgZflOuBuTcPHCZSU3zMCs0fsImZZxr6Qm1tbff+iyNS/ufoYgeVfsWhlEl9FoLv1g4HG6oA+uDHz+jKz9uSRHcGqD6P4JJK+H+yy0PeYfo7b6eSqFxgt8q8QfifUaCrVoCiY+c=
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 install:
   - pip install -r requirements_dev.txt
   - PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-bootstraptest.py --destination plex --advertise-ip=127.0.0.1
-    --without-album --bootstrap-timeout 300 --docker-tag $PLEX_CONTAINER_TAG --accept-eula
+    --without-album --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG --accept-eula
 
 script:
   - py.test tests --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,68 @@ Usage Examples
         print(playlist.title)
 
 
+Running tests over PlexAPI
+--------------------------
+
+In order to test the PlexAPI library you have to prepare a Plex Server instance with following libraries:
+
+1. Movies section (agent `com.plexapp.agents.imdb`) containing both movies:
+    * Sintel - https://durian.blender.org/
+    * Elephants Dream - https://orange.blender.org/
+    * Sita Sings the Blues - http://www.sitasingstheblues.com/
+    * Big Buck Bunny - https://peach.blender.org/
+2. TV Show section (agent `com.plexapp.agents.thetvdb`) containing the shows:
+    * Game of Thrones (Season 1 and 2)
+    * The 100 (Seasons 1 and 2)
+    * (or symlink the above movies with proper names)
+3. Music section (agent `com.plexapp.agents.lastfm`) containing the albums:
+    * Infinite State - Unmastered Impulses - https://github.com/kennethreitz/unmastered-impulses
+    * Broke For Free - Layers - http://freemusicarchive.org/music/broke_for_free/Layers/
+4. A Photos section (any agent) containing the photoalbums (photoalbum is just a folder on your disk):
+    * `Cats`
+    * Within `Cats` album you need to place 3 photos (cute cat photos, of course)
+    * Within `Cats` album you should place 3 more photoalbums (one of them should be named `Cats in bed`,
+      names of others doesn't matter)
+    * Within `Cats in bed` you need to place 7 photos
+    * Within other 2 albums you should place 1 photo in each
+
+Instead of manual creation of the library you could use a script `tools/plex-boostraptest.py` with appropriate
+arguments and add this new server to a shared user which username is defined in environment veriable `SHARED_USERNAME`.
+It uses `official docker image`_ to create a proper instance.
+
+Also in order to run most of the tests you have to provide some environment variables:
+
+* `PLEXAPI_AUTH_SERVER_BASEURL` containing an URL to your Plex instance, e.g. `http://127.0.0.1:32400` (without trailing
+  slash)
+* `PLEXAPI_AUTH_MYPLEX_USERNAME` and `PLEXAPI_AUTH_MYPLEX_PASSWORD` with your MyPlex username and password accordingly
+
+After this step you can run tests with following command:
+
+.. code-block:: bash
+
+    py.test tests -rxXs --ignore=tests/test_sync.py
+
+Some of the tests in main test-suite require a shared user in your account (e.g. `test_myplex_users`,
+`test_myplex_updateFriend`, etc.), you need to provide a valid shared user's username to get them running you need to
+provide the username of the shared user as an environment variable `SHARED_USERNAME`. You can enable a Guest account and
+simply pass `Guest` as `SHARED_USERNAME` (or just create a user like `plexapitest` and play with it).
+
+To be able to run tests over Mobile Sync api you have to some some more environment variables, to following values
+exactly:
+
+* PLEXAPI_HEADER_PROVIDES='controller,sync-target'
+* PLEXAPI_HEADER_PLATFORM=iOS
+* PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1
+* PLEXAPI_HEADER_DEVICE=iPhone
+
+And finally run the sync-related tests:
+
+.. code-block:: bash
+
+    py.test tests/test_sync.py -rxXs
+
+.. _official docker image: https://hub.docker.com/r/plexinc/pms-docker/
+
 Common Questions
 ----------------
 

--- a/plexapi/alert.py
+++ b/plexapi/alert.py
@@ -12,6 +12,18 @@ class AlertListener(threading.Thread):
         alerts you must call .start() on the object once it's created. When calling
         `PlexServer.startAlertListener()`, the thread will be started for you.
 
+        Known `state`-values for timeline entries, with identifier=`com.plexapp.plugins.library`:
+
+            :0: The item was created
+            :1: Reporting progress on item processing
+            :2: Matching the item
+            :3: Downloading the metadata
+            :4: Processing downloaded metadata
+            :5: The item processed
+            :9: The item deleted
+
+        When metadata agent is not set for the library processing ends with state=1.
+
         Parameters:
             server (:class:`~plexapi.server.PlexServer`): PlexServer this listener is connected to.
             callback (func): Callback function to call on recieved messages. The callback function

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -853,13 +853,11 @@ class PhotoSection(LibrarySection):
 
     def searchAlbums(self, title, **kwargs):
         """ Search for an album. See :func:`~plexapi.library.LibrarySection.search()` for usage. """
-        key = '/library/sections/%s/all?type=14' % self.key
-        return self.fetchItems(key, title=title)
+        return self.search(libtype='photoalbum', title=title, **kwargs)
 
     def searchPhotos(self, title, **kwargs):
         """ Search for a photo. See :func:`~plexapi.library.LibrarySection.search()` for usage. """
-        key = '/library/sections/%s/all?type=13' % self.key
-        return self.fetchItems(key, title=title)
+        return self.search(libtype='photo', title=title, **kwargs)
 
     def sync(self, resolution, limit=None, **kwargs):
         """ Add current Music library section as sync item for specified device.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -470,8 +470,8 @@ class LibrarySection(PlexObject):
                 libtype (str): Filter results to a spcifiec libtype (movie, show, episode, artist,
                     album, track; optional).
                 **kwargs (dict): Any of the available filters for the current library section. Partial string
-                        matches allowed. Multiple matches OR together. All inputs will be compared with the
-                        available options and a warning logged if the option does not appear valid.
+                        matches allowed. Multiple matches OR together. Negative filtering also possible, just add an
+                        exclamation mark to the end of filter name, e.g. `resolution!=1x1`.
 
                         * unwatched: Display or hide unwatched content (True, False). [all]
                         * duplicate: Display or hide duplicate items (True, False). [movie]
@@ -486,6 +486,9 @@ class LibrarySection(PlexObject):
                         * resolution: List of video resolutions to search within ([resolution_or_key, ...]). [movie]
                         * studio: List of studios to search within ([studio_or_key, ...]). [music]
                         * year: List of years to search within ([yyyy, ...]). [all]
+
+            Raises:
+                :class:`plexapi.exceptions.BadRequest`: when applying unknown filter
         """
         # cleanup the core arguments
         args = {}
@@ -510,7 +513,10 @@ class LibrarySection(PlexObject):
 
     def _cleanSearchFilter(self, category, value, libtype=None):
         # check a few things before we begin
-        if category not in self.ALLOWED_FILTERS:
+        if category.endswith('!'):
+            if category[:-1] not in self.ALLOWED_FILTERS:
+                raise BadRequest('Unknown filter category: %s' % category[:-1])
+        elif category not in self.ALLOWED_FILTERS:
             raise BadRequest('Unknown filter category: %s' % category)
         if category in self.BOOLEAN_FILTERS:
             return '1' if value else '0'
@@ -839,12 +845,12 @@ class PhotoSection(LibrarySection):
 
         Attributes:
             ALLOWED_FILTERS (list<str>): List of allowed search filters. ('all', 'iso',
-                'make', 'lens', 'aperture', 'exposure')
+                'make', 'lens', 'aperture', 'exposure', 'device', 'resolution')
             ALLOWED_SORT (list<str>): List of allowed sorting keys. ('addedAt')
             TAG (str): 'Directory'
             TYPE (str): 'photo'
     """
-    ALLOWED_FILTERS = ('all', 'iso', 'make', 'lens', 'aperture', 'exposure', 'device')
+    ALLOWED_FILTERS = ('all', 'iso', 'make', 'lens', 'aperture', 'exposure', 'device', 'resolution')
     ALLOWED_SORT = ('addedAt',)
     TAG = 'Directory'
     TYPE = 'photo'

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -844,7 +844,7 @@ class PhotoSection(LibrarySection):
             TAG (str): 'Directory'
             TYPE (str): 'photo'
     """
-    ALLOWED_FILTERS = ('all', 'iso', 'make', 'lens', 'aperture', 'exposure')
+    ALLOWED_FILTERS = ('all', 'iso', 'make', 'lens', 'aperture', 'exposure', 'device')
     ALLOWED_SORT = ('addedAt',)
     TAG = 'Directory'
     TYPE = 'photo'

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -395,7 +395,7 @@ class MyPlexAccount(PlexObject):
         if library is not None:
             params['optOutLibraryStats'] = int(library)
         url = 'https://plex.tv/api/v2/user/privacy'
-        return self.query(url, method=self._session.put, params=params)
+        return self.query(url, method=self._session.put, data=params)
 
     def syncItems(self, client=None, clientId=None):
         """ Returns an instance of :class:`plexapi.sync.SyncList` for specified client.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -278,7 +278,7 @@ class MyPlexAccount(PlexObject):
                 "invited_id": user.id}}
             url = self.FRIENDINVITE.format(machineId=machineId)
         # Remove share sections, add shares to user without shares, or update shares
-        if sectionIds:
+        if not user_servers or sectionIds:
             if removeSections is True:
                 response_servers = self.query(url, self._session.delete, json=params, headers=headers)
             elif 'invited_id' in params.get('shared_server', ''):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -376,7 +376,8 @@ class MyPlexAccount(PlexObject):
 
     def setWebhooks(self, urls):
         log.info('Setting webhooks: %s' % urls)
-        data = self.query(self.WEBHOOKS, self._session.post, data={'urls[]': urls})
+        data = {'urls[]': urls} if len(urls) else {'urls': ''}
+        data = self.query(self.WEBHOOKS, self._session.post, data=data)
         self._webhooks = self.listAttrs(data, 'url', etag='webhook')
         return self._webhooks
 

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -263,7 +263,7 @@ class MyPlexAccount(PlexObject):
         # Update friend servers
         response_filters = ''
         response_servers = ''
-        user = self.user(user.username if isinstance(user, MyPlexUser) else user)
+        user = user if isinstance(user, MyPlexUser) else self.user(user)
         machineId = server.machineIdentifier if isinstance(server, PlexServer) else server
         sectionIds = self._getSectionIds(machineId, sections)
         headers = {'Content-Type': 'application/json'}

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -154,7 +154,7 @@ class Photo(PlexPartialObject):
         sync_item.metadataType = self.METADATA_TYPE
         sync_item.machineIdentifier = self._server.machineIdentifier
 
-        section = self._server.library.sectionByID(self.librarySectionID)
+        section = self.section()
 
         sync_item.location = 'library://%s/item/%s' % (section.uuid, quote_plus(self.key))
         sync_item.policy = Policy.create(limit)

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -168,8 +168,8 @@ class Playlist(PlexPartialObject, Playable):
                                     :mod:`plexapi.sync` module. Used only when playlist contains video.
                 photoResolution (str): maximum allowed resolution for synchronized photos, see PHOTO_QUALITY_* values in
                                        the module :mod:`plexapi.sync`. Used only when playlist contains photos.
-                audioBitrate (int): maximum bitrate for synchronized music, better use one of MUSIC_BITRATE_* values from the
-                                    module :mod:`plexapi.sync`. Used only when playlist contains audio.
+                audioBitrate (int): maximum bitrate for synchronized music, better use one of MUSIC_BITRATE_* values
+                                    from the module :mod:`plexapi.sync`. Used only when playlist contains audio.
                 client (:class:`plexapi.myplex.MyPlexDevice`): sync destination, see
                                                                :func:`plexapi.myplex.MyPlexAccount.sync`.
                 clientId (str): sync destination, see :func:`plexapi.myplex.MyPlexAccount.sync`.

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -293,8 +293,6 @@ class PlexServer(PlexObject):
         releases = self.fetchItems('/updater/status')
         if len(releases):
             return releases[0]
-        else:
-            return None
 
     def isLatest(self):
         """ Check if the installed version of PMS is the latest. """

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -299,7 +299,6 @@ class PlexServer(PlexObject):
     def isLatest(self):
         """ Check if the installed version of PMS is the latest. """
         release = self.check_for_update(force=True)
-        print(release)
         return release is None
 
     def installUpdate(self):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -290,12 +290,17 @@ class PlexServer(PlexObject):
         part = '/updater/check?download=%s' % (1 if download else 0)
         if force:
             self.query(part, method=self._session.put)
-        return self.fetchItem('/updater/status')
+        releases = self.fetchItems('/updater/status')
+        if len(releases):
+            return releases[0]
+        else:
+            return None
 
     def isLatest(self):
         """ Check if the installed version of PMS is the latest. """
         release = self.check_for_update(force=True)
-        return bool(release.version == self.version)
+        print(release)
+        return release is None
 
     def installUpdate(self):
         """ Install the newest version of Plex Media Server. """

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -99,7 +99,7 @@ class Setting(PlexObject):
             group (str): Group name this setting is categorized as.
             enumValues (list,dict): List or dictionary of valis values for this setting.
     """
-    _bool_cast = lambda x: True if x == 'true' else False
+    _bool_cast = lambda x: True if x == 'true' or x == '1' else False
     _bool_str = lambda x: str(x).lower()
     TYPES = {
         'bool': {'type': bool, 'cast': _bool_cast, 'tostr': _bool_str},

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -14,9 +14,9 @@ from plexapi.exceptions import NotFound
 
 # Search Types - Plex uses these to filter specific media types when searching.
 # Library Types - Populated at runtime
-SEARCHTYPES = {'movie': 1, 'show': 2, 'season': 3, 'episode': 4,
-               'artist': 8, 'album': 9, 'track': 10, 'photo': 14,
-               'collection': 18}
+SEARCHTYPES = {'movie': 1, 'show': 2, 'season': 3, 'episode': 4, 'trailer': 5, 'comic': 6, 'person': 7,
+               'artist': 8, 'album': 9, 'track': 10, 'picture': 11, 'clip': 12, 'photo': 13, 'photoalbum': 14,
+               'playlist': 15, 'playlistFolder': 16, 'collection': 18, 'userPlaylistItem': 1001}
 PLEXOBJECTS = {}
 
 

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -323,7 +323,7 @@ class Show(Video):
 
     def seasons(self, **kwargs):
         """ Returns a list of :class:`~plexapi.video.Season` objects. """
-        key = '/library/metadata/%s/children' % self.ratingKey
+        key = '/library/metadata/%s/children?excludeAllLeaves=1' % self.ratingKey
         return self.fetchItems(key, **kwargs)
 
     def season(self, title=None):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,4 +15,4 @@ sphinx
 sphinx-rtd-theme
 sphinxcontrib-napoleon
 tqdm
-websocket-client==0.48.0
+websocket-client

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,6 @@ pytest
 pytest-cache
 pytest-cov
 pytest-mock
-pytest-rerunfailures
 recommonmark
 requests
 sphinx

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,7 @@ pytest
 pytest-cache
 pytest-cov
 pytest-mock
+pytest-rerunfailures
 recommonmark
 requests
 sphinx

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,4 +15,4 @@ sphinx
 sphinx-rtd-theme
 sphinxcontrib-napoleon
 tqdm
-websocket-client
+websocket-client==0.48.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,9 +208,12 @@ def photoalbum(photos):
 def shared_username(account):
     username = environ.get('SHARED_USERNAME', 'PKKid')
     for user in account.users():
-        if user.username == username:
+        if user.title.lower() == username.lower():
             return username
-    pytest.skip('Shared user wasn`t found')
+        elif (user.username and user.email and user.id and username.lower() in
+              (user.username.lower(), user.email.lower(), str(user.id))):
+            return username
+    pytest.skip('Shared user %s wasn`t found in your MyPlex account' % username)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 #    Broke For Free - Layers - http://freemusicarchive.org/music/broke_for_free/Layers/
 # 4. A Photos section containing the photoalbums:
 #    Cats (with cute cat photos inside)
+import time
 from datetime import datetime
 from functools import partial
 from os import environ
@@ -280,3 +281,15 @@ def is_string(value, gte=1):
 
 def is_thumb(key):
     return is_metadata(key, contains='/thumb/')
+
+
+def wait_until(condition_function, delay=0.25, timeout=1, *args, **kwargs):
+    start = time.time()
+    ready = condition_function(*args, **kwargs)
+    while not ready and time.time() - start < timeout:
+        time.sleep(delay)
+        ready = condition_function(*args, **kwargs)
+
+    assert ready, 'Wait timeout'
+
+    return ready

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@
 #    Cats (with cute cat photos inside)
 from datetime import datetime
 from functools import partial
+from os import environ
 
 import pytest
 import requests
@@ -78,8 +79,7 @@ def account():
 
 @pytest.fixture(scope='session')
 def account_once(account):
-    from os import environ
-    if environ.get('TEST_ACCOUNT_ONCE') != '1':
+    if environ.get('TEST_ACCOUNT_ONCE') != '1' and environ.get('CI') == 'true':
         pytest.skip('Do not forget to test this by providing TEST_ACCOUNT_ONCE=1')
     return account
 
@@ -201,6 +201,15 @@ def photoalbum(photos):
         return photos.get('Cats')
     except:
         return photos.get('photo_album1')
+
+
+@pytest.fixture()
+def shared_username(account):
+    username = environ.get('SHARED_USERNAME', 'PKKid')
+    for user in account.users():
+        if user.username == username:
+            return username
+    pytest.skip('Shared user wasn`t found')
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ CONTENTRATINGS = {'TV-14', 'TV-MA', 'G', 'NR'}
 FRAMERATES = {'24p', 'PAL', 'NTSC'}
 PROFILES = {'advanced simple', 'main', 'constrained baseline'}
 RESOLUTIONS = {'sd', '480', '576', '720', '1080'}
+ENTITLEMENTS = {'ios', 'cpms', 'roku', 'android', 'xbox_one', 'xbox_360', 'windows', 'windows_phone'}
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,14 @@ def account():
 
 
 @pytest.fixture(scope='session')
+def account_once(account):
+    from os import environ
+    if environ.get('TEST_ACCOUNT_ONCE') != '1':
+        pytest.skip('Do not forget to test this by providing TEST_ACCOUNT_ONCE=1')
+    return account
+
+
+@pytest.fixture(scope='session')
 def account_plexpass(account):
     if not account.subscriptionActive:
         pytest.skip('PlexPass subscription is not active, unable to test sync-stuff, be careful!')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,14 +76,21 @@ def account():
 
 
 @pytest.fixture(scope='session')
-def account_synctarget(account):
+def account_plexpass(account):
+    if not account.subscriptionActive:
+        pytest.skip('PlexPass subscription is not active, unable to test sync-stuff, be careful!')
+    return account
+
+
+@pytest.fixture(scope='session')
+def account_synctarget(account_plexpass):
     assert 'sync-target' in plexapi.X_PLEX_PROVIDES, 'You have to set env var ' \
                                                      'PLEXAPI_HEADER_PROVIDES=sync-target,controller'
     assert 'sync-target' in plexapi.BASE_HEADERS['X-Plex-Provides']
     assert 'iOS' == plexapi.X_PLEX_PLATFORM, 'You have to set env var PLEXAPI_HEADER_PLATFORM=iOS'
     assert '11.4.1' == plexapi.X_PLEX_PLATFORM_VERSION, 'You have to set env var PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1'
     assert 'iPhone' == plexapi.X_PLEX_DEVICE, 'You have to set env var PLEXAPI_HEADER_DEVICE=iPhone'
-    return account
+    return account_plexpass
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,4 @@
 # -*- coding: utf-8 -*-
-# Running these tests requires a few things in your Plex Library.
-# 1. Movies section containing both movies:
-#  * Sintel - https://durian.blender.org/
-#  * Elephants Dream - https://orange.blender.org/
-#  * Sita Sings the Blues - http://www.sitasingstheblues.com/
-#  * Big Buck Bunny - https://peach.blender.org/
-# 2. TV Show section containing the shows:
-#  * Game of Thrones (Season 1 and 2)
-#  * The 100 (Seasons 1 and 2)
-#  * (or symlink the above movies with proper names)
-# 3. Music section containing the albums:
-#    Infinite State - Unmastered Impulses - https://github.com/kennethreitz/unmastered-impulses
-#    Broke For Free - Layers - http://freemusicarchive.org/music/broke_for_free/Layers/
-# 4. A Photos section containing the photoalbums:
-#    Cats (with cute cat photos inside)
 import time
 from datetime import datetime
 from functools import partial

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,10 +286,12 @@ def is_thumb(key):
 def wait_until(condition_function, delay=0.25, timeout=1, *args, **kwargs):
     start = time.time()
     ready = condition_function(*args, **kwargs)
+    retries = 1
     while not ready and time.time() - start < timeout:
+        retries += 1
         time.sleep(delay)
         ready = condition_function(*args, **kwargs)
 
-    assert ready, 'Wait timeout'
+    assert ready, 'Wait timeout after %d retries, %.2f seconds' % (retries, time.time() - start)
 
     return ready

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -57,7 +57,7 @@ def test_library_fetchItem(plex, movie):
 
 
 def test_library_onDeck(plex, movie):
-    movie.updateProgress(5000)
+    movie.updateProgress(movie.duration * 1000 / 10)  # set progress to 10%
     assert len(list(plex.library.onDeck()))
     movie.markUnwatched()
 
@@ -143,11 +143,12 @@ def test_librarty_deleteMediaPreviews(movies):
 
 
 def test_library_MovieSection_onDeck(movie, movies, tvshows, episode):
-    movie.updateProgress(5000)
-    episode.markWatched()
-    assert len(movies.onDeck()) + len(tvshows.onDeck())
-    episode.markUnwatched()
+    movie.updateProgress(movie.duration * 1000 / 10)  # set progress to 10%
+    assert movies.onDeck()
     movie.markUnwatched()
+    episode.markWatched()
+    assert tvshows.onDeck()
+    episode.markUnwatched()
 
 
 def test_library_MovieSection_recentlyAdded(movies):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -56,8 +56,10 @@ def test_library_fetchItem(plex, movie):
     assert item1 == item2 == movie
 
 
-def test_library_onDeck(plex):
+def test_library_onDeck(plex, movie):
+    movie.updateProgress(5000)
     assert len(list(plex.library.onDeck()))
+    movie.markUnwatched()
 
 
 def test_library_recentlyAdded(plex):
@@ -140,8 +142,12 @@ def test_librarty_deleteMediaPreviews(movies):
     movies.deleteMediaPreviews()
 
 
-def test_library_MovieSection_onDeck(movies, tvshows):
+def test_library_MovieSection_onDeck(movie, movies, tvshows, episode):
+    movie.updateProgress(5000)
+    episode.markWatched()
     assert len(movies.onDeck()) + len(tvshows.onDeck())
+    episode.markUnwatched()
+    movie.markUnwatched()
 
 
 def test_library_MovieSection_recentlyAdded(movies):

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -109,7 +109,6 @@ def test_myplex_deletewebhooks(account):
             account.deleteWebhook('http://example.com')
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_myplex_optout(account_once):
     def enabled():
         ele = account_once.query('https://plex.tv/api/v2/user/privacy')

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -152,3 +152,12 @@ def test_myplex_updateFriend(account, plex, mocker):
                                  allowCameraUpload=True, allowChannels=False, filterMovies=vid_filter,
                                  filterTelevision=vid_filter, filterMusic={'label': ['foo']})
 
+
+def test_myplex_plexpass_attributes(account_plexpass):
+    assert account_plexpass.subscriptionActive
+    assert account_plexpass.subscriptionStatus == 'Active'
+    assert account_plexpass.subscriptionPlan
+    assert 'sync' in account_plexpass.subscriptionFeatures
+    assert 'premium_music_metadata' in account_plexpass.subscriptionFeatures
+    assert 'plexpass' in account_plexpass.roles
+    assert 'all' in account_plexpass.entitlements

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -98,9 +98,9 @@ def test_myplex_deletewebhooks(account):
         account.deleteWebhook('http://site.com')
 
 
-def test_myplex_optout(account):
+def test_myplex_optout(account_once):
     def enabled():
-        ele = account.query('https://plex.tv/api/v2/user/privacy')
+        ele = account_once.query('https://plex.tv/api/v2/user/privacy')
         lib = ele.attrib.get('optOutLibraryStats')
         play = ele.attrib.get('optOutPlayback')
         return bool(int(lib)), bool(int(play))
@@ -108,11 +108,11 @@ def test_myplex_optout(account):
     # This should be False False
     library_enabled, playback_enabled = enabled()
 
-    account.optOut(library=True, playback=True)
+    account_once.optOut(library=True, playback=True)
 
     assert all(enabled())
 
-    account.optOut(library=False, playback=False)
+    account_once.optOut(library=False, playback=False)
 
     assert not all(enabled())
 

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -71,13 +71,14 @@ def _test_myplex_connect_to_device(account):
 
 def test_myplex_users(account):
     users = account.users()
-    assert users, 'Found no users on account: %s' % account.name
+    if not len(users):
+        return pytest.skip('You have to add a shared account into your MyPlex')
     print('Found %s users.' % len(users))
     user = account.user(users[0].title)
     print('Found user: %s' % user)
     assert user, 'Could not find user %s' % users[0].title
 
-    assert len(users[0].servers[0].sections()) == 10, "Could'nt info about the shared libraries"
+    assert len(users[0].servers[0].sections()) > 0, "Couldn't info about the shared libraries"
 
 
 def test_myplex_resource(account, plex):

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -116,16 +116,10 @@ def test_myplex_optout(account_once):
         play = ele.attrib.get('optOutPlayback')
         return bool(int(lib)), bool(int(play))
 
-    # This should be False False
-    library_enabled, playback_enabled = enabled()
-
     account_once.optOut(library=True, playback=True)
-
-    assert all(enabled())
-
+    utils.wait_until(lambda: enabled() == (True, True))
     account_once.optOut(library=False, playback=False)
-
-    assert not all(enabled())
+    utils.wait_until(lambda: enabled() == (False, False))
 
 
 def test_myplex_inviteFriend_remove(account, plex, mocker):

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -87,7 +87,7 @@ def test_myplex_resource(account, plex):
 
 def test_myplex_webhooks(account):
     if account.subscriptionActive:
-        assert not account.webhooks()
+        assert type(account.webhooks()) is list
     else:
         with pytest.raises(BadRequest):
             account.webhooks()
@@ -95,7 +95,7 @@ def test_myplex_webhooks(account):
 
 def test_myplex_addwebhooks(account):
     if account.subscriptionActive:
-        assert len(account.addWebhook('http://example.com')) == 1
+        assert 'http://example.com' in account.addWebhook('http://example.com')
     else:
         with pytest.raises(BadRequest):
             account.addWebhook('http://example.com')
@@ -103,7 +103,7 @@ def test_myplex_addwebhooks(account):
 
 def test_myplex_deletewebhooks(account):
     if account.subscriptionActive:
-        assert not account.deleteWebhook('http://example.com')
+        assert 'http://example.com' not in account.deleteWebhook('http://example.com')
     else:
         with pytest.raises(BadRequest):
             account.deleteWebhook('http://example.com')

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -160,4 +160,4 @@ def test_myplex_plexpass_attributes(account_plexpass):
     assert 'sync' in account_plexpass.subscriptionFeatures
     assert 'premium_music_metadata' in account_plexpass.subscriptionFeatures
     assert 'plexpass' in account_plexpass.roles
-    assert 'all' in account_plexpass.entitlements
+    assert set(account_plexpass.entitlements) == utils.ENTITLEMENTS

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -87,7 +87,7 @@ def test_myplex_resource(account, plex):
 
 def test_myplex_webhooks(account):
     if account.subscriptionActive:
-        assert type(account.webhooks()) is list
+        assert isinstance(account.webhooks(), list)
     else:
         with pytest.raises(BadRequest):
             account.webhooks()

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -109,6 +109,7 @@ def test_myplex_deletewebhooks(account):
             account.deleteWebhook('http://example.com')
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_myplex_optout(account_once):
     def enabled():
         ele = account_once.query('https://plex.tv/api/v2/user/privacy')

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -5,5 +5,5 @@ def test_photo_Photoalbum(photoalbum):
     assert len(photoalbum.photos()) == 3
     cats_in_bed = photoalbum.album('Cats in bed')
     assert len(cats_in_bed.photos()) == 7
-    a_pic = cats_in_bed.photo('maxresdefault')
+    a_pic = cats_in_bed.photo('photo7')
     assert a_pic

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -99,12 +99,12 @@ def test_playqueues(plex):
     assert playqueue.playQueueID, 'Play queue ID not set.'
 
 
-def test_copyToUser(plex, show, fresh_plex):
+def test_copyToUser(plex, show, fresh_plex, shared_username):
     episodes = show.episodes()
     playlist = plex.createPlaylist('shared_from_test_plexapi', episodes)
     try:
-        playlist.copyToUser('PKKid')
-        user = plex.myPlexAccount().user('PKKid')
+        playlist.copyToUser(shared_username)
+        user = plex.myPlexAccount().user(shared_username)
         user_plex = fresh_plex(plex._baseurl, user.get_token(plex.machineIdentifier))
         assert playlist.title in [p.title for p in user_plex.playlists()]
     finally:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -116,9 +116,11 @@ def test_server_playlists(plex, show):
         playlist.delete()
 
 
-def test_server_history(plex):
+def test_server_history(plex, movie):
+    movie.markWatched()
     history = plex.history()
     assert len(history)
+    movie.markUnwatched()
 
 
 def test_server_Server_query(plex):
@@ -230,13 +232,20 @@ def test_server_account(plex):
     # assert account.mappingError == 'publisherror'
     assert account.mappingErrorMessage is None
     assert account.mappingState == 'mapped'
-    assert re.match(utils.REGEX_IPADDR, account.privateAddress)
-    assert int(account.privatePort) >= 1000
-    assert re.match(utils.REGEX_IPADDR, account.publicAddress)
-    assert int(account.publicPort) >= 1000
+    if account.mappingError != 'unreachable':
+        assert re.match(utils.REGEX_IPADDR, account.privateAddress)
+        assert int(account.privatePort) >= 1000
+        assert re.match(utils.REGEX_IPADDR, account.publicAddress)
+        assert int(account.publicPort) >= 1000
+    else:
+        assert account.privateAddress == ''
+        assert int(account.privatePort) == 0
+        assert account.publicAddress == ''
+        assert int(account.publicPort) == 0
     assert account.signInState == 'ok'
     assert isinstance(account.subscriptionActive, bool)
-    if account.subscriptionActive: assert len(account.subscriptionFeatures)
+    if account.subscriptionActive:
+        assert len(account.subscriptionFeatures)
     # Below check keeps failing.. it should go away.
     # else: assert sorted(account.subscriptionFeatures) == ['adaptive_bitrate',
     #     'download_certificates', 'federated-auth', 'news']

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,10 +30,7 @@ def test_server_alert_listener(plex, movies):
         messages = []
         listener = plex.startAlertListener(messages.append)
         movies.refresh()
-        starttime, runtime = time.time(), 0
-        while len(messages) < 3 and runtime <= 30:
-            time.sleep(1)
-            runtime = int(time.time() - starttime)
+        utils.wait_until(lambda: len(messages) >= 3, delay=1, timeout=30)
         assert len(messages) >= 3
     finally:
         listener.stop()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,8 @@ def test_server_attr(plex, account):
     assert len(plex.friendlyName) >= 1
     assert len(plex.machineIdentifier) == 40
     assert plex.myPlex is True
-    assert plex.myPlexMappingState == 'mapped'
+    # if you run the tests very shortly after server creation the state in rare cases may be `unknown`
+    assert plex.myPlexMappingState in ('mapped', 'unknown')
     assert plex.myPlexSigninState == 'ok'
     assert utils.is_int(plex.myPlexSubscription, gte=0)
     assert re.match(utils.REGEX_EMAIL, plex.myPlexUsername)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -165,7 +165,12 @@ def test_server_sessions(plex):
 
 
 def test_server_isLatest(plex, mocker):
-    plex.isLatest()
+    from os import environ
+    is_latest = plex.isLatest()
+    if environ.get('PLEX_CONTAINER_TAG') and environ['PLEX_CONTAINER_TAG'] != 'latest':
+        assert not is_latest
+    else:
+        return pytest.skip('Do not forget to run with PLEX_CONTAINER_TAG != latest to ensure that update is available')
 
 
 def test_server_installUpdate(plex, mocker):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,7 +8,7 @@ from requests import Session
 from . import conftest as utils
 
 
-def test_server_attr(plex):
+def test_server_attr(plex, account):
     assert plex._baseurl == utils.SERVER_BASEURL
     assert len(plex.friendlyName) >= 1
     assert len(plex.machineIdentifier) == 40
@@ -19,7 +19,7 @@ def test_server_attr(plex):
     assert re.match(utils.REGEX_EMAIL, plex.myPlexUsername)
     assert plex.platform in ('Linux', 'Windows')
     assert len(plex.platformVersion) >= 5
-    assert plex._token == utils.SERVER_TOKEN
+    assert plex._token == account.authenticationToken
     assert utils.is_int(plex.transcoderActiveVideoSessions, gte=0)
     assert utils.is_datetime(plex.updatedAt)
     assert len(plex.version) >= 5
@@ -131,14 +131,14 @@ def test_server_Server_query(plex):
         PlexServer(utils.SERVER_BASEURL, '1234')
 
 
-def test_server_Server_session():
+def test_server_Server_session(account):
     # Mock Sesstion
     class MySession(Session):
         def __init__(self):
             super(self.__class__, self).__init__()
             self.plexapi_session_test = True
     # Test Code
-    plex = PlexServer(utils.SERVER_BASEURL, utils.SERVER_TOKEN, session=MySession())
+    plex = PlexServer(utils.SERVER_BASEURL, account.authenticationToken, session=MySession())
     assert hasattr(plex._session, 'plexapi_session_test')
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,7 +12,8 @@ def test_settings_get(plex):
 def test_settings_set(plex):
     cd = plex.settings.get('sendCrashReports')
     old_value = cd.value
-    cd.set(not old_value)
+    new_value = not old_value
+    cd.set(new_value)
     plex.settings.save()
-    delattr(plex, '_settings')
-    assert plex.settings.get('sendCrashReports').value == (not old_value)
+    plex._settings = None
+    assert plex.settings.get('sendCrashReports').value == new_value

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,10 +10,10 @@ def test_settings_get(plex):
 
 
 def test_settings_set(plex):
-    cd = plex.settings.get('sendCrashReports')
+    cd = plex.settings.get('autoEmptyTrash')
     old_value = cd.value
     new_value = not old_value
     cd.set(new_value)
     plex.settings.save()
     plex._settings = None
-    assert plex.settings.get('sendCrashReports').value == new_value
+    assert plex.settings.get('autoEmptyTrash').value == new_value

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,9 +10,9 @@ def test_settings_get(plex):
 
 
 def test_settings_set(plex):
-    cd = plex.settings.get('collectUsageData')
+    cd = plex.settings.get('sendCrashReports')
     old_value = cd.value
     cd.set(not old_value)
     plex.settings.save()
     delattr(plex, '_settings')
-    assert plex.settings.get('collectUsageData').value == (not old_value)
+    assert plex.settings.get('sendCrashReports').value == (not old_value)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,9 +9,10 @@ def test_settings_get(plex):
     assert plex.settings.get('FriendlyName').value == ''
 
 
-def test_settings_get(plex):
+def test_settings_set(plex):
     cd = plex.settings.get('collectUsageData')
-    cd.set(False)
-    # Save works but since we reload asap the data isnt changed.
-    # or it might be our caching that does this. ## TODO
+    old_value = cd.value
+    cd.set(not old_value)
     plex.settings.save()
+    delattr(plex, '_settings')
+    assert plex.settings.get('collectUsageData').value == (not old_value)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -227,7 +227,8 @@ def test_sync_entire_library_photos(clear_sync_device, photos):
     new_item = photos.sync(PHOTO_QUALITY_MEDIUM, client=clear_sync_device)
     photos._server.refreshSync()
     item = ensure_sync_item(clear_sync_device, new_item)
-    section_content = photos.search(libtype='photo')
+    # It's not that easy, to just get all the photos within the library, so let`s query for photos with resolution!=0x0
+    section_content = photos.search(libtype='photo', **{'resolution!': '0x0'})
     media_list = item.getMedia()
     assert len(section_content) == len(media_list)
     assert [e.ratingKey for e in section_content] == [m.ratingKey for m in media_list]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -228,7 +228,7 @@ def test_sync_entire_library_photos(clear_sync_device, photos):
     photos._server.refreshSync()
     item = ensure_sync_item(clear_sync_device, new_item)
     # It's not that easy, to just get all the photos within the library, so let`s query for photos with resolution!=0x0
-    section_content = photos.search(libtype='photo', **{'resolution!': '0x0'})
+    section_content = photos.search(libtype='photo', **{'device!': '0x0'})
     media_list = item.getMedia()
     assert len(section_content) == len(media_list)
     assert [e.ratingKey for e in section_content] == [m.ratingKey for m in media_list]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -227,7 +227,7 @@ def test_sync_entire_library_photos(clear_sync_device, photos):
     new_item = photos.sync(PHOTO_QUALITY_MEDIUM, client=clear_sync_device)
     photos._server.refreshSync()
     item = ensure_sync_item(clear_sync_device, new_item)
-    # It's not that easy, to just get all the photos within the library, so let`s query for photos with resolution!=0x0
+    # It's not that easy, to just get all the photos within the library, so let`s query for photos with device!=0x0
     section_content = photos.search(libtype='photo', **{'device!': '0x0'})
     media_list = item.getMedia()
     assert len(section_content) == len(media_list)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,3 +1,4 @@
+from plexapi.exceptions import BadRequest
 from . import conftest as utils
 
 from plexapi.sync import VIDEO_QUALITY_3_MBPS_720p, AUDIO_BITRATE_192_KBPS, PHOTO_QUALITY_MEDIUM
@@ -18,12 +19,23 @@ def test_current_device_got_sync_target(clear_sync_device):
     assert 'sync-target' in clear_sync_device.provides
 
 
+def get_media(item, server):
+    try:
+        return item.getMedia()
+    except BadRequest as e:
+        if 'not_found' in str(e):
+            server.refreshSync()
+            return None
+        else:
+            raise
+
+
 def test_add_movie_to_sync(clear_sync_device, movie):
     new_item = movie.sync(VIDEO_QUALITY_3_MBPS_720p, client=clear_sync_device)
     movie._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=movie._server)
     assert len(media_list) == 1
     assert media_list[0].ratingKey == movie.ratingKey
 
@@ -45,7 +57,7 @@ def test_add_show_to_sync(clear_sync_device, show):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     episodes = show.episodes()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
 
@@ -57,7 +69,7 @@ def test_add_season_to_sync(clear_sync_device, show):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     episodes = season.episodes()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=season._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
 
@@ -67,7 +79,7 @@ def test_add_episode_to_sync(clear_sync_device, episode):
     episode._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=episode._server)
     assert 1 == len(media_list)
     assert episode.ratingKey == media_list[0].ratingKey
 
@@ -79,12 +91,12 @@ def test_limited_watched(clear_sync_device, show):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     episodes = show.episodes()[:5]
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert 5 == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
     episodes[0].markWatched()
     show._server.refreshSync()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert 5 == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
 
@@ -96,13 +108,13 @@ def test_limited_unwatched(clear_sync_device, show):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     episodes = show.episodes(viewCount=0)[:5]
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
     episodes[0].markWatched()
     show._server.refreshSync()
     episodes = show.episodes(viewCount=0)[:5]
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
 
@@ -114,13 +126,13 @@ def test_unlimited_and_watched(clear_sync_device, show):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     episodes = show.episodes()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
     episodes[0].markWatched()
     show._server.refreshSync()
     episodes = show.episodes()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
 
@@ -132,13 +144,13 @@ def test_unlimited_and_unwatched(clear_sync_device, show):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     episodes = show.episodes(viewCount=0)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
     episodes[0].markWatched()
     show._server.refreshSync()
     episodes = show.episodes(viewCount=0)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=show._server)
     assert len(episodes) == len(media_list)
     assert [e.ratingKey for e in episodes] == [m.ratingKey for m in media_list]
 
@@ -149,7 +161,7 @@ def test_add_music_artist_to_sync(clear_sync_device, artist):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     tracks = artist.tracks()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=artist._server)
     assert len(tracks) == len(media_list)
     assert [t.ratingKey for t in tracks] == [m.ratingKey for m in media_list]
 
@@ -160,7 +172,7 @@ def test_add_music_album_to_sync(clear_sync_device, album):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     tracks = album.tracks()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=album._server)
     assert len(tracks) == len(media_list)
     assert [t.ratingKey for t in tracks] == [m.ratingKey for m in media_list]
 
@@ -170,7 +182,7 @@ def test_add_music_track_to_sync(clear_sync_device, track):
     track._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=track._server)
     assert 1 == len(media_list)
     assert track.ratingKey == media_list[0].ratingKey
 
@@ -181,7 +193,7 @@ def test_add_photo_to_sync(clear_sync_device, photoalbum):
     photo._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=photo._server)
     assert 1 == len(media_list)
     assert photo.ratingKey == media_list[0].ratingKey
 
@@ -192,7 +204,7 @@ def test_sync_entire_library_movies(clear_sync_device, movies):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     section_content = movies.all()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=movies._server)
     assert len(section_content) == len(media_list)
     assert [e.ratingKey for e in section_content] == [m.ratingKey for m in media_list]
 
@@ -203,7 +215,7 @@ def test_sync_entire_library_tvshows(clear_sync_device, tvshows):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     section_content = tvshows.searchEpisodes()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=tvshows._server)
     assert len(section_content) == len(media_list)
     assert [e.ratingKey for e in section_content] == [m.ratingKey for m in media_list]
 
@@ -214,7 +226,7 @@ def test_sync_entire_library_music(clear_sync_device, music):
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
     section_content = music.searchTracks()
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=music._server)
     assert len(section_content) == len(media_list)
     assert [e.ratingKey for e in section_content] == [m.ratingKey for m in media_list]
 
@@ -226,7 +238,7 @@ def test_sync_entire_library_photos(clear_sync_device, photos):
                             sync_item=new_item)
     # It's not that easy, to just get all the photos within the library, so let`s query for photos with device!=0x0
     section_content = photos.search(libtype='photo', **{'device!': '0x0'})
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=photos._server)
     assert len(section_content) == len(media_list)
     assert [e.ratingKey for e in section_content] == [m.ratingKey for m in media_list]
 
@@ -238,7 +250,7 @@ def test_playlist_movie_sync(plex, clear_sync_device, movies):
     playlist._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=playlist._server)
     assert len(items) == len(media_list)
     assert [e.ratingKey for e in items] == [m.ratingKey for m in media_list]
     playlist.delete()
@@ -251,7 +263,7 @@ def test_playlist_tvshow_sync(plex, clear_sync_device, show):
     playlist._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=playlist._server)
     assert len(items) == len(media_list)
     assert [e.ratingKey for e in items] == [m.ratingKey for m in media_list]
     playlist.delete()
@@ -264,7 +276,7 @@ def test_playlist_mixed_sync(plex, clear_sync_device, movie, episode):
     playlist._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=playlist._server)
     assert len(items) == len(media_list)
     assert [e.ratingKey for e in items] == [m.ratingKey for m in media_list]
     playlist.delete()
@@ -277,7 +289,7 @@ def test_playlist_music_sync(plex, clear_sync_device, artist):
     playlist._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=playlist._server)
     assert len(items) == len(media_list)
     assert [e.ratingKey for e in items] == [m.ratingKey for m in media_list]
     playlist.delete()
@@ -290,7 +302,7 @@ def test_playlist_photos_sync(plex, clear_sync_device, photoalbum):
     playlist._server.refreshSync()
     item = utils.wait_until(get_sync_item_from_server, delay=0.5, timeout=3, device=clear_sync_device,
                             sync_item=new_item)
-    media_list = item.getMedia()
+    media_list = utils.wait_until(get_media, delay=0.25, timeout=3, item=item, server=playlist._server)
     assert len(items) == len(media_list)
     assert [e.ratingKey for e in items] == [m.ratingKey for m in media_list]
     playlist.delete()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -183,10 +183,8 @@ def test_add_music_track_to_sync(clear_sync_device, track):
     assert track.ratingKey == media_list[0].ratingKey
 
 
-def test_add_photo_to_sync(clear_sync_device, photos):
-    photo = photos.all()[0]
-    if not hasattr(photo, 'librarySectionID'):
-        pytest.skip('Photos are not ready for individual synchronization yet')
+def test_add_photo_to_sync(clear_sync_device, photoalbum):
+    photo = photoalbum.photo('photo1')
     new_item = photo.sync(PHOTO_QUALITY_MEDIUM, client=clear_sync_device)
     photo._server.refreshSync()
     item = ensure_sync_item(clear_sync_device, new_item)
@@ -229,7 +227,7 @@ def test_sync_entire_library_photos(clear_sync_device, photos):
     new_item = photos.sync(PHOTO_QUALITY_MEDIUM, client=clear_sync_device)
     photos._server.refreshSync()
     item = ensure_sync_item(clear_sync_device, new_item)
-    section_content = photos.all()
+    section_content = photos.search(libtype='photo')
     media_list = item.getMedia()
     assert len(section_content) == len(media_list)
     assert [e.ratingKey for e in section_content] == [m.ratingKey for m in media_list]
@@ -283,10 +281,8 @@ def test_playlist_music_sync(plex, clear_sync_device, artist):
     playlist.delete()
 
 
-def test_playlist_photos_sync(plex, clear_sync_device, photos):
-    items = photos.all()
-    if not hasattr(items[0], 'librarySectionID'):
-        pytest.skip('Photos are not ready for individual synchronization yet')
+def test_playlist_photos_sync(plex, clear_sync_device, photoalbum):
+    items = photoalbum.photos()
     playlist = plex.createPlaylist('Sync: Photos', items)
     new_item = playlist.sync(photoResolution=PHOTO_QUALITY_MEDIUM, client=clear_sync_device)
     playlist._server.refreshSync()

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -178,10 +178,10 @@ def test_video_Movie_attrs(movies):
     assert utils.is_int(media.width, gte=200)
     # Video
     video = movie.media[0].parts[0].videoStreams()[0]
-    assert video.bitDepth == 8
+    assert video.bitDepth in (8, None)  # Different versions of Plex Server return different values
     assert utils.is_int(video.bitrate)
     assert video.cabac is None
-    assert video.chromaSubsampling == '4:2:0'
+    assert video.chromaSubsampling in ('4:2:0', None)
     assert video.codec in utils.CODECS
     assert video.codecID is None
     assert video.colorSpace is None
@@ -198,7 +198,7 @@ def test_video_Movie_attrs(movies):
     assert utils.is_int(video.level)
     assert video.profile in utils.PROFILES
     assert utils.is_int(video.refFrames)
-    assert video.scanType is None
+    assert video.scanType in ('progressive', None)
     assert video.selected is False
     assert video._server._baseurl == utils.SERVER_BASEURL
     assert utils.is_int(video.streamType)
@@ -217,10 +217,10 @@ def test_video_Movie_attrs(movies):
     assert utils.is_int(part.size, gte=1000000)
     # Stream 1
     stream1 = part.streams[0]
-    assert stream1.bitDepth == 8
+    assert stream1.bitDepth in (8, None)
     assert utils.is_int(stream1.bitrate)
     assert stream1.cabac is None
-    assert stream1.chromaSubsampling == '4:2:0'
+    assert stream1.chromaSubsampling in ('4:2:0', None)
     assert stream1.codec in utils.CODECS
     assert stream1.codecID is None
     assert stream1.colorSpace is None
@@ -237,7 +237,7 @@ def test_video_Movie_attrs(movies):
     assert utils.is_int(stream1.level)
     assert stream1.profile in utils.PROFILES
     assert utils.is_int(stream1.refFrames)
-    assert stream1.scanType is None
+    assert stream1.scanType in ('progressive', None)
     assert stream1.selected is False
     assert stream1._server._baseurl == utils.SERVER_BASEURL
     assert utils.is_int(stream1.streamType)
@@ -301,7 +301,7 @@ def test_video_Show_attrs(show):
     assert utils.is_int(show.duration, gte=1600000)
     assert utils.is_section(show._initpath)
     # Check reloading the show loads the full list of genres
-    assert sorted([i.tag for i in show.genres]) == ['Adventure', 'Drama']
+    assert not {'Adventure', 'Drama'} - {i.tag for i in show.genres}
     show.reload()
     assert sorted([i.tag for i in show.genres]) == ['Adventure', 'Drama', 'Fantasy']
     # So the initkey should have changed because of the reload

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -14,7 +14,7 @@ def test_video_Movie_attributeerror(movie):
         movie.asshat
 
 def test_video_ne(movies):
-    assert len(movies.fetchItems('/library/sections/7/all', title__ne='Sintel')) == 3
+    assert len(movies.fetchItems('/library/sections/1/all', title__ne='Sintel')) == 3
 
 
 def test_video_Movie_delete(movie, patched_http_call):
@@ -33,10 +33,10 @@ def test_video_Movie_addCollection(movie):
     assert labelname not in [tag.tag for tag in movie.collections if tag]
 
 
-def test_video_Movie_getStreamURL(movie):
+def test_video_Movie_getStreamURL(movie, account):
     key = movie.ratingKey
-    assert movie.getStreamURL() == '{0}/video/:/transcode/universal/start.m3u8?X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&offset=0&path=%2Flibrary%2Fmetadata%2F{1}&X-Plex-Token={2}'.format(utils.SERVER_BASEURL, key, utils.SERVER_TOKEN)  # noqa
-    assert movie.getStreamURL(videoResolution='800x600') == '{0}/video/:/transcode/universal/start.m3u8?X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&offset=0&path=%2Flibrary%2Fmetadata%2F{1}&videoResolution=800x600&X-Plex-Token={2}'.format(utils.SERVER_BASEURL, key, utils.SERVER_TOKEN)  # noqa
+    assert movie.getStreamURL() == '{0}/video/:/transcode/universal/start.m3u8?X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&offset=0&path=%2Flibrary%2Fmetadata%2F{1}&X-Plex-Token={2}'.format(utils.SERVER_BASEURL, key, account.authenticationToken)  # noqa
+    assert movie.getStreamURL(videoResolution='800x600') == '{0}/video/:/transcode/universal/start.m3u8?X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&offset=0&path=%2Flibrary%2Fmetadata%2F{1}&videoResolution=800x600&X-Plex-Token={2}'.format(utils.SERVER_BASEURL, key, account.authenticationToken)  # noqa
 
 
 def test_video_Movie_isFullObject_and_reload(plex):
@@ -118,7 +118,7 @@ def test_video_Movie_attrs(movies):
     assert float(movie.rating) >= 6.4
     #assert movie.ratingImage == 'rottentomatoes://image.rating.ripe'
     assert movie.ratingKey >= 1
-    assert sorted([i.tag for i in movie.roles])[:4] == ['Aladdin Ullah', 'Annette Hanshaw', 'Aseem Chhabra', 'Debargo Sanyal']  # noqa
+    assert sorted([i.tag for i in movie.roles])[:4] == ['Aladdin Ullah', 'Annette Hanshaw', 'Aseem Chhabra', 'Bhavana Nagulapally']  # noqa
     assert movie._server._baseurl == utils.SERVER_BASEURL
     assert movie.sessionKey is None
     assert movie.studio == 'Nina Paley'
@@ -301,7 +301,7 @@ def test_video_Show_attrs(show):
     assert utils.is_int(show.duration, gte=1600000)
     assert utils.is_section(show._initpath)
     # Check reloading the show loads the full list of genres
-    assert sorted([i.tag for i in show.genres]) == ['Adventure', 'Drama', 'Fantasy']
+    assert sorted([i.tag for i in show.genres]) == ['Adventure', 'Drama']
     show.reload()
     assert sorted([i.tag for i in show.genres]) == ['Adventure', 'Drama', 'Fantasy']
     # So the initkey should have changed because of the reload
@@ -316,8 +316,8 @@ def test_video_Show_attrs(show):
     assert show.originallyAvailableAt.strftime('%Y-%m-%d') == '2011-04-17'
     assert show.rating >= 8.0
     assert utils.is_int(show.ratingKey)
-    assert sorted([i.tag for i in show.roles])[:4] == ['Aidan Gillen', 'Alexander Siddig', 'Alfie Allen', 'Art Parkinson']
-    assert sorted([i.tag for i in show.actors])[:4] == ['Aidan Gillen', 'Alexander Siddig', 'Alfie Allen', 'Art Parkinson']
+    assert sorted([i.tag for i in show.roles])[:4] == ['Aidan Gillen', 'Aimee Richardson', 'Alexander Siddig', 'Alfie Allen']  # noqa
+    assert sorted([i.tag for i in show.actors])[:4] == ['Aidan Gillen', 'Aimee Richardson', 'Alexander Siddig', 'Alfie Allen']  # noqa
     assert show._server._baseurl == utils.SERVER_BASEURL
     assert show.studio == 'HBO'
     assert utils.is_string(show.summary, gte=100)
@@ -503,7 +503,7 @@ def test_video_Episode_attrs(episode):
     assert utils.is_metadata(part._initpath)
     assert len(part.key) >= 10
     assert part._server._baseurl == utils.SERVER_BASEURL
-    assert utils.is_int(part.size, gte=30000000)
+    assert part.size == 18184197
 
 
 def test_video_Season(show):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -151,9 +151,9 @@ def test_video_Movie_attrs(movies):
     assert audio.id >= 1
     assert audio.index == 1
     assert utils.is_metadata(audio._initpath)
-    assert audio.language == 'English'
-    assert audio.languageCode == 'eng'
-    assert audio.samplingRate == 48000
+    assert audio.language is None
+    assert audio.languageCode is None
+    assert audio.samplingRate == 44100
     assert audio.selected is True
     assert audio._server._baseurl == utils.SERVER_BASEURL
     assert audio.streamType == 2
@@ -184,7 +184,7 @@ def test_video_Movie_attrs(movies):
     assert video.chromaSubsampling == '4:2:0'
     assert video.codec in utils.CODECS
     assert video.codecID is None
-    assert video.colorSpace == 'bt709'
+    assert video.colorSpace is None
     assert video.duration is None
     assert utils.is_float(video.frameRate, gte=20.0)
     assert video.frameRateMode is None
@@ -193,8 +193,8 @@ def test_video_Movie_attrs(movies):
     assert utils.is_int(video.id)
     assert utils.is_int(video.index, gte=0)
     assert utils.is_metadata(video._initpath)
-    assert video.language == 'English'
-    assert video.languageCode == 'eng'
+    assert video.language is None
+    assert video.languageCode is None
     assert utils.is_int(video.level)
     assert video.profile in utils.PROFILES
     assert utils.is_int(video.refFrames)
@@ -223,7 +223,7 @@ def test_video_Movie_attrs(movies):
     assert stream1.chromaSubsampling == '4:2:0'
     assert stream1.codec in utils.CODECS
     assert stream1.codecID is None
-    assert stream1.colorSpace == 'bt709'
+    assert stream1.colorSpace is None
     assert stream1.duration is None
     assert utils.is_float(stream1.frameRate, gte=20.0)
     assert stream1.frameRateMode is None
@@ -232,8 +232,8 @@ def test_video_Movie_attrs(movies):
     assert utils.is_int(stream1.id)
     assert utils.is_int(stream1.index, gte=0)
     assert utils.is_metadata(stream1._initpath)
-    assert stream1.language == 'English'
-    assert stream1.languageCode == 'eng'
+    assert stream1.language is None
+    assert stream1.languageCode is None
     assert utils.is_int(stream1.level)
     assert stream1.profile in utils.PROFILES
     assert utils.is_int(stream1.refFrames)
@@ -259,8 +259,8 @@ def test_video_Movie_attrs(movies):
     assert utils.is_int(stream2.id)
     assert utils.is_int(stream2.index)
     assert utils.is_metadata(stream2._initpath)
-    assert stream2.language == 'English'
-    assert stream2.languageCode == 'eng'
+    assert stream2.language is None
+    assert stream2.languageCode is None
     assert utils.is_int(stream2.samplingRate)
     assert stream2.selected is True
     assert stream2._server._baseurl == utils.SERVER_BASEURL
@@ -508,7 +508,7 @@ def test_video_Episode_attrs(episode):
 
 def test_video_Season(show):
     seasons = show.seasons()
-    assert len(seasons) >= 1
+    assert len(seasons) == 2
     assert ['Season 1', 'Season 2'] == [s.title for s in seasons[:2]]
     assert show.season('Season 1') == seasons[0]
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -503,7 +503,7 @@ def test_video_Episode_attrs(episode):
     assert utils.is_metadata(part._initpath)
     assert len(part.key) >= 10
     assert part._server._baseurl == utils.SERVER_BASEURL
-    assert part.size == 18184197
+    assert utils.is_int(part.size, gte=18184197)
 
 
 def test_video_Season(show):

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -1,4 +1,4 @@
-""" The script is used to create bootstrap a docker container with Plex and with all the libraries required for testing.
+""" The script is used to bootstrap a docker container with Plex and with all the libraries required for testing.
 """
 
 import argparse
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 import plexapi
 from plexapi.compat import which, makedirs
-from plexapi.exceptions import BadRequest
+from plexapi.exceptions import BadRequest, NotFound
 from plexapi.myplex import MyPlexAccount
 from plexapi.utils import download, SEARCHTYPES
 
@@ -343,6 +343,16 @@ if __name__ == '__main__':
 
         for section in sections:
             create_section(server, section)
+
+    import logging
+    logging.basicConfig(level=logging.INFO)
+    shared_username = os.environ.get('SHARED_USERNAME', 'PKKid')
+    try:
+        user = account.user(shared_username)
+        account.updateFriend(user, server)
+        print('The server was shared with user "%s"' % shared_username)
+    except NotFound:
+        pass
 
     print('Base URL is %s' % server.url('', False))
     if opts.show_token:

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -21,6 +21,7 @@ from plexapi.utils import download, SEARCHTYPES
 DOCKER_CMD = [
     'docker', 'run', '-d',
     '--name', 'plex-test-%(image_tag)s',
+    '--restart', 'on-failure',
     '-p', '32400:32400/tcp',
     '-p', '3005:3005/tcp',
     '-p', '8324:8324/tcp',

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -253,13 +253,27 @@ if __name__ == '__main__':
         photos_path = os.path.join(path, 'media', 'Photos')
         makedirs(photos_path, exist_ok=True)
 
-        has_photos = len(glob(os.path.join(photos_path, '*.jpg')))
-        while has_photos < 10:
-            has_photos += 1
-            download('https://picsum.photos/800/600/?random', '',
-                     filename='photo%d.jpg' % has_photos, savepath=photos_path)
+        folders = {
+            ('Cats', ): 3,
+            ('Cats', 'Cats in bed'): 7,
+            ('Cats', 'Cats not in bed'): 1,
+            ('Cats', 'Not cats in bed'): 1,
+        }
 
-        print('Photos collected, but we need to create an album later...')
+        has_photos = 0
+        for folder_path, required_cnt in folders.items():
+            folder_path = os.path.join(photos_path, *folder_path)
+            photos_in_folder = len(glob(os.path.join(folder_path, '*.jpg')))
+            while photos_in_folder < required_cnt:
+                photos_in_folder += 1
+                download('https://picsum.photos/800/600/?random', '',
+                         filename='photo%d.jpg' % photos_in_folder, savepath=folder_path)
+            has_photos += photos_in_folder
+
+        if opts.with_photo_album:
+            print('Photos collected, but we need to create an album later...')
+        else:
+            print('Photos collected...')
         sections.append(dict(name='Photos', type='photo', location='/data/Photos', agent='com.plexapp.agents.none',
                              scanner='Plex Photo Scanner'))
 

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -246,7 +246,7 @@ if __name__ == '__main__':
         expected_media_count += len(glob(os.path.join(dest_path, '*.mp3')))
 
         print('Finished with Music...')
-        sections.append(dict(name='Music', type='artist', location='/data/Music', agent='com.plexapp.agents.none',
+        sections.append(dict(name='Music', type='artist', location='/data/Music', agent='com.plexapp.agents.lastfm',
                              scanner='Plex Music Scanner'))
 
     if opts.with_photos:

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -268,7 +268,7 @@ if __name__ == '__main__':
                          filename='photo%d.jpg' % photos_in_folder, savepath=folder_path)
             has_photos += photos_in_folder
 
-        print('Photos collected...')
+        print('Finished with photos...')
         sections.append(dict(name='Photos', type='photo', location='/data/Photos', agent='com.plexapp.agents.none',
                              scanner='Plex Photo Scanner'))
 
@@ -278,15 +278,17 @@ if __name__ == '__main__':
         library = server.library
 
         processed_media = 0
+        print('Expected media count: %d' % expected_media_count)
 
         def alert_callback(data):
-            global finished, processed_media
+            global processed_media
             if data['type'] == 'timeline':
                 for entry in data['TimelineEntry']:
                     if entry['identifier'] == 'com.plexapp.plugins.library' and entry['state'] == 5 \
                             and entry['type'] in (SEARCHTYPES['movie'], SEARCHTYPES['episode'], SEARCHTYPES['track'],
                                                   SEARCHTYPES['photo']):
                         processed_media += 1
+                        print('Processed media count: %d' % processed_media)
 
         notifier = server.startAlertListener(alert_callback)
 

--- a/tools/plex-teardowntest.py
+++ b/tools/plex-teardowntest.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Listen to plex alerts and print them to the console.
-Because we're using print as a function, example only works in Python3.
+Remove current Plex Server and a Client from MyPlex account. Useful when running tests in CI.
 """
 from plexapi.myplex import MyPlexAccount
 from plexapi.server import PlexServer

--- a/tools/plex-teardowntest.py
+++ b/tools/plex-teardowntest.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Listen to plex alerts and print them to the console.
+Because we're using print as a function, example only works in Python3.
+"""
+from plexapi.myplex import MyPlexAccount
+from plexapi.server import PlexServer
+from plexapi import X_PLEX_IDENTIFIER
+
+
+if __name__ == '__main__':
+    myplex = MyPlexAccount()
+    plex = PlexServer(token=myplex.authenticationToken)
+    for device in plex.myPlexAccount().devices():
+        if device.clientIdentifier == plex.machineIdentifier:
+            print('Removing device "%s", with id "%s"' % (device.name, device. clientIdentifier))
+            device.delete()
+
+    # If we suddenly remove the client first we wouldn't be able to authenticate to delete the server
+    for device in plex.myPlexAccount().devices():
+        if device.clientIdentifier == X_PLEX_IDENTIFIER:
+            print('Removing device "%s", with id "%s"' % (device.name, device. clientIdentifier))
+            device.delete()
+            break


### PR DESCRIPTION
Currently I can see following problems with tests:

1. [X] Tests which run on Travis-CI depends on external Plex Server
2. [X] The tests aren't running for pull requests
3. [X] flake8 executed for each python version, which is senselessly
4. [X] Deploy to PyPi executed for each python version which lead to errors in uploading
5. [X] The tests require quite a work on building a library, but even after the library is ready not all tests are passing
6. [x] Part of tests are require an existence of user `PKKid`
7. [x] Some of `MyPlexAccount` test require that you don't have a PlexPass (and it's not really documented)
8. [x] My Mobile Sync tests require a Plex Pass on other hand, and this is also not documented
9. [x] The readme not covers a testing procedure
10. [x] Test results should be reproducible, without "unstable" tests
11. [x] Tests agains shared libraries should be easy-to-run, and the should run automatically in Travis 

As for now I've partially resolved first few easy issues, and stuck with generating a proper library: I have no idea how to get tests related to `photoalbum` to pass, and I need your help here.

To get my new approach working you have to define `PLEXAPI_AUTH_MYPLEX_USERNAME` and `PLEXAPI_AUTH_MYPLEX_PASSWORD` in the your Travis CI ENV variables, instead of `PLEXAPI_AUTH_SERVER_BASEURL` and `PLEXAPI_AUTH_SERVER_TOKEN`.

After each run of travis the newly created server and client would be removed from the MyPlex account.

You can check the Travis CI output by visiting https://travis-ci.org/andrey-yantsen/python-plexapi/builds/426206148.