### PR TITLE
Fix for getting Episode by index from Season

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -468,7 +468,7 @@ class Season(Video):
         key = '/library/metadata/%s/children' % self.ratingKey
         if title:
             return self.fetchItem(key, title=title)
-        return self.fetchItem(key, seasonNumber=self.index, index=episode)
+        return self.fetchItem(key, parentIndex=self.index, index=episode)
 
     def get(self, title=None, episode=None):
         """ Alias to :func:`~plexapi.video.Season.episode()`. """

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -571,6 +571,11 @@ def test_video_Season_episode(show):
     assert episode.title == 'Winter Is Coming'
 
 
+def test_video_Season_episode_by_index(show):
+    episode = show.season(1).episode(episode=1)
+    assert episode.index == 1
+
+
 def test_video_Season_episodes(show):
     episodes = show.season(2).episodes()
     assert len(episodes) >= 1


### PR DESCRIPTION
The Episode object doesn't contain the 'seasonNumber' attribute, resulting all queries to get an Episode from a Season using index to result in NotFound.  I replaced 'seasonNumber' with 'parentIndex', the proper attribute on the Episode object.