### PR TITLE
fix docs for Raises clauses

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -471,7 +471,7 @@ class Playable(object):
                     offset, copyts, protocol, mediaIndex, platform.
 
             Raises:
-                Unsupported: When the item doesn't support fetching a stream URL.
+                :class:`plexapi.exceptions.Unsupported`: When the item doesn't support fetching a stream URL.
         """
         if self.TYPE not in ('movie', 'episode', 'track'):
             raise Unsupported('Fetching stream URL for %s is unsupported.' % self.TYPE)

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -139,7 +139,7 @@ class PlexClient(PlexObject):
                 value (bool): Enable or disable proxying (optional, default True).
 
             Raises:
-                :class:`~plexapi.exceptions.Unsupported`: Cannot use client proxy with unknown server.
+                :class:`plexapi.exceptions.Unsupported`: Cannot use client proxy with unknown server.
         """
         if server:
             self._server = server
@@ -177,8 +177,7 @@ class PlexClient(PlexObject):
                 **params (dict): Additional GET parameters to include with the command.
 
             Raises:
-                :class:`~plexapi.exceptions.Unsupported`: When we detect the client
-                    doesn't support this capability.
+                :class:`plexapi.exceptions.Unsupported`: When we detect the client doesn't support this capability.
         """
         command = command.strip('/')
         controller = command.split('/')[0]
@@ -272,7 +271,7 @@ class PlexClient(PlexObject):
                 **params (dict): Additional GET parameters to include with the command.
 
             Raises:
-                :class:`~plexapi.exceptions.Unsupported`: When no PlexServer specified in this object.
+                :class:`plexapi.exceptions.Unsupported`: When no PlexServer specified in this object.
         """
         if not self._server:
             raise Unsupported('A server must be specified before using this command.')
@@ -440,7 +439,7 @@ class PlexClient(PlexObject):
                     also: https://github.com/plexinc/plex-media-player/wiki/Remote-control-API#modified-commands
 
             Raises:
-                :class:`~plexapi.exceptions.Unsupported`: When no PlexServer specified in this object.
+                :class:`plexapi.exceptions.Unsupported`: When no PlexServer specified in this object.
         """
         if not self._server:
             raise Unsupported('A server must be specified before using this command.')

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -443,7 +443,7 @@ class LibrarySection(PlexObject):
                 **kwargs (dict): Additional kwargs to narrow down the choices.
 
             Raises:
-                :class:`~plexapi.exceptions.BadRequest`: Cannot include kwarg equal to specified category.
+                :class:`plexapi.exceptions.BadRequest`: Cannot include kwarg equal to specified category.
         """
         # TODO: Should this be moved to base?
         if category in kwargs:

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -433,8 +433,8 @@ class MyPlexAccount(PlexObject):
                 :class:`plexapi.sync.SyncItem`: an instance of created syncItem.
 
             Raises:
-                :class:`plexapi.exceptions.BadRequest` when client with provided clientId wasn`t found.
-                :class:`plexapi.exceptions.BadRequest` provided client doesn`t provides `sync-target`.
+                :class:`plexapi.exceptions.BadRequest`: when client with provided clientId wasn`t found.
+                :class:`plexapi.exceptions.BadRequest`: provided client doesn`t provides `sync-target`.
         """
         if not client and not clientId:
             clientId = X_PLEX_IDENTIFIER
@@ -690,7 +690,7 @@ class MyPlexResource(PlexObject):
                     HTTP or HTTPS connection.
 
             Raises:
-                :class:`~plexapi.exceptions.NotFound`: When unable to connect to any addresses for this resource.
+                :class:`plexapi.exceptions.NotFound`: When unable to connect to any addresses for this resource.
         """
         # Sort connections from (https, local) to (http, remote)
         # Only check non-local connections unless we own the resource
@@ -797,7 +797,7 @@ class MyPlexDevice(PlexObject):
             at least one connection was successful, the PlexClient object is built and returned.
 
             Raises:
-                :class:`~plexapi.exceptions.NotFound`: When unable to connect to any addresses for this device.
+                :class:`plexapi.exceptions.NotFound`: When unable to connect to any addresses for this device.
         """
         cls = PlexServer if 'server' in self.provides else PlexClient
         listargs = [[cls, url, self.token, timeout] for url in self.connections]
@@ -814,7 +814,7 @@ class MyPlexDevice(PlexObject):
         """ Returns an instance of :class:`plexapi.sync.SyncList` for current device.
 
             Raises:
-                :class:`plexapi.exceptions.BadRequest` when the device doesn`t provides `sync-target`.
+                :class:`plexapi.exceptions.BadRequest`: when the device doesn`t provides `sync-target`.
         """
         if 'sync-target' not in self.provides:
             raise BadRequest('Requested syncList for device which do not provides sync-target')

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -232,7 +232,7 @@ class PlexServer(PlexObject):
                 name (str): Name of the client to return.
 
             Raises:
-                :class:`~plexapi.exceptions.NotFound`: Unknown client name
+                :class:`plexapi.exceptions.NotFound`: Unknown client name
         """
         for client in self.clients():
             if client and client.title == name:
@@ -326,7 +326,7 @@ class PlexServer(PlexObject):
                 title (str): Title of the playlist to return.
 
             Raises:
-                :class:`~plexapi.exceptions.NotFound`: Invalid playlist title
+                :class:`plexapi.exceptions.NotFound`: Invalid playlist title
         """
         return self.fetchItem('/playlists', title=title)
 
@@ -393,7 +393,7 @@ class PlexServer(PlexObject):
                 callback (func): Callback function to call on recieved messages.
 
             raises:
-                :class:`~plexapi.exception.Unsupported`: Websocket-client not installed.
+                :class:`plexapi.exception.Unsupported`: Websocket-client not installed.
         """
         notifier = AlertListener(self, callback)
         notifier.start()

--- a/plexapi/sync.py
+++ b/plexapi/sync.py
@@ -201,7 +201,7 @@ class MediaSettings(object):
                 videoQuality (int): idx of quality of the video, one of VIDEO_QUALITY_* values defined in this module.
 
             Raises:
-                :class:`plexapi.exceptions.BadRequest` when provided unknown video quality.
+                :class:`plexapi.exceptions.BadRequest`: when provided unknown video quality.
         """
         if videoQuality == VIDEO_QUALITY_ORIGINAL:
             return MediaSettings('', '', '')

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -133,7 +133,7 @@ def searchType(libtype):
             libtype (str): LibType to lookup (movie, show, season, episode, artist, album, track,
                                               collection)
         Raises:
-            NotFound: Unknown libtype
+            :class:`plexapi.exceptions.NotFound`: Unknown libtype
     """
     libtype = compat.ustr(libtype)
     if libtype in [compat.ustr(v) for v in SEARCHTYPES.values()]:

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -351,8 +351,8 @@ class Show(Video):
                 episode (int): Episode number (default:None; required if title not specified).
 
            Raises:
-                BadRequest: If season and episode is missing.
-                NotFound: If the episode is missing.
+                :class:`plexapi.exceptions.BadRequest`: If season and episode is missing.
+                :class:`plexapi.exceptions.NotFound`: If the episode is missing.
         """
         if title:
             key = '/library/metadata/%s/allLeaves' % self.ratingKey


### PR DESCRIPTION
Sphinx 1.8 fail when trying to process Raises like 
```
:class:`~plexapi.exceptions.NotFound`: Unknown client name
```
So let's use absolute path.