### PR TITLE
Fix show.episode() not allowing season 0

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -357,7 +357,7 @@ class Show(Video):
         if title:
             key = '/library/metadata/%s/allLeaves' % self.ratingKey
             return self.fetchItem(key, title__iexact=title)
-        elif season and episode:
+        elif season is not None and episode:
             results = [i for i in self.episodes() if i.seasonNumber == season and i.index == episode]
             if results:
                 return results[0]


### PR DESCRIPTION
In show.episode(), a season value of 0 will evaluate to false, and the function thinks a season has not been provided.  Since season 0 is a valid Plex season, this now explicitly checks for a value of 'None', which correctly evaluates season 0 as valid.