### PR TITLE
Closes #334 - set default audio & subtitle stream

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -125,22 +125,42 @@ class MediaPart(PlexObject):
         """ Returns a list of :class:`~plexapi.media.SubtitleStream` objects in this MediaPart. """
         return [stream for stream in self.streams if stream.streamType == SubtitleStream.STREAMTYPE]
         
-    def setDefaultAudioStream(self, id):
+    def setDefaultAudioStream(self, stream=None, streamID=None):
         """ Set the default :class:`~plexapi.media.AudioStream` for this MediaPart.
 
             Parameters:
-                id (int): ID of the AudioStream to set
+                stream (:class:`~plexapi.media.AudioStream`): AudioStream to set as default 
+                    (default:None; required if streamID is not specified).
+                streamID (int): ID of the AudioStream to set 
+                    (default:None; required if stream is not specified).
+            
+            Raises:
+                :class:`plexapi.exceptions.BadRequest`: If both stream and streamID are missing.
         """
-        key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, id)
+        if stream:
+            key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, stream.id)
+        elif streamID:
+            key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, streamID)
+        else:
+            raise BadRequest('Missing argument: stream or streamID is required')
         self._server.query(key, method=self._server._session.put)
-        
-    def setDefaultSubtitleStream(self, id):
+            
+    def setDefaultSubtitleStream(self, stream=None, streamID=None):
         """ Set the default :class:`~plexapi.media.SubtitleStream` for this MediaPart.
+            (Note: pass no parameters to disable subtitles)
 
             Parameters:
-                id (int): ID of the SubtitleStream to set (0 for no subtitles)
+                stream (:class:`~plexapi.media.SubtitleStream`): SubtitleStream to set as default 
+                    (default:None).
+                streamID (int): ID of the AudioStream to set 
+                    (default:None).
         """
-        key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, id)
+        if stream:
+            key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, stream.id)
+        elif streamID:
+            key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, streamID)
+        else:
+            key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, 0)
         self._server.query(key, method=self._server._session.put)
         
 

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -124,6 +124,25 @@ class MediaPart(PlexObject):
     def subtitleStreams(self):
         """ Returns a list of :class:`~plexapi.media.SubtitleStream` objects in this MediaPart. """
         return [stream for stream in self.streams if stream.streamType == SubtitleStream.STREAMTYPE]
+        
+    def setDefaultAudioStream(self, id):
+        """ Set the default :class:`~plexapi.media.AudioStream` for this MediaPart.
+
+            Parameters:
+                id (int): ID of the AudioStream to set
+        """
+        key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, id)
+        self._server.query(key, method=self._server._session.put)
+        
+    def setDefaultSubtitleStream(self, id):
+        """ Set the default :class:`~plexapi.media.SubtitleStream` for this MediaPart.
+
+            Parameters:
+                id (int): ID of the SubtitleStream to set (0 for no subtitles)
+        """
+        key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, id)
+        self._server.query(key, method=self._server._session.put)
+        
 
 
 class MediaPartStream(PlexObject):

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -130,32 +130,26 @@ class MediaPart(PlexObject):
 
             Parameters:
                 stream (:class:`~plexapi.media.AudioStream`): AudioStream to set as default 
-            
-            Raises:
-                :class:`plexapi.exceptions.BadRequest`: If stream is not an AudioStream.
         """
-        if type(stream) == AudioStream:
+        if isinstance(stream, AudioStream):
             key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, stream.id)
-            self._server.query(key, method=self._server._session.put)
         else:
-            raise BadRequest("Object 'stream' is not an AudioStream.")
+            key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, stream)
+        self._server.query(key, method=self._server._session.put)
             
     def setDefaultSubtitleStream(self, stream):
         """ Set the default :class:`~plexapi.media.SubtitleStream` for this MediaPart.
             
             Parameters:
                 stream (:class:`~plexapi.media.SubtitleStream`): SubtitleStream to set as default.
-            
-            Raises:
-                :class:`plexapi.exceptions.BadRequest`: If stream is not a SubtitleStream.
         """
-        if type(stream) == SubtitleStream:
+        if isinstance(stream, SubtitleStream):
             key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, stream.id)
-            self._server.query(key, method=self._server._session.put)
         else:
-            raise BadRequest("Object 'stream' is not a SubtitleStream.")
+            key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, stream)
+        self._server.query(key, method=self._server._session.put)
         
-    def resetSubtitles(self):
+    def resetDefaultSubtitleStream(self):
         """ Set default subtitle of this MediaPart to 'none'. """
         key = "/library/parts/%d?subtitleStreamID=0&allParts=1" % (self.id)
         self._server.query(key, method=self._server._session.put)

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -144,7 +144,6 @@ class MediaPart(PlexObject):
         self._server.query(key, method=self._server._session.put)
         
 
-
 class MediaPartStream(PlexObject):
     """ Base class for media streams. These consist of video, audio and subtitles.
 

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -125,44 +125,40 @@ class MediaPart(PlexObject):
         """ Returns a list of :class:`~plexapi.media.SubtitleStream` objects in this MediaPart. """
         return [stream for stream in self.streams if stream.streamType == SubtitleStream.STREAMTYPE]
         
-    def setDefaultAudioStream(self, stream=None, streamID=None):
+    def setDefaultAudioStream(self, stream):
         """ Set the default :class:`~plexapi.media.AudioStream` for this MediaPart.
 
             Parameters:
                 stream (:class:`~plexapi.media.AudioStream`): AudioStream to set as default 
-                    (default:None; required if streamID is not specified).
-                streamID (int): ID of the AudioStream to set 
-                    (default:None; required if stream is not specified).
             
             Raises:
-                :class:`plexapi.exceptions.BadRequest`: If both stream and streamID are missing.
+                :class:`plexapi.exceptions.BadRequest`: If stream is not an AudioStream.
         """
-        if stream:
+        if type(stream) == AudioStream:
             key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, stream.id)
-        elif streamID:
-            key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, streamID)
+            self._server.query(key, method=self._server._session.put)
         else:
-            raise BadRequest('Missing argument: stream or streamID is required')
-        self._server.query(key, method=self._server._session.put)
+            raise BadRequest("Object 'stream' is not an AudioStream.")
             
-    def setDefaultSubtitleStream(self, stream=None, streamID=None):
+    def setDefaultSubtitleStream(self, stream):
         """ Set the default :class:`~plexapi.media.SubtitleStream` for this MediaPart.
-            (Note: pass no parameters to disable subtitles)
-
+            
             Parameters:
-                stream (:class:`~plexapi.media.SubtitleStream`): SubtitleStream to set as default 
-                    (default:None).
-                streamID (int): ID of the AudioStream to set 
-                    (default:None).
+                stream (:class:`~plexapi.media.SubtitleStream`): SubtitleStream to set as default.
+            
+            Raises:
+                :class:`plexapi.exceptions.BadRequest`: If stream is not a SubtitleStream.
         """
-        if stream:
+        if type(stream) == SubtitleStream:
             key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, stream.id)
-        elif streamID:
-            key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, streamID)
+            self._server.query(key, method=self._server._session.put)
         else:
-            key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, 0)
-        self._server.query(key, method=self._server._session.put)
+            raise BadRequest("Object 'stream' is not a SubtitleStream.")
         
+    def resetSubtitles(self):
+        """ Set default subtitle of this MediaPart to 'none'. """
+        key = "/library/parts/%d?subtitleStreamID=0&allParts=1" % (self.id)
+        self._server.query(key, method=self._server._session.put)
 
 class MediaPartStream(PlexObject):
     """ Base class for media streams. These consist of video, audio and subtitles.


### PR DESCRIPTION
Set the 'selected' flags of audio & subtitle streams of a MediaPart. #334.