### PR TITLE
Add support for MyPlex PIN login

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
+import threading
 import time
 
 import requests
@@ -1050,6 +1051,186 @@ class MyPlexDevice(PlexObject):
             raise BadRequest('Requested syncList for device which do not provides sync-target')
 
         return self._server.syncItems(client=self)
+
+
+class MyPlexPinLogin(object):
+    """
+        MyPlex PIN login class which supports getting the four character PIN which the user must
+        enter on https://plex.tv/link to authenticate the client and provide an access token to
+        create a :class:`~plexapi.myplex.MyPlexAccount` instance.
+        This helper class supports a polling, threaded and callback approach.
+
+        - The polling approach expects the developer to periodically check if the PIN login was
+          successful using :func:`plexapi.myplex.MyPlexPinLogin.checkLogin`.
+        - The threaded approach expects the developer to call
+          :func:`plexapi.myplex.MyPlexPinLogin.run` and then at a later time call
+          :func:`plexapi.myplex.MyPlexPinLogin.waitForLogin` to wait for and check the result.
+        - The callback approach is an extension of the threaded approach and expects the developer
+          to pass the `callback` parameter to the call to :func:`plexapi.myplex.MyPlexPinLogin.run`.
+          The callback will be called when the thread waiting for the PIN login to succeed either
+          finishes or expires. The parameter passed to the callback is the received authentication
+          token or `None` if the login expired.
+
+        Parameters:
+            session (requests.Session, optional): Use your own session object if you want to
+                cache the http responses from PMS
+            requestTimeout (int): timeout in seconds on initial connect to plex.tv (default config.TIMEOUT).
+
+        Attributes:
+            PINS (str): 'https://plex.tv/pins.xml'
+            CHECKPINS (str): 'https://plex.tv/pins/{pinid}.xml'
+            POLLINTERVAL (int): 1
+            finished (bool): Whether the pin login has finished or not.
+            expired (bool): Whether the pin login has expired or not.
+            token (str): Token retrieved through the pin login.
+            pin (str): Pin to use for the login on https://plex.tv/link.
+    """
+    PINS = 'https://plex.tv/pins.xml'               # get
+    CHECKPINS = 'https://plex.tv/pins/{pinid}.xml'  # get
+    POLLINTERVAL = 1
+
+    def __init__(self, session=None, requestTimeout=None):
+        super(MyPlexPinLogin, self).__init__()
+        self._session = session or requests.Session()
+        self._requestTimeout = requestTimeout or TIMEOUT
+
+        self._loginTimeout = None
+        self._callback = None
+        self._thread = None
+        self._abort = False
+        self._id = None
+
+        self.finished = False
+        self.expired = False
+        self.token = None
+        self.pin = self._getPin()
+
+    def run(self, callback=None, timeout=None):
+        """ Starts the thread which monitors the PIN login state.
+            Parameters:
+                callback (Callable[str]): Callback called with the received authentication token (optional).
+                timeout (int): Timeout in seconds waiting for the PIN login to succeed (optional).
+
+            Raises:
+                :class:`RuntimeError`: if the thread is already running.
+                :class:`RuntimeError`: if the PIN login for the current PIN has expired.
+        """
+        if self._thread and not self._abort:
+            raise RuntimeError('MyPlexPinLogin thread is already running')
+        if self.expired:
+            raise RuntimeError('MyPlexPinLogin has expired')
+
+        self._loginTimeout = timeout
+        self._callback = callback
+        self._abort = False
+        self.finished = False
+        self._thread = threading.Thread(target=self._pollLogin, name='plexapi.myplex.MyPlexPinLogin')
+        self._thread.start()
+
+    def waitForLogin(self):
+        """ Waits for the PIN login to succeed or expire.
+            Parameters:
+                callback (Callable[str]): Callback called with the received authentication token (optional).
+                timeout (int): Timeout in seconds waiting for the PIN login to succeed (optional).
+
+            Returns:
+                `True` if the PIN login succeeded or `False` otherwise.
+        """
+        if not self._thread or self._abort:
+            return False
+
+        self._thread.join()
+        if self.expired or not self.token:
+            return False
+
+        return True
+
+    def stop(self):
+        """ Stops the thread monitoring the PIN login state. """
+        if not self._thread or self._abort:
+            return
+
+        self._abort = True
+        self._thread.join()
+
+    def checkLogin(self):
+        """ Returns `True` if the PIN login has succeeded. """
+        if self._thread:
+            return False
+
+        try:
+            return self._checkLogin()
+        except Exception:
+            self.expired = True
+            self.finished = True
+
+        return False
+
+    def _getPin(self):
+        if self.pin:
+            return self.pin
+
+        url = self.PINS
+        response = self._query(url, self._session.post)
+        if not response:
+            return None
+
+        self._id = response.find('id').text
+        self.pin = response.find('code').text
+
+        return self.pin
+
+    def _checkLogin(self):
+        if not self._id:
+            return False
+
+        if self.token:
+            return True
+
+        url = self.CHECKPINS.format(pinid=self._id)
+        response = self._query(url)
+        if not response:
+            return False
+
+        token = response.find('auth_token').text
+        if not token:
+            return False
+
+        self.token = token
+        self.finished = True
+        return True
+
+    def _pollLogin(self):
+        try:
+            start = time.time()
+            while not self._abort and (not self._loginTimeout or (time.time() - start) < self._loginTimeout):
+                try:
+                    result = self._checkLogin()
+                except Exception:
+                    self.expired = True
+                    break
+
+                if result:
+                    break
+
+                time.sleep(self.POLLINTERVAL)
+
+            if self.token and self._callback:
+                self._callback(self.token)
+        finally:
+            self.finished = True
+
+    def _query(self, url, method=None):
+        method = method or self._session.get
+        log.debug('%s %s', method.__name__.upper(), url)
+        headers = BASE_HEADERS.copy()
+        response = method(url, headers=headers, timeout=self._requestTimeout)
+        if not response.ok:  # pragma: no cover
+            codename = codes.get(response.status_code)[0]
+            errtext = response.text.replace('\n', ' ')
+            raise BadRequest('(%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
+        data = response.text.encode('utf8')
+        return ElementTree.fromstring(data) if data.strip() else None
 
 
 def _connect(cls, url, token, timeout, results, i, job_is_done_event=None):


### PR DESCRIPTION
I've added a class `myplex.MyPlexPinLogin` which supports PIN login using https://plex.tv/link which is mostly useful on clients using a 10-ft interface.

When creating a new instance of `myplex.MyPlexPinLogin` it asks Plex for a PIN and then it checks whether an authenticated user has entered the PIN. If that is the case it returns an access token which can be used to create a `myplex.MyPlexAccount` instance.

There are three modes:
* The **polling** approach expects the developer to periodically check if the PIN login was successful using `myplex.MyPlexPinLogin.checkLogin()`.
* The **threaded** approach expects the developer to call `myplex.MyPlexPinLogin.run()` and then at a later time call `myplex.MyPlexPinLogin.waitForLogin()` to wait for and check the result.
* The **callback** approach is an extension of the threaded approach and expects the developer to pass the `callback` parameter to the call to `myplex.MyPlexPinLogin.run`. The callback will be called when the thread waiting for the PIN login to succeed either finishes or expires. The parameter passed to the callback is the received authentication token or `None` if the login expired.

**DISCLAIMER**: I'm not a very experienced Python developer. I tried to follow the code style in `plexapi.myplex` but I'm sure I got some things wrong (especially in the docstrings).