### PR TITLE
Update websockets client

### DIFF
--- a/plexapi/alert.py
+++ b/plexapi/alert.py
@@ -6,9 +6,9 @@ from plexapi import log
 
 
 class AlertListener(threading.Thread):
-    """ Creates a websocket connection to the PlexServer to optionally recieve alert notifications.
+    """ Creates a websocket connection to the PlexServer to optionally receive alert notifications.
         These often include messages from Plex about media scans as well as updates to currently running
-        Transcode Sessions. This class implements threading.Thread, therfore to start monitoring
+        Transcode Sessions. This class implements threading.Thread, therefore to start monitoring
         alerts you must call .start() on the object once it's created. When calling
         `PlexServer.startAlertListener()`, the thread will be started for you.
 
@@ -26,9 +26,9 @@ class AlertListener(threading.Thread):
 
         Parameters:
             server (:class:`~plexapi.server.PlexServer`): PlexServer this listener is connected to.
-            callback (func): Callback function to call on recieved messages. The callback function
+            callback (func): Callback function to call on received messages. The callback function
                 will be sent a single argument 'data' which will contain a dictionary of data
-                recieved from the server. :samp:`def my_callback(data): ...`
+                received from the server. :samp:`def my_callback(data): ...`
     """
     key = '/:/websockets/notifications'
 
@@ -48,7 +48,7 @@ class AlertListener(threading.Thread):
         self._ws.run_forever()
 
     def stop(self):
-        """ Stop the AlertListener thread. Once the notifier is stopped, it cannot be diractly
+        """ Stop the AlertListener thread. Once the notifier is stopped, it cannot be directly
             started again. You must call :func:`plexapi.server.PlexServer.startAlertListener()`
             from a PlexServer instance.
         """
@@ -56,7 +56,7 @@ class AlertListener(threading.Thread):
         self._ws.close()
 
     def _onMessage(self, *args):
-        """ Called when websocket message is recieved.
+        """ Called when websocket message is received.
             In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp object
             and the message as a STR. Current releases appear to only return the message.
             We are assuming the last argument in the tuple is the message.
@@ -72,7 +72,7 @@ class AlertListener(threading.Thread):
             log.error('AlertListener Msg Error: %s', err)
 
     def _onError(self, *args):  # pragma: no cover
-        """ Called when websocket error is recieved.
+        """ Called when websocket error is received.
             In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp object
             and the error. Current releases appear to only return the error.
             We are assuming the last argument in the tuple is the message. 

--- a/plexapi/alert.py
+++ b/plexapi/alert.py
@@ -56,8 +56,13 @@ class AlertListener(threading.Thread):
         self._ws.close()
 
     def _onMessage(self, *args):
+        """ Called when websocket message is recieved.
+            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp object
+            and the message as a STR. Current releases appear to only return the message.
+            We are assuming the last argument in the tuple is the message.
+            This is to support compatibility with current and previous releases of websocket-client. 
+        """
         message = args[-1]
-        """ Called when websocket message is recieved. """
         try:
             data = json.loads(message)['NotificationContainer']
             log.debug('Alert: %s %s %s', *data)
@@ -67,6 +72,11 @@ class AlertListener(threading.Thread):
             log.error('AlertListener Msg Error: %s', err)
 
     def _onError(self, *args):  # pragma: no cover
+        """ Called when websocket error is recieved.
+            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp object
+            and the error. Current releases appear to only return the error.
+            We are assuming the last argument in the tuple is the message. 
+            This is to support compatibility with current and previous releases of websocket-client. 
+        """
         err = args[-1]
-        """ Called when websocket error is recieved. """
         log.error('AlertListener Error: %s' % err)

--- a/plexapi/alert.py
+++ b/plexapi/alert.py
@@ -55,7 +55,8 @@ class AlertListener(threading.Thread):
         log.info('Stopping AlertListener.')
         self._ws.close()
 
-    def _onMessage(self, ws, message):
+    def _onMessage(self, *args):
+        message = args[-1]
         """ Called when websocket message is recieved. """
         try:
             data = json.loads(message)['NotificationContainer']
@@ -65,6 +66,7 @@ class AlertListener(threading.Thread):
         except Exception as err:  # pragma: no cover
             log.error('AlertListener Msg Error: %s', err)
 
-    def _onError(self, ws, err):  # pragma: no cover
+    def _onError(self, *args):  # pragma: no cover
+        err = args[-1]
         """ Called when websocket error is recieved. """
         log.error('AlertListener Error: %s' % err)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 #---------------------------------------------------------
 requests
 tqdm
-websocket-client==0.48.0
+websocket-client

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ requests
 sphinx
 sphinxcontrib-napoleon
 tqdm
-websocket-client==0.48.0
+websocket-client
 
 # Installing sphinx-rtd-theme directly from github above is used until a point release
 # above 0.4.3 is released. https://github.com/readthedocs/sphinx_rtd_theme/issues/739


### PR DESCRIPTION
Looks like websockets-client returns 2 args in 0.48.0 while in the latest release, it only returns 1 arg.
So I used *args to handle the difference in releases and assume that the last arg is the message.

This should resolve issue #401 