### PR TITLE
Fix spelling of "original"

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -168,12 +168,12 @@ class Artist(Audio):
         """ Alias of :func:`~plexapi.audio.Artist.track`. """
         return self.track(title)
 
-    def download(self, savepath=None, keep_orginal_name=False, **kwargs):
+    def download(self, savepath=None, keep_original_name=False, **kwargs):
         """ Downloads all tracks for this artist to the specified location.
 
             Parameters:
                 savepath (str): Title of the track to return.
-                keep_orginal_name (bool): Set True to keep the original filename as stored in
+                keep_original_name (bool): Set True to keep the original filename as stored in
                     the Plex server. False will create a new filename with the format
                     "<Atrist> - <Album> <Track>".
                 kwargs (dict): If specified, a :func:`~plexapi.audio.Track.getStreamURL()` will
@@ -184,7 +184,7 @@ class Artist(Audio):
         filepaths = []
         for album in self.albums():
             for track in album.tracks():
-                filepaths += track.download(savepath, keep_orginal_name, **kwargs)
+                filepaths += track.download(savepath, keep_original_name, **kwargs)
         return filepaths
 
 
@@ -251,12 +251,12 @@ class Album(Audio):
         """ Return :func:`~plexapi.audio.Artist` of this album. """
         return self.fetchItem(self.parentKey)
 
-    def download(self, savepath=None, keep_orginal_name=False, **kwargs):
+    def download(self, savepath=None, keep_original_name=False, **kwargs):
         """ Downloads all tracks for this artist to the specified location.
 
             Parameters:
                 savepath (str): Title of the track to return.
-                keep_orginal_name (bool): Set True to keep the original filename as stored in
+                keep_original_name (bool): Set True to keep the original filename as stored in
                     the Plex server. False will create a new filename with the format
                     "<Atrist> - <Album> <Track>".
                 kwargs (dict): If specified, a :func:`~plexapi.audio.Track.getStreamURL()` will
@@ -266,7 +266,7 @@ class Album(Audio):
         """
         filepaths = []
         for track in self.tracks():
-            filepaths += track.download(savepath, keep_orginal_name, **kwargs)
+            filepaths += track.download(savepath, keep_original_name, **kwargs)
         return filepaths
 
     def _defaultSyncTitle(self):

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -519,13 +519,13 @@ class Playable(object):
         """
         client.playMedia(self)
 
-    def download(self, savepath=None, keep_orginal_name=False, **kwargs):
+    def download(self, savepath=None, keep_original_name=False, **kwargs):
         """ Downloads this items media to the specified location. Returns a list of
             filepaths that have been saved to disk.
 
             Parameters:
                 savepath (str): Title of the track to return.
-                keep_orginal_name (bool): Set True to keep the original filename as stored in
+                keep_original_name (bool): Set True to keep the original filename as stored in
                     the Plex server. False will create a new filename with the format
                     "<Artist> - <Album> <Track>".
                 kwargs (dict): If specified, a :func:`~plexapi.audio.Track.getStreamURL()` will
@@ -537,7 +537,7 @@ class Playable(object):
         locations = [i for i in self.iterParts() if i]
         for location in locations:
             filename = location.file
-            if keep_orginal_name is False:
+            if keep_original_name is False:
                 filename = '%s.%s' % (self._prettyfilename(), location.container)
             # So this seems to be a alot slower but allows transcode.
             if kwargs:

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -224,12 +224,12 @@ class Movie(Playable, Video):
         # This is just for compat.
         return self.title
 
-    def download(self, savepath=None, keep_orginal_name=False, **kwargs):
+    def download(self, savepath=None, keep_original_name=False, **kwargs):
         """ Download video files to specified directory.
 
             Parameters:
                 savepath (str): Defaults to current working dir.
-                keep_orginal_name (bool): True to keep the original file name otherwise
+                keep_original_name (bool): True to keep the original file name otherwise
                     a friendlier is generated.
                 **kwargs: Additional options passed into :func:`~plexapi.base.PlexObject.getStreamURL()`.
         """
@@ -237,7 +237,7 @@ class Movie(Playable, Video):
         locations = [i for i in self.iterParts() if i]
         for location in locations:
             name = location.file
-            if not keep_orginal_name:
+            if not keep_original_name:
                 title = self.title.replace(' ', '.')
                 name = '%s.%s' % (title, location.container)
             if kwargs is not None:
@@ -376,18 +376,18 @@ class Show(Video):
         """ Alias to :func:`~plexapi.video.Show.episode()`. """
         return self.episode(title, season, episode)
 
-    def download(self, savepath=None, keep_orginal_name=False, **kwargs):
+    def download(self, savepath=None, keep_original_name=False, **kwargs):
         """ Download video files to specified directory.
 
             Parameters:
                 savepath (str): Defaults to current working dir.
-                keep_orginal_name (bool): True to keep the original file name otherwise
+                keep_original_name (bool): True to keep the original file name otherwise
                     a friendlier is generated.
                 **kwargs: Additional options passed into :func:`~plexapi.base.PlexObject.getStreamURL()`.
         """
         filepaths = []
         for episode in self.episodes():
-            filepaths += episode.download(savepath, keep_orginal_name, **kwargs)
+            filepaths += episode.download(savepath, keep_original_name, **kwargs)
         return filepaths
 
 
@@ -477,18 +477,18 @@ class Season(Video):
         """ Returns list of unwatched :class:`~plexapi.video.Episode` objects. """
         return self.episodes(watched=False)
 
-    def download(self, savepath=None, keep_orginal_name=False, **kwargs):
+    def download(self, savepath=None, keep_original_name=False, **kwargs):
         """ Download video files to specified directory.
 
             Parameters:
                 savepath (str): Defaults to current working dir.
-                keep_orginal_name (bool): True to keep the original file name otherwise
+                keep_original_name (bool): True to keep the original file name otherwise
                     a friendlier is generated.
                 **kwargs: Additional options passed into :func:`~plexapi.base.PlexObject.getStreamURL()`.
         """
         filepaths = []
         for episode in self.episodes():
-            filepaths += episode.download(savepath, keep_orginal_name, **kwargs)
+            filepaths += episode.download(savepath, keep_original_name, **kwargs)
         return filepaths
 
     def _defaultSyncTitle(self):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -91,7 +91,7 @@ def test_video_Movie_attrs(movies):
     assert utils.is_metadata(movie.art)
     assert movie.artUrl
     assert movie.audienceRating == 8.5
-    # Disabled this since it failed on the last run, wasnt in the orginal xml result.
+    # Disabled this since it failed on the last run, wasnt in the original xml result.
     #assert movie.audienceRatingImage == 'rottentomatoes://image.rating.upright'
     movie.reload()  # RELOAD
     assert movie.chapterSource is None


### PR DESCRIPTION
Fix spelling of "original", formerly spelled "orignal".