### PR TITLE
Fix for starting playback on Chrome and Plex for windows

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -465,6 +465,13 @@ class PlexClient(PlexObject):
         server_url = media._server._baseurl.split(':')
         server_port = server_url[-1].strip('/')
 
+        if hasattr(media, "playlistType"):
+            mediatype = media.playlistType
+        elif media.listType == "audio":
+            mediatype = "music"
+        else:
+            mediatype = "video"
+
         if self.product != 'OpenPHT':
             try:
                 self.sendCommand('timeline/subscribe', port=server_port, protocol='http')
@@ -482,6 +489,7 @@ class PlexClient(PlexObject):
             'offset': offset,
             'key': media.key,
             'token': media._server._token,
+            'type': mediatype,
             'containerKey': '/playQueues/%s?window=100&own=1' % playqueue.playQueueID,
         }, **params))
 

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -490,7 +490,7 @@ class PlexClient(PlexObject):
             'port': server_port,
             'offset': offset,
             'key': media.key,
-            'token': media._server._token,
+            'token': media._server.createToken(),
             'type': mediatype,
             'containerKey': '/playQueues/%s?window=100&own=1' % playqueue.playQueueID,
         }, **params))

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -300,6 +300,8 @@ class PlexClient(PlexObject):
             'address': server_url[1].strip('/'),
             'port': server_url[-1],
             'key': media.key,
+            'protocol': server_url[0],
+            'token': media._server.createToken()
         }, **params))
 
     # -------------------


### PR DESCRIPTION
The simplest way to figure out the correct params is to use dev tools and check the network tab for player/proxy/poll and look at the xml response. queryXXX is part of the queryparams in the url and the others seems to be the X-PLEX headers