### PR TITLE
Support history for specific ratingKeys

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -421,9 +421,13 @@ class PlexPartialObject(PlexObject):
                 'havnt allowed items to be deleted' % self.key)
             raise
 
-    def history(self):
-        """ Get Play History for a media item. """
-        return self._server.history(ratingKey=self.ratingKey)
+    def history(self, maxresults=9999999, mindate=None):
+        """ Get Play History for a media item.
+            Parameters:
+                maxresults (int): Only return the specified number of results (optional).
+                mindate (datetime): Min datetime to return results from.
+        """
+        return self._server.history(maxresults=maxresults, mindate=mindate, ratingKey=self.ratingKey)
 
 
     # The photo tag cant be built atm. TODO

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -421,6 +421,11 @@ class PlexPartialObject(PlexObject):
                 'havnt allowed items to be deleted' % self.key)
             raise
 
+    def history(self):
+        """ Get Play History for a media item. """
+        return self._server.history(ratingKey=self.ratingKey)
+
+
     # The photo tag cant be built atm. TODO
     # def arts(self):
     #     part = '%s/arts' % self.key

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -294,6 +294,13 @@ class Library(PlexObject):
             part += urlencode(kwargs)
         return self._server.query(part, method=self._server._session.post)
 
+    def history(self):
+        """ Get Play History for all library Sections for the owner. """
+        hist = []
+        for section in self.sections():
+            hist.extend(section.history())
+        return hist
+
 
 class LibrarySection(PlexObject):
     """ Base class for a single library section.
@@ -632,6 +639,10 @@ class LibrarySection(PlexObject):
         sync_item.mediaSettings = mediaSettings
 
         return myplex.sync(client=client, clientId=clientId, sync_item=sync_item)
+
+    def history(self):
+        """ Get Play History for this library Section for the owner. """
+        return self._server.history(librarySectionID=self.key, accountID=1)
 
 
 class MovieSection(LibrarySection):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -294,11 +294,15 @@ class Library(PlexObject):
             part += urlencode(kwargs)
         return self._server.query(part, method=self._server._session.post)
 
-    def history(self):
-        """ Get Play History for all library Sections for the owner. """
+    def history(self, maxresults=9999999, mindate=None):
+        """ Get Play History for all library Sections for the owner.
+            Parameters:
+                maxresults (int): Only return the specified number of results (optional).
+                mindate (datetime): Min datetime to return results from.
+        """
         hist = []
         for section in self.sections():
-            hist.extend(section.history())
+            hist.extend(section.history(maxresults=maxresults, mindate=mindate))
         return hist
 
 
@@ -640,9 +644,13 @@ class LibrarySection(PlexObject):
 
         return myplex.sync(client=client, clientId=clientId, sync_item=sync_item)
 
-    def history(self):
-        """ Get Play History for this library Section for the owner. """
-        return self._server.history(librarySectionID=self.key, accountID=1)
+    def history(self, maxresults=9999999, mindate=None):
+        """ Get Play History for this library Section for the owner.
+            Parameters:
+                maxresults (int): Only return the specified number of results (optional).
+                mindate (datetime): Min datetime to return results from.
+        """
+        return self._server.history(maxresults=maxresults, mindate=mindate, librarySectionID=self.key, accountID=1)
 
 
 class MovieSection(LibrarySection):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -600,13 +600,17 @@ class MyPlexAccount(PlexObject):
             raise BadRequest('(%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
         return response.json()['token']
 
-    def history(self):
-        """ Get Play History for all library sections on all servers for the owner. """
+    def history(self, maxresults=9999999, mindate=None):
+        """ Get Play History for all library sections on all servers for the owner.
+            Parameters:
+                maxresults (int): Only return the specified number of results (optional).
+                mindate (datetime): Min datetime to return results from.
+        """
         servers = [x for x in self.resources() if x.provides == 'server' and x.owned]
         hist = []
         for server in servers:
             conn = server.connect()
-            hist.extend(conn.history(accountID=1))
+            hist.extend(conn.history(maxresults=maxresults, mindate=mindate, accountID=1))
         return hist
 
 
@@ -686,11 +690,15 @@ class MyPlexUser(PlexObject):
 
         raise NotFound('Unable to find server %s' % name)
 
-    def history(self):
-        """ Get all Play History for a user in all shared servers. """
+    def history(self, maxresults=9999999, mindate=None):
+        """ Get all Play History for a user in all shared servers.
+            Parameters:
+                maxresults (int): Only return the specified number of results (optional).
+                mindate (datetime): Min datetime to return results from.
+        """
         hist = []
         for server in self.servers:
-            hist.extend(server.history())
+            hist.extend(server.history(maxresults=maxresults, mindate=mindate))
         return hist
 
 
@@ -719,10 +727,15 @@ class Section(PlexObject):
         self.type = data.attrib.get('type')
         self.shared = utils.cast(bool, data.attrib.get('shared'))
 
-    def history(self):
-        """ Get all Play History for a user for this section in this shared server. """
+    def history(self, maxresults=9999999, mindate=None):
+        """ Get all Play History for a user for this section in this shared server.
+            Parameters:
+                maxresults (int): Only return the specified number of results (optional).
+                mindate (datetime): Min datetime to return results from.
+        """
         server = self._server._server.resource(self._server.name).connect()
-        return server.history(accountID=self._server.accountID, librarySectionID=self.sectionKey)
+        return server.history(maxresults=maxresults, mindate=mindate,
+                              accountID=self._server.accountID, librarySectionID=self.sectionKey)
 
 
 class MyPlexServerShare(PlexObject):
@@ -781,10 +794,14 @@ class MyPlexServerShare(PlexObject):
 
         return sections
 
-    def history(self):
-        """ Get all Play History for a user in this shared server. """
+    def history(self, maxresults=9999999, mindate=None):
+        """ Get all Play History for a user in this shared server.
+            Parameters:
+                maxresults (int): Only return the specified number of results (optional).
+                mindate (datetime): Min datetime to return results from.
+        """
         server = self._server.resource(self.name).connect()
-        return server.history(accountID=self.accountID)
+        return server.history(maxresults=maxresults, mindate=mindate, accountID=self.accountID)
 
 
 class MyPlexResource(PlexObject):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -600,6 +600,15 @@ class MyPlexAccount(PlexObject):
             raise BadRequest('(%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
         return response.json()['token']
 
+    def history(self):
+        """ Get Play History for all library sections on all servers for the owner. """
+        servers = [x for x in self.resources() if x.provides == 'server' and x.owned]
+        hist = []
+        for server in servers:
+            conn = server.connect()
+            hist.extend(conn.history(accountID=1))
+        return hist
+
 
 class MyPlexUser(PlexObject):
     """ This object represents non-signed in users such as friends and linked
@@ -654,6 +663,8 @@ class MyPlexUser(PlexObject):
         self.title = data.attrib.get('title', '')
         self.username = data.attrib.get('username', '')
         self.servers = self.findItems(data, MyPlexServerShare)
+        for server in self.servers:
+            server.accountID = self.id
 
     def get_token(self, machineIdentifier):
         try:
@@ -662,6 +673,25 @@ class MyPlexUser(PlexObject):
                     return item.attrib.get('accessToken')
         except Exception:
             log.exception('Failed to get access token for %s' % self.title)
+
+    def server(self, name):
+        """ Returns the :class:`~plexapi.myplex.MyPlexServerShare` that matches the name specified.
+
+            Parameters:
+                name (str): Name of the server to return.
+        """
+        for server in self.servers:
+            if name.lower() == server.name.lower():
+                return server
+
+        raise NotFound('Unable to find server %s' % name)
+
+    def history(self):
+        """ Get all Play History for a user in all shared servers. """
+        hist = []
+        for server in self.servers:
+            hist.extend(server.history())
+        return hist
 
 
 class Section(PlexObject):
@@ -689,6 +719,11 @@ class Section(PlexObject):
         self.type = data.attrib.get('type')
         self.shared = utils.cast(bool, data.attrib.get('shared'))
 
+    def history(self):
+        """ Get all Play History for a user for this section in this shared server. """
+        server = self._server._server.resource(self._server.name).connect()
+        return server.history(accountID=self._server.accountID, librarySectionID=self.sectionKey)
+
 
 class MyPlexServerShare(PlexObject):
     """ Represents a single user's server reference. Used for library sharing.
@@ -711,6 +746,7 @@ class MyPlexServerShare(PlexObject):
         """ Load attribute values from Plex XML response. """
         self._data = data
         self.id = utils.cast(int, data.attrib.get('id'))
+        self.accountID = utils.cast(int, data.attrib.get('accountID'))
         self.serverId = utils.cast(int, data.attrib.get('serverId'))
         self.machineIdentifier = data.attrib.get('machineIdentifier')
         self.name = data.attrib.get('name')
@@ -720,7 +756,21 @@ class MyPlexServerShare(PlexObject):
         self.owned = utils.cast(bool, data.attrib.get('owned'))
         self.pending = utils.cast(bool, data.attrib.get('pending'))
 
+    def section(self, name):
+        """ Returns the :class:`~plexapi.myplex.Section` that matches the name specified.
+
+            Parameters:
+                name (str): Name of the section to return.
+        """
+        for section in self.sections():
+            if name.lower() == section.title.lower():
+                return section
+
+        raise NotFound('Unable to find section %s' % name)
+
     def sections(self):
+        """ Returns a list of all :class:`~plexapi.myplex.Section` objects shared with this user.
+        """
         url = MyPlexAccount.FRIENDSERVERS.format(machineId=self.machineIdentifier, serverId=self.id)
         data = self._server.query(url)
         sections = []
@@ -730,6 +780,11 @@ class MyPlexServerShare(PlexObject):
                 sections.append(Section(self, section, url))
 
         return sections
+
+    def history(self):
+        """ Get all Play History for a user in this shared server. """
+        server = self._server.resource(self.name).connect()
+        return server.history(accountID=self.accountID)
 
 
 class MyPlexResource(PlexObject):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -322,7 +322,7 @@ class PlexServer(PlexObject):
             # figure out what method this is..
             return self.query(part, method=self._session.put)
 
-    def history(self, maxresults=9999999, mindate=None):
+    def history(self, maxresults=9999999, mindate=None, ratingKey=None):
         """ Returns a list of media items from watched history. If there are many results, they will
             be fetched from the server in batches of X_PLEX_CONTAINER_SIZE amounts. If you're only
             looking for the first <num> results, it would be wise to set the maxresults option to that
@@ -335,6 +335,8 @@ class PlexServer(PlexObject):
         """
         results, subresults = [], '_init'
         args = {'sort': 'viewedAt:desc'}
+        if ratingKey:
+            args['metadataItemID'] = ratingKey
         if mindate:
             args['viewedAt>'] = int(mindate.timestamp())
         args['X-Plex-Container-Start'] = 0

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -322,7 +322,7 @@ class PlexServer(PlexObject):
             # figure out what method this is..
             return self.query(part, method=self._session.put)
 
-    def history(self, maxresults=9999999, mindate=None, ratingKey=None):
+    def history(self, maxresults=9999999, mindate=None, ratingKey=None, accountID=None, librarySectionID=None):
         """ Returns a list of media items from watched history. If there are many results, they will
             be fetched from the server in batches of X_PLEX_CONTAINER_SIZE amounts. If you're only
             looking for the first <num> results, it would be wise to set the maxresults option to that
@@ -333,11 +333,17 @@ class PlexServer(PlexObject):
                 mindate (datetime): Min datetime to return results from. This really helps speed
                     up the result listing. For example: datetime.now() - timedelta(days=7)
                 ratingKey (int/str) Request history for a specific ratingKey item.
+                accountID (int/str) Request history for a specific account ID.
+                librarySectionID (int/str) Request history for a specific library section ID.
         """
         results, subresults = [], '_init'
         args = {'sort': 'viewedAt:desc'}
         if ratingKey:
             args['metadataItemID'] = ratingKey
+        if accountID:
+            args['accountID'] = accountID
+        if librarySectionID:
+            args['librarySectionID'] = librarySectionID
         if mindate:
             args['viewedAt>'] = int(mindate.timestamp())
         args['X-Plex-Container-Start'] = 0

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -332,6 +332,7 @@ class PlexServer(PlexObject):
                 maxresults (int): Only return the specified number of results (optional).
                 mindate (datetime): Min datetime to return results from. This really helps speed
                     up the result listing. For example: datetime.now() - timedelta(days=7)
+                ratingKey (int/str) Request history for a specific ratingKey item.
         """
         results, subresults = [], '_init'
         args = {'sort': 'viewedAt:desc'}

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -32,6 +32,13 @@ def test_audio_Artist_get(artist, music):
     artist.title == 'Infinite State'
 
 
+def test_audio_Artist_history(artist):
+    artist.markWatched()
+    history = artist.history()
+    assert len(history)
+    artist.markUnwatched()
+
+
 def test_audio_Artist_track(artist):
     track = artist.track('Holy Moment')
     assert track.title == 'Holy Moment'
@@ -78,6 +85,20 @@ def test_audio_Album_attrs(album):
     assert utils.is_int(album.viewCount, gte=0)
     assert album.year == 2016
     assert album.artUrl is None
+
+
+def test_audio_Album_history(album):
+    album.markWatched()
+    history = album.history()
+    assert len(history)
+    album.markUnwatched()
+
+
+def test_audio_Track_history(track):
+    track.markWatched()
+    history = track.history()
+    assert len(history)
+    track.markUnwatched()
 
 
 def test_audio_Album_tracks(album):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -33,10 +33,8 @@ def test_audio_Artist_get(artist, music):
 
 
 def test_audio_Artist_history(artist):
-    artist.markWatched()
     history = artist.history()
     assert len(history)
-    artist.markUnwatched()
 
 
 def test_audio_Artist_track(artist):
@@ -88,17 +86,13 @@ def test_audio_Album_attrs(album):
 
 
 def test_audio_Album_history(album):
-    album.markWatched()
     history = album.history()
     assert len(history)
-    album.markUnwatched()
 
 
 def test_audio_Track_history(track):
-    track.markWatched()
     history = track.history()
     assert len(history)
-    track.markUnwatched()
 
 
 def test_audio_Album_tracks(album):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import pytest
+from datetime import datetime
+from plexapi.exceptions import BadRequest, NotFound
+from . import conftest as utils
+
+
+def test_history_Movie(movie):
+    movie.markWatched()
+    history = movie.history()
+    assert len(history)
+    movie.markUnwatched()
+
+
+def test_history_Show(show):
+    show.markWatched()
+    history = show.history()
+    assert len(history)
+    show.markUnwatched()
+
+
+def test_history_Season(show):
+    season = show.season('Season 1')
+    season.markWatched()
+    history = season.history()
+    assert len(history)
+    season.markUnwatched()
+
+
+def test_history_Episode(episode):
+    episode.markWatched()
+    history = episode.history()
+    assert len(history)
+    episode.markUnwatched()
+
+
+def test_history_Artist(artist):
+    history = artist.history()
+
+
+def test_history_Album(album):
+    history = album.history()
+
+
+def test_history_Track(track):
+    history = track.history()
+
+
+def test_history_MyAccount(account, movie, show):
+    movie.markWatched()
+    show.markWatched()
+    history = account.history()
+    assert len(history)
+    movie.markUnwatched()
+    show.markUnwatched()
+
+
+def test_history_MyLibrary(plex, movie, show):
+    movie.markWatched()
+    show.markWatched()
+    history = plex.library.history()
+    assert len(history)
+    movie.markUnwatched()
+    show.markUnwatched()
+
+
+def test_history_MySection(plex, movie):
+    movie.markWatched()
+    history = plex.library.section('Movies').history()
+    assert len(history)
+    movie.markUnwatched()
+
+
+def test_history_MyServer(plex, movie):
+    movie.markWatched()
+    history = plex.history()
+    assert len(history)
+    movie.markUnwatched()
+
+
+def test_history_User(account, shared_username):
+    user = account.user(shared_username)
+    history = user.history()
+
+
+def test_history_UserServer(account, shared_username, plex):
+    userSharedServer = account.user(shared_username).server(plex.friendlyName)
+    history = userSharedServer.history()
+
+
+def test_history_UserSection(account, shared_username, plex):
+    userSharedServerSection = account.user(shared_username).server(plex.friendlyName).section('Movies')
+    history = userSharedServerSection.history()
+

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -272,6 +272,13 @@ def test_video_Movie_attrs(movies):
     assert stream2.type == 2
 
 
+def test_video_Movie_history(movie):
+    movie.markWatched()
+    history = movie.history()
+    assert len(history)
+    movie.markUnwatched()
+
+
 def test_video_Show(show):
     assert show.title == 'Game of Thrones'
 
@@ -336,6 +343,13 @@ def test_video_Show_attrs(show):
     assert utils.is_int(show.viewedLeafCount, gte=0)
     assert show.year == 2011
     assert show.url(None) is None
+
+
+def test_video_Show_history(show):
+    show.markWatched()
+    history = show.history()
+    assert len(history)
+    show.markUnwatched()
 
 
 def test_video_Show_watched(tvshows):
@@ -444,6 +458,13 @@ def test_video_Episode(show):
         show.episode(season=1337, episode=1337)
 
 
+def test_video_Episode_history(episode):
+    episode.markWatched()
+    history = episode.history()
+    assert len(history)
+    episode.markUnwatched()
+
+
 # Analyze seems to fail intermittently
 @pytest.mark.xfail
 def test_video_Episode_analyze(tvshows):
@@ -518,6 +539,14 @@ def test_video_Season(show):
     assert len(seasons) == 2
     assert ['Season 1', 'Season 2'] == [s.title for s in seasons[:2]]
     assert show.season('Season 1') == seasons[0]
+
+
+def test_video_Season_history(show):
+    season = show.season('Season 1')
+    season.markWatched()
+    history = season.history()
+    assert len(history)
+    season.markUnwatched()
 
 
 def test_video_Season_attrs(show):


### PR DESCRIPTION
This change adds history selection for specific ratingKeys, much like the Plex "View Play History".
History can be requested from a movie, show, season, episode, artist, album, or track.

- Add history method to PlexPartialObject
- Add ratingKey arg to server history method.
- Add tests for movie, show, season, episode, artist, album, and track history.

I added tests. However, I have not actually run them. I had a separate test against my own server. Hopefully I created these tests correctly.