### PR TITLE
Get season from index instead of creating title

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -332,9 +332,9 @@ class Show(Video):
             Parameters:
                 title (str or int): Title or Number of the season to return.
         """
-        if isinstance(title, int):
-            title = 'Season %s' % title if title != 0 else 'Specials'
         key = '/library/metadata/%s/children' % self.ratingKey
+        if isinstance(title, int):
+            return self.fetchItem(key, etag='Directory', index__iexact=str(title))
         return self.fetchItem(key, etag='Directory', title__iexact=title)
 
     def episodes(self, **kwargs):


### PR DESCRIPTION
Currently, when passing a season number X, this function creates a season title "Season X", then fetches the season based off that. If the user has changed the title of their season to something more befitting of the show, this obviously fails. This patch fixes that by grabbing a season based off the Season.index when an integer is passed.