### PR TITLE
Ignore negative epoch values

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -181,7 +181,7 @@ def toDatetime(value, format=None):
             # https://bugs.python.org/issue30684
             # And platform support for before epoch seems to be flaky.
             # TODO check for others errors too.
-            if int(value) == 0:
+            if int(value) <= 0:
                 value = 86400
             value = datetime.fromtimestamp(int(value))
     return value


### PR DESCRIPTION
Further fixing #276
Plex will sometimes return "junk" negative epoch values, and these negative values are not handled well. (plus a common issue with Python on Windows https://bugs.python.org/issue29097)

`toDatetime` seems to only be called on "recent" date values (addedAt, updatedAt etc.) therefore I imagine limited harm simply ignoring these negative epoch values.