### PR TITLE
Update library.py

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -291,7 +291,7 @@ class Library(PlexObject):
         part = '/library/sections?name=%s&type=%s&agent=%s&scanner=%s&language=%s&location=%s' % (
             quote_plus(name), type, agent, quote_plus(scanner), language, quote_plus(location))  # noqa E126
         if kwargs:
-            part += urlencode(kwargs)
+            part += '&' + urlencode(kwargs)
         return self._server.query(part, method=self._server._session.post)
 
 


### PR DESCRIPTION
Issue when passing kwargs to url:

plexapi.exceptions.BadRequest: (400) bad_request; https://...31.plex.direct:32400/library/sections?name=6J0VMAS4&type=movie&agent=com.plexapp.agents.imdb&scanner=Plex+Movie+Scanner&language=de&location=%2FUser%2Fmoviescollections=False&extras=False&includeInGlobal=False

-> path is /user/movies
-> collections=False is kwarg

No '&' between.