### PR TITLE
Lookup episode/season show() with RatingKeys

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -505,7 +505,7 @@ class Season(Video):
 
     def show(self):
         """ Return this seasons :func:`~plexapi.video.Show`.. """
-        return self.fetchItem(self.parentKey)
+        return self.fetchItem(int(self.parentRatingKey))
 
     def watched(self):
         """ Returns list of watched :class:`~plexapi.video.Episode` objects. """
@@ -646,7 +646,7 @@ class Episode(Playable, Video):
 
     def show(self):
         """" Return this episodes :func:`~plexapi.video.Show`.. """
-        return self.fetchItem(self.grandparentKey)
+        return self.fetchItem(int(self.grandparentRatingKey))
 
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """


### PR DESCRIPTION
Sometimes the `parentKey` or `grandparentKey` are not available without a refresh. This simplifies the `show()` lookup for both `Episode` and `Season` types.

Partial fix to #429.