### PR TITLE
Welcome the green build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     - stage: test
       python: 3.6
       env:
-        - PLEX_CONTAINER_TAG=1.9.7.4460-a39b25852
+        - PLEX_CONTAINER_TAG=1.10.1.4602-f54242b6b
         - TEST_ACCOUNT_ONCE=1
     - stage: test
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     - stage: test
       python: 3.6
       env:
-        - PLEX_CONTAINER_TAG=1.3.2.3112-1751929
+        - PLEX_CONTAINER_TAG=1.9.7.4460-a39b25852
         - TEST_ACCOUNT_ONCE=1
     - stage: test
       python: 3.6

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -378,13 +378,13 @@ class LibrarySection(PlexObject):
         return self.fetchItem(key, title__iexact=title)
 
     def all(self, sort=None, **kwargs):
-        """ Returns a list of media from this library section. 
-        
+        """ Returns a list of media from this library section.
+
             Parameters:
                     sort (string): The sort string
         """
         sortStr = ''
-        if sort != None:
+        if sort is not None:
             sortStr = '?sort=' + sort
         
         key = '/library/sections/%s/all%s' % (self.key, sortStr)

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -124,19 +124,19 @@ class MediaPart(PlexObject):
     def subtitleStreams(self):
         """ Returns a list of :class:`~plexapi.media.SubtitleStream` objects in this MediaPart. """
         return [stream for stream in self.streams if stream.streamType == SubtitleStream.STREAMTYPE]
-        
+
     def setDefaultAudioStream(self, stream):
         """ Set the default :class:`~plexapi.media.AudioStream` for this MediaPart.
 
             Parameters:
-                stream (:class:`~plexapi.media.AudioStream`): AudioStream to set as default 
+                stream (:class:`~plexapi.media.AudioStream`): AudioStream to set as default
         """
         if isinstance(stream, AudioStream):
             key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, stream.id)
         else:
             key = "/library/parts/%d?audioStreamID=%d&allParts=1" % (self.id, stream)
         self._server.query(key, method=self._server._session.put)
-            
+
     def setDefaultSubtitleStream(self, stream):
         """ Set the default :class:`~plexapi.media.SubtitleStream` for this MediaPart.
             
@@ -148,11 +148,12 @@ class MediaPart(PlexObject):
         else:
             key = "/library/parts/%d?subtitleStreamID=%d&allParts=1" % (self.id, stream)
         self._server.query(key, method=self._server._session.put)
-        
+
     def resetDefaultSubtitleStream(self):
         """ Set default subtitle of this MediaPart to 'none'. """
         key = "/library/parts/%d?subtitleStreamID=0&allParts=1" % (self.id)
         self._server.query(key, method=self._server._session.put)
+
 
 class MediaPartStream(PlexObject):
     """ Base class for media streams. These consist of video, audio and subtitles.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ CONTENTRATINGS = {'TV-14', 'TV-MA', 'G', 'NR', 'Not Rated'}
 FRAMERATES = {'24p', 'PAL', 'NTSC'}
 PROFILES = {'advanced simple', 'main', 'constrained baseline'}
 RESOLUTIONS = {'sd', '480', '576', '720', '1080'}
-ENTITLEMENTS = {'ios', 'cpms', 'roku', 'android', 'xbox_one', 'xbox_360', 'windows', 'windows_phone'}
+ENTITLEMENTS = {'ios', 'roku', 'android', 'xbox_one', 'xbox_360', 'windows', 'windows_phone'}
 
 TEST_AUTHENTICATED = 'authenticated'
 TEST_ANONYMOUSLY = 'anonymously'

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -118,7 +118,7 @@ def test_video_Movie_attrs(movies):
     assert float(movie.rating) >= 6.4
     #assert movie.ratingImage == 'rottentomatoes://image.rating.ripe'
     assert movie.ratingKey >= 1
-    assert sorted([i.tag for i in movie.roles])[:4] == ['Aladdin Ullah', 'Annette Hanshaw', 'Aseem Chhabra', 'Bhavana Nagulapally']  # noqa
+    assert set(sorted([i.tag for i in movie.roles])) >= {'Aladdin Ullah', 'Annette Hanshaw', 'Aseem Chhabra', 'Debargo Sanyal'}  # noqa
     assert movie._server._baseurl == utils.SERVER_BASEURL
     assert movie.sessionKey is None
     assert movie.studio == 'Nina Paley'


### PR DESCRIPTION
Now we're using Plex Server 1.10.1 instead of 1.3.2 — from this version the smart playlists test isn't failing. Also I've fixed a couple more tests and a few flake8 warnings.

fixes #338.