### PR TITLE
Fix the documentation on originalTitle for Trackobjects

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -284,15 +284,15 @@ class Track(Audio, Playable):
             art (str): Track artwork (/library/metadata/<ratingkey>/art/<artid>)
             chapterSource (TYPE): Unknown
             duration (int): Length of this album in seconds.
-            grandparentArt (str): Artist artowrk.
-            grandparentKey (str): Artist API URL.
-            grandparentRatingKey (str): Unique key identifying artist.
-            grandparentThumb (str): URL to artist thumbnail image.
-            grandparentTitle (str): Name of the artist for this track.
+            grandparentArt (str): Album artist artwork.
+            grandparentKey (str): Album artist API URL.
+            grandparentRatingKey (str): Unique key identifying album artist.
+            grandparentThumb (str): URL to album artist thumbnail image.
+            grandparentTitle (str): Name of the album artist for this track.
             guid (str): Unknown (unique ID).
             media (list): List of :class:`~plexapi.media.Media` objects for this track.
             moods (list): List of :class:`~plexapi.media.Mood` objects for this track.
-            originalTitle (str): Original track title (if translated).
+            originalTitle (str): Track artist.
             parentIndex (int): Album index.
             parentKey (str): Album API URL.
             parentRatingKey (int): Unique key identifying album.


### PR DESCRIPTION
Weirdly originalTitle refers to the track interpreter and not the original title lol