### PR TITLE
Workaround for Android TV client commands.

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -205,7 +205,10 @@ class PlexClient(PlexObject):
         except ElementTree.ParseError:
             # Workaround for players which don't return valid XML on successful commands
             #   - Plexamp: `b'OK'`
-            if self.product in ('Plexamp',):
+            if self.product in (
+                'Plexamp',
+                'Plex for Android (TV)',
+            ):
                 return
             raise
 


### PR DESCRIPTION
As found in https://github.com/home-assistant/home-assistant/issues/27996, Android TV clients also provide invalid XML responses to commands. This adds the product name to the list of workaround clients.