### PR TITLE
Plexamp workaround for bad responses

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -202,19 +202,16 @@ class PlexClient(PlexObject):
 
         proxy = self._proxyThroughServer if proxy is None else proxy
 
-        if self.product in ('Plexamp'):
+        try:
+            if proxy:
+                return self._server.query(key, headers=headers)
+            return self.query(key, headers=headers)
+        except ElementTree.ParseError:
             # Workaround for players which don't return valid XML on successful commands
             #   - Plexamp: `b'OK'`
-            try:
-                if proxy:
-                    return self._server.query(key, headers=headers)
-                return self.query(key, headers=headers)
-            except ElementTree.ParseError:
-                return None
+            if self.product not in ('Plexamp'):
+                raise
 
-        if proxy:
-            return self._server.query(key, headers=headers)
-        return self.query(key, headers=headers)
 
     def url(self, key, includeToken=False):
         """ Build a URL string with proper token argument. Token will be appended to the URL

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -205,8 +205,8 @@ class PlexClient(PlexObject):
         except ElementTree.ParseError:
             # Workaround for players which don't return valid XML on successful commands
             #   - Plexamp: `b'OK'`
-            if self.product in ('Plexamp'):
-                return None
+            if self.product in ('Plexamp',):
+                return
             raise
 
     def url(self, key, includeToken=False):

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -165,6 +165,8 @@ class PlexClient(PlexObject):
             log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
             raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
         data = response.text.encode('utf8')
+        if data == b'OK':   # Workaround for misbehaving clients such as Plexamp
+            data = ''
         return ElementTree.fromstring(data) if data.strip() else None
 
     def sendCommand(self, command, proxy=None, **params):


### PR DESCRIPTION
Plexamp responds to commands with `b'OK'` which is not valid XML, leading to a parser error on every response. This ignores that specific response.