### PR TITLE
Allow MusicSection search by track.userRating and sort by userRating

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -776,8 +776,8 @@ class MusicSection(LibrarySection):
             TAG (str): 'Directory'
             TYPE (str): 'artist'
     """
-    ALLOWED_FILTERS = ('genre', 'country', 'collection', 'mood')
-    ALLOWED_SORT = ('addedAt', 'lastViewedAt', 'viewCount', 'titleSort')
+    ALLOWED_FILTERS = ('genre', 'country', 'collection', 'mood', 'track.userRating')
+    ALLOWED_SORT = ('addedAt', 'lastViewedAt', 'viewCount', 'titleSort', 'userRating')
     TAG = 'Directory'
     TYPE = 'artist'
 


### PR DESCRIPTION
Changes to allow searching by the track's userRating in the MusicSection.

Resolves https://github.com/pkkid/python-plexapi/issues/317