### PR TITLE
Do not fail while parsing illegal dates. Return None instead.

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -9,11 +9,8 @@ from datetime import datetime
 from getpass import getpass
 from threading import Thread, Event
 from tqdm import tqdm
-from plexapi import compat
+from plexapi import compat, log
 from plexapi.exceptions import NotFound
-
-
-LOG = logging.getLogger(__name__)
 
 
 # Search Types - Plex uses these to filter specific media types when searching.
@@ -183,7 +180,7 @@ def toDatetime(value, format=None):
             try:
                 value = datetime.strptime(value, format)
             except ValueError:
-                LOG.info('Failed to parse %s to datetime, defaulting to None', value)
+                log.info('Failed to parse %s to datetime, defaulting to None', value)
                 return None
         else:
             # https://bugs.python.org/issue30684

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -176,7 +176,11 @@ def toDatetime(value, format=None):
     """
     if value and value is not None:
         if format:
-            value = datetime.strptime(value, format)
+            try:
+                value = datetime.strptime(value, format)
+            except ValueError:
+                # parsing failed
+                return None
         else:
             # https://bugs.python.org/issue30684
             # And platform support for before epoch seems to be flaky.

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -12,6 +12,10 @@ from tqdm import tqdm
 from plexapi import compat
 from plexapi.exceptions import NotFound
 
+
+LOG = logging.getLogger(__name__)
+
+
 # Search Types - Plex uses these to filter specific media types when searching.
 # Library Types - Populated at runtime
 SEARCHTYPES = {'movie': 1, 'show': 2, 'season': 3, 'episode': 4, 'trailer': 5, 'comic': 6, 'person': 7,
@@ -179,7 +183,7 @@ def toDatetime(value, format=None):
             try:
                 value = datetime.strptime(value, format)
             except ValueError:
-                # parsing failed
+                LOG.info('Failed to parse %s to datetime, defaulting to None', value)
                 return None
         else:
             # https://bugs.python.org/issue30684


### PR DESCRIPTION
hi,

I'm using your project and I stumbled upon a nasty Plex db having malformed dates here and there.
This caused ValueError exceptions, while parsing Plex XML, that emerged without any context.
Example: audio.Artist.albums() method fails if one album has illformed originallyAvailableAt attribute.

I'm not fond of the solution I propose you, but I needed a quick patch and the new behaviour is a bit better, at least for me.
