### PR TITLE
Don't warn when also raising exception

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -172,7 +172,6 @@ class MyPlexAccount(PlexObject):
         if response.status_code not in (200, 201, 204):  # pragma: no cover
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
-            log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
             raise BadRequest('(%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
@@ -487,7 +486,6 @@ class MyPlexAccount(PlexObject):
         if response.status_code not in (200, 201, 204):  # pragma: no cover
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
-            log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
             raise BadRequest('(%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
         return response.json()['token']
 


### PR DESCRIPTION
We should not log warnings if we are also raising exceptions. It is up to the caller to decide how to handle the error and if they should notify the user. 

This was triggered because I got logs for bad requests for 401 Unauthorized.