### PR TITLE
Speed up Library Section Get

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -374,7 +374,7 @@ class LibrarySection(PlexObject):
             Parameters:
                 title (str): Title of the item to return.
         """
-        key = '/library/sections/%s/all' % self.key
+        key = '/library/sections/%s/all?title=%s' % (self.key, title)
         return self.fetchItem(key, title__iexact=title)
 
     def all(self, sort=None, **kwargs):


### PR DESCRIPTION
The original code pulled a full list of all library items on a library.section.get(title) and then searched that list.
With this change, the library get uses the title as a search filter such that the returned list is much shorter.
My tests show a significant performance improvement.