### PR TITLE
Adding Managed User support

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -62,6 +62,7 @@ class MyPlexAccount(PlexObject):
             _session (obj): Requests session object used to access this client.
     """
     FRIENDINVITE = 'https://plex.tv/api/servers/{machineId}/shared_servers'                     # post with data
+    HOMEUSERCREATE = 'https://plex.tv/api/home/users?title={title}'                             # post with data
     FRIENDSERVERS = 'https://plex.tv/api/servers/{machineId}/shared_servers/{serverId}'         # put with data
     PLEXSERVERS = 'https://plex.tv/api/servers/{machineId}'                                     # get
     FRIENDUPDATE = 'https://plex.tv/api/friends/{userId}'                                       # put with args, delete
@@ -229,6 +230,52 @@ class MyPlexAccount(PlexObject):
         headers = {'Content-Type': 'application/json'}
         url = self.FRIENDINVITE.format(machineId=machineId)
         return self.query(url, self._session.post, json=params, headers=headers)
+
+    def createHomeUser(self, user, server, sections=None, allowSync=False, allowCameraUpload=False,
+                          allowChannels=False, filterMovies=None, filterTelevision=None, filterMusic=None):
+        """ Share library content with the specified user.
+        
+            Parameters:
+                user (str): MyPlexUser, username, email of the user to be added.
+                server (PlexServer): PlexServer object or machineIdentifier containing the library sections to share.
+                sections ([Section]): Library sections, names or ids to be shared (default None shares all sections).
+                allowSync (Bool): Set True to allow user to sync content.
+                allowCameraUpload (Bool): Set True to allow user to upload photos.
+                allowChannels (Bool): Set True to allow user to utilize installed channels.
+                filterMovies (Dict): Dict containing key 'contentRating' and/or 'label' each set to a list of
+                    values to be filtered. ex: {'contentRating':['G'], 'label':['foo']}
+                filterTelevision (Dict): Dict containing key 'contentRating' and/or 'label' each set to a list of
+                    values to be filtered. ex: {'contentRating':['G'], 'label':['foo']}
+                filterMusic (Dict): Dict containing key 'label' set to a list of values to be filtered.
+                    ex: {'label':['foo']}
+        """
+        machineId = server.machineIdentifier if isinstance(server, PlexServer) else server
+        sectionIds = self._getSectionIds(server, sections)
+
+        headers = {'Content-Type': 'application/json'}
+        url = self.HOMEUSERCREATE.format(title=user)
+        # UserID needs to be created and referenced when adding sections
+        user_creation = self.query(url, self._session.post, headers=headers)
+        userIds = {}
+        for elem in user_creation.findall("."):
+            # Find userID
+            userIds['id'] = elem.attrib.get('id')
+        log.debug(userIds)
+        params = {
+            'server_id': machineId,
+            'shared_server': {'library_section_ids': sectionIds, 'invited_id': userIds['id']},
+            'sharing_settings': {
+                'allowSync': ('1' if allowSync else '0'),
+                'allowCameraUpload': ('1' if allowCameraUpload else '0'),
+                'allowChannels': ('1' if allowChannels else '0'),
+                'filterMovies': self._filterDictToStr(filterMovies or {}),
+                'filterTelevision': self._filterDictToStr(filterTelevision or {}),
+                'filterMusic': self._filterDictToStr(filterMusic or {}),
+            },
+        }
+        url = self.FRIENDINVITE.format(machineId=machineId)
+        library_assignment = self.query(url, self._session.post, json=params, headers=headers)
+        return user_creation, library_assignment
 
     def removeFriend(self, user):
         """ Remove the specified user from all sharing.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -67,6 +67,7 @@ class MyPlexAccount(PlexObject):
     FRIENDSERVERS = 'https://plex.tv/api/servers/{machineId}/shared_servers/{serverId}'         # put with data
     PLEXSERVERS = 'https://plex.tv/api/servers/{machineId}'                                     # get
     FRIENDUPDATE = 'https://plex.tv/api/friends/{userId}'                                       # put with args, delete
+    REMOVEHOMEUSER = 'https://plex.tv/api/home/users/{userId}'                                  # delete
     REMOVEINVITE = 'https://plex.tv/api/invites/requested/{userId}?friend=0&server=1&home=0'    # delete
     REQUESTED = 'https://plex.tv/api/invites/requested'                                         # get
     REQUESTS = 'https://plex.tv/api/invites/requests'                                           # get
@@ -337,6 +338,16 @@ class MyPlexAccount(PlexObject):
         user = self.user(user)
         url = self.FRIENDUPDATE if user.friend else self.REMOVEINVITE
         url = url.format(userId=user.id)
+        return self.query(url, self._session.delete)
+
+    def removeHomeUser(self, user):
+        """ Remove the specified managed user from home.
+
+            Parameters:
+                user (str): MyPlexUser, username, email of the user to be removed from home.
+        """
+        user = self.user(user)
+        url = self.REMOVEHOMEUSER.format(userId=user.id)
         return self.query(url, self._session.delete)
 
     def updateFriend(self, user, server, sections=None, removeSections=False, allowSync=None, allowCameraUpload=None,

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -157,6 +157,27 @@ def test_myplex_updateFriend(account, plex, mocker, shared_username):
                                      filterTelevision=vid_filter, filterMusic={'label': ['foo']})
 
 
+def test_myplex_createExistingUser(account, plex, shared_username):
+    user = account.user(shared_username)
+    url = 'https://plex.tv/api/invites/requested/{}?friend=0&server=0&home=1'.format(user.id)
+
+    account.createExistingUser(user, plex)
+    assert shared_username in [u.username for u in account.users() if u.home is True]
+    # Remove Home invite
+    account.query(url, account._session.delete)
+    # Confirm user was removed from home and has returned to friend
+    assert shared_username not in [u.username for u in plex.myPlexAccount().users() if u.home is True]
+    assert shared_username in [u.username for u in plex.myPlexAccount().users() if u.home is False]
+
+
+def test_myplex_createHomeUser_remove(account, plex):
+    homeuser = 'New Home User'
+    account.createHomeUser(homeuser, plex)
+    assert homeuser in [u.title for u in plex.myPlexAccount().users() if u.home is True]
+    account.removeHomeUser(homeuser)
+    assert homeuser not in [u.title for u in plex.myPlexAccount().users() if u.home is True]
+
+
 def test_myplex_plexpass_attributes(account_plexpass):
     assert account_plexpass.subscriptionActive
     assert account_plexpass.subscriptionStatus == 'Active'


### PR DESCRIPTION
In response to #350 

Adding ability to create and remove a Home User. Adding ability to create an Existing Plex User. When creating an Existing Plex User that already exists in Sharing/Friend, carry over section shares and settings. If Existing Plex User does not already exist in Sharing/Friend, sections and settings can be applied.