### PR TITLE
Skip attr reload for 'session'

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -6,6 +6,7 @@ from plexapi.compat import quote_plus, urlencode
 from plexapi.exceptions import BadRequest, NotFound, UnknownType, Unsupported
 from plexapi.utils import tag_helper
 
+DONT_RELOAD_FOR_KEYS = ['key', 'session']
 OPERATORS = {
     'exact': lambda v, q: v == q,
     'iexact': lambda v, q: v.lower() == q.lower(),
@@ -278,7 +279,8 @@ class PlexPartialObject(PlexObject):
         # Dragons inside.. :-/
         value = super(PlexPartialObject, self).__getattribute__(attr)
         # Check a few cases where we dont want to reload
-        if attr == 'key' or attr.startswith('_'): return value
+        if attr in DONT_RELOAD_FOR_KEYS: return value
+        if attr.startswith('_'): return value
         if value not in (None, []): return value
         if self.isFullObject(): return value
         # Log the reload.


### PR DESCRIPTION
Fix as suggested by @pkkid in #397.

As described there:
> When we see None or empty list, we assume the object returned from Plex is incomplete and reload the official full object from the url defined by self.key. The problem here is that new object doesn't store any information about the playing sessions of that object, and they get overwritten with the empty data in Playable().