### PR TITLE
Run tests over unclaimed server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 
 stages:
-  - syntax
-  - name: test
-    if: type != pull_request
+  - test
   - name: deploy
     if: tag = present
 
@@ -28,8 +26,10 @@ before_install:
   - pip install --upgrade pytest pytest-cov coveralls
 install:
   - pip install -r requirements_dev.txt
-  - PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-bootstraptest.py --destination plex --advertise-ip=127.0.0.1
-    --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG
+  - '[ -z "${PLEXAPI_AUTH_MYPLEX_USERNAME}" ] && PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-bootstraptest.py
+     --destination plex --advertise-ip=127.0.0.1 --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG --unclaimed ||
+     PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-bootstraptest.py --destination plex --advertise-ip=127.0.0.1
+    --bootstrap-timeout 540 --docker-tag $PLEX_CONTAINER_TAG'
 
 script:
   - py.test tests -rxXs --ignore=tests/test_sync.py --tb=native --verbose --cov-config .coveragerc --cov=plexapi
@@ -41,18 +41,16 @@ after_success:
   - coveralls
 
 after_script:
-  - PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-teardowntest.py
+  - '[ -z "${PLEXAPI_AUTH_MYPLEX_USERNAME}" ] || PYTHONPATH="$PWD:$PYTHONPATH" python -u tools/plex-teardowntest.py'
 
 jobs:
   include:
-    - stage: syntax
-      python: 3.6
+    - python: 3.6
       name: "Flake8"
       install:
         - pip install -r requirements_dev.txt
       script: flake8 plexapi --exclude=compat.py --max-line-length=120 --ignore=E128,E701,E702,E731,W293
-      after_success: true
-      after_script: true
+      after_success: skip
       env:
         - PLEX_CONTAINER_TAG=latest
     - stage: test
@@ -60,6 +58,12 @@ jobs:
       env:
         - PLEX_CONTAINER_TAG=1.3.2.3112-1751929
         - TEST_ACCOUNT_ONCE=1
+    - stage: test
+      python: 3.6
+      if: type != 'pull_request'  # pull requests always run over unclaimed server
+      after_success: skip
+      env:
+        - PLEX_CONTAINER_TAG=latest PLEXAPI_AUTH_MYPLEX_USERNAME=
     - stage: deploy
       name: "Deploy to PyPi"
       python: 3.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,25 +42,52 @@ PROFILES = {'advanced simple', 'main', 'constrained baseline'}
 RESOLUTIONS = {'sd', '480', '576', '720', '1080'}
 ENTITLEMENTS = {'ios', 'cpms', 'roku', 'android', 'xbox_one', 'xbox_360', 'windows', 'windows_phone'}
 
+TEST_AUTHENTICATED = 'authenticated'
+TEST_ANONYMOUSLY = 'anonymously'
+
+
+ANON_PARAM = pytest.param(TEST_ANONYMOUSLY, marks=pytest.mark.anonymous)
+AUTH_PARAM = pytest.param(TEST_AUTHENTICATED, marks=pytest.mark.authenticated)
+
 
 def pytest_addoption(parser):
     parser.addoption('--client', action='store_true', default=False, help='Run client tests.')
 
 
+def pytest_generate_tests(metafunc):
+    if 'plex' in metafunc.fixturenames:
+        if 'account' in metafunc.fixturenames or TEST_AUTHENTICATED in metafunc.definition.keywords:
+            metafunc.parametrize('plex', [AUTH_PARAM], indirect=True)
+        else:
+            metafunc.parametrize('plex', [ANON_PARAM, AUTH_PARAM], indirect=True)
+    elif 'account' in metafunc.fixturenames:
+        metafunc.parametrize('account', [AUTH_PARAM], indirect=True)
+
+
 def pytest_runtest_setup(item):
     if 'client' in item.keywords and not item.config.getvalue('client'):
         return pytest.skip('Need --client option to run.')
+    if TEST_AUTHENTICATED in item.keywords and not (MYPLEX_USERNAME and MYPLEX_PASSWORD):
+        return pytest.skip('You have to specify MYPLEX_USERNAME and MYPLEX_PASSWORD to run authenticated tests')
+    if TEST_ANONYMOUSLY in item.keywords and MYPLEX_USERNAME and MYPLEX_PASSWORD:
+        return pytest.skip('Anonymous tests should be ran on unclaimed server, without providing MYPLEX_USERNAME and '
+                           'MYPLEX_PASSWORD')
 
 
 # ---------------------------------
 #  Fixtures
 # ---------------------------------
 
+
+def get_account():
+    return MyPlexAccount()
+
+
 @pytest.fixture(scope='session')
 def account():
     assert MYPLEX_USERNAME, 'Required MYPLEX_USERNAME not specified.'
     assert MYPLEX_PASSWORD, 'Required MYPLEX_PASSWORD not specified.'
-    return MyPlexAccount()
+    return get_account()
 
 
 @pytest.fixture(scope='session')
@@ -89,10 +116,14 @@ def account_synctarget(account_plexpass):
 
 
 @pytest.fixture(scope='session')
-def plex(account):
+def plex(request):
     assert SERVER_BASEURL, 'Required SERVER_BASEURL not specified.'
     session = requests.Session()
-    return PlexServer(SERVER_BASEURL, account.authenticationToken, session=session)
+    if request.param == TEST_AUTHENTICATED:
+        token = get_account().authenticationToken
+    else:
+        token = None
+    return PlexServer(SERVER_BASEURL, token, session=session)
 
 
 @pytest.fixture()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -146,7 +146,7 @@ def test_library_MovieSection_onDeck(movie, movies, tvshows, episode):
     movie.updateProgress(movie.duration * 1000 / 10)  # set progress to 10%
     assert movies.onDeck()
     movie.markUnwatched()
-    episode.markWatched()
+    episode.updateProgress(episode.duration * 1000 / 10)
     assert tvshows.onDeck()
     episode.markUnwatched()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,7 +121,15 @@ def test_server_history(plex, movie):
     movie.markUnwatched()
 
 
+@pytest.mark.anonymously
 def test_server_Server_query(plex):
+    assert plex.query('/')
+    with pytest.raises(BadRequest):
+        assert plex.query('/asdf/1234/asdf', headers={'random_headers': '1234'})
+
+
+@pytest.mark.authenticated
+def test_server_Server_query_authenticated(plex):
     assert plex.query('/')
     with pytest.raises(BadRequest):
         assert plex.query('/asdf/1234/asdf', headers={'random_headers': '1234'})
@@ -142,6 +150,7 @@ def test_server_Server_session(account):
     assert hasattr(plex._session, 'plexapi_session_test')
 
 
+@pytest.mark.authenticated
 def test_server_token_in_headers(plex):
     headers = plex._headers()
     assert 'X-Plex-Token' in headers
@@ -223,6 +232,7 @@ def test_server_clients(plex):
     assert client.version == '2.12.5'
 
 
+@pytest.mark.authenticated
 def test_server_account(plex):
     account = plex.account()
     assert account.authToken


### PR DESCRIPTION
I've added some extra checks and now we have an additional run of tests in Travis: over unclaimed server. You can check out how it looks on my fork's build: https://travis-ci.org/andrey-yantsen/python-plexapi/builds/429074802.

With this PR tests will be ran over PRs, they'll automatically run with unclaimed server.

Also, since we're not using an external server for testing anymore, maybe we can disable [Limit concurrent jobs](https://docs.travis-ci.com/user/customizing-the-build/#limiting-concurrent-jobs) in travis? I'm guessing it's enabled now, because the jobs are running one-by-one, and with this scheme the tests (5 runs of them) would be taking about an hour to complete.