### PR TITLE
photo_tags

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -869,7 +869,7 @@ class PhotoSection(LibrarySection):
             TYPE (str): 'photo'
     """
     ALLOWED_FILTERS = ('all', 'iso', 'make', 'lens', 'aperture', 'exposure', 'device', 'resolution', 'place',
-                       'originallyAvailableAt', 'addedAt', 'title', 'userRating', 'tag')
+                       'originallyAvailableAt', 'addedAt', 'title', 'userRating', 'tag', 'year')
     ALLOWED_SORT = ('addedAt',)
     TAG = 'Directory'
     TYPE = 'photo'

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -869,7 +869,7 @@ class PhotoSection(LibrarySection):
             TYPE (str): 'photo'
     """
     ALLOWED_FILTERS = ('all', 'iso', 'make', 'lens', 'aperture', 'exposure', 'device', 'resolution', 'place',
-                       'originallyAvailableAt', 'addedAt', 'title', 'userRating')
+                       'originallyAvailableAt', 'addedAt', 'title', 'userRating', 'tag')
     ALLOWED_SORT = ('addedAt',)
     TAG = 'Directory'
     TYPE = 'photo'

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -420,6 +420,25 @@ class Label(MediaTag):
 
 
 @utils.registerPlexObject
+class Tag(MediaTag):
+    """ Represents a single tag media tag.
+
+        Attributes:
+            TAG (str): 'tag'
+            FILTER (str): 'tag'
+    """
+    TAG = 'Tag'
+    FILTER = 'tag'
+
+    def _loadData(self, data):
+        self._data = data
+        self.id = cast(int, data.attrib.get('id', 0))
+        self.filter = data.attrib.get('filter')
+        self.tag = data.attrib.get('tag')
+        self.title = self.tag
+
+
+@utils.registerPlexObject
 class Country(MediaTag):
     """ Represents a single Country media tag.
 

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -117,6 +117,7 @@ class Photo(PlexPartialObject):
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self.year = utils.cast(int, data.attrib.get('year'))
         self.media = self.findItems(data, media.Media)
+        self.tag = self.findItems(data, media.Tag)
 
     def photoalbum(self):
         """ Return this photo's :class:`~plexapi.photo.Photoalbum`. """


### PR DESCRIPTION
Allow for photo tags to be searchable. 
Addressing issue found in #399. Tags were not searchable for photos.