### PR TITLE
Fix Show.season(0) not returning 'Specials'

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -333,7 +333,7 @@ class Show(Video):
                 title (str or int): Title or Number of the season to return.
         """
         if isinstance(title, int):
-            title = 'Season %s' % title
+            title = 'Season %s' % title if title != 0 else 'Specials'
         key = '/library/metadata/%s/children' % self.ratingKey
         return self.fetchItem(key, etag='Directory', title__iexact=title)
 


### PR DESCRIPTION
Currently Show.season(0) attempts to return a season with the title 'Season 0', which throws an exception because Plex titles Season 0 as 'Specials'.  This fixes that bug.