### PR TITLE
poster_change

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -445,6 +445,7 @@ class PlexPartialObject(PlexObject):
             self._server.query(key, method=self._server._session.post, data=data)
 
     def setPoster(self, poster):
+        """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
         key = poster._initpath[:-1]
         data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
         self._server.query(data, method=self._server._session.put)

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -429,6 +429,26 @@ class PlexPartialObject(PlexObject):
         """
         return self._server.history(maxresults=maxresults, mindate=mindate, ratingKey=self.ratingKey)
 
+    def posters(self):
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('%s/posters' % self.key)
+
+    def uploadPoster(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '%s/posters?url=%s' % (self.key, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '%s/posters?' % self.key
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setPoster(self, poster):
+        key = poster._initpath[:-1]
+        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
+        self._server.query(data, method=self._server._session.put)
+
     # The photo tag cant be built atm. TODO
     # def arts(self):
     #     part = '%s/arts' % self.key

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -448,6 +448,25 @@ class PlexPartialObject(PlexObject):
         """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
         poster.select()
 
+    def arts(self):
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('%s/arts' % self.key)
+
+    def uploadArt(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/arts?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/arts?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setArt(self, art):
+        """ Set :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        art.select()
+
     # The photo tag cant be built atm. TODO
     # def arts(self):
     #     part = '%s/arts' % self.key

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -446,9 +446,7 @@ class PlexPartialObject(PlexObject):
 
     def setPoster(self, poster):
         """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
-        key = poster._initpath[:-1]
-        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
-        self._server.query(data, method=self._server._session.put)
+        poster.select()
 
     # The photo tag cant be built atm. TODO
     # def arts(self):

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -449,12 +449,12 @@ class PlexPartialObject(PlexObject):
         poster.select()
 
     def arts(self):
-        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+        """ Returns list of available art objects. :class:`~plexapi.media.Poster`. """
 
         return self.fetchItems('%s/arts' % self.key)
 
     def uploadArt(self, url=None, filepath=None):
-        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        """ Upload art from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
         if url:
             key = '/library/metadata/%s/arts?url=%s' % (self.ratingKey, quote_plus(url))
             self._server.query(key, method=self._server._session.post)

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1073,7 +1073,7 @@ class Collections(PlexObject):
     def posters(self):
         """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
 
-        return self.fetchItems('%s/posters' % self.key)
+        return self.fetchItems('/library/metadata/%s/posters' % self.ratingKey)
 
     def uploadPoster(self, url=None, filepath=None):
         """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1081,7 +1081,7 @@ class Collections(PlexObject):
             key = '/library/metadata/%s/posters?url=%s' % (self.ratingKey, quote_plus(url))
             self._server.query(key, method=self._server._session.post)
         elif filepath:
-            key = '%s/posters?' % self.key
+            key = '/library/metadata/%s/posters?' % self.ratingKey
             data = open(filepath, 'rb').read()
             self._server.query(key, method=self._server._session.post, data=data)
 

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1089,5 +1089,24 @@ class Collections(PlexObject):
         """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
         poster.select()
 
+    def arts(self):
+        """ Returns list of available art objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('/library/metadata/%s/arts' % self.ratingKey)
+
+    def uploadArt(self, url=None, filepath=None):
+        """ Upload art from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/arts?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/arts?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setArt(self, art):
+        """ Set :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        art.select()
+
     # def edit(self, **kwargs):
     #    TODO

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1070,5 +1070,26 @@ class Collections(PlexObject):
         part = '/library/metadata/%s/prefs?collectionSort=%s' % (self.ratingKey, key)
         return self._server.query(part, method=self._server._session.put)
 
+    def posters(self):
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('%s/posters' % self.key)
+
+    def uploadPoster(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/posters?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '%s/posters?' % self.key
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setPoster(self, poster):
+        """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        key = poster._initpath[:-1]
+        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
+        self._server.query(data, method=self._server._session.put)
+
     # def edit(self, **kwargs):
     #    TODO

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1087,9 +1087,7 @@ class Collections(PlexObject):
 
     def setPoster(self, poster):
         """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
-        key = poster._initpath[:-1]
-        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
-        self._server.query(data, method=self._server._session.put)
+        poster.select()
 
     # def edit(self, **kwargs):
     #    TODO

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -557,6 +557,11 @@ class Poster(PlexObject):
         self.selected = data.attrib.get('selected')
         self.thumb = data.attrib.get('thumb')
 
+    def select(self):
+        key = self._initpath[:-1]
+        data = '%s?url=%s' % (key, compat.quote_plus(self.ratingKey))
+        self._server.query(data, method=self._server._session.put)
+
 
 @utils.registerPlexObject
 class Producer(MediaTag):

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from plexapi import log, utils
+from plexapi import log, utils, compat
 from plexapi.base import PlexObject
 from plexapi.exceptions import BadRequest
 from plexapi.utils import cast

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -286,6 +286,4 @@ class Playlist(PlexPartialObject, Playable):
 
     def setPoster(self, poster):
         """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
-        key = poster._initpath[:-1]
-        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
-        self._server.query(data, method=self._server._session.put)
+        poster.select()

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -268,3 +268,24 @@ class Playlist(PlexPartialObject, Playable):
             raise Unsupported('Unsupported playlist content')
 
         return myplex.sync(sync_item, client=client, clientId=clientId)
+
+    def posters(self):
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('/library/metadata/%s/posters' % self.ratingKey)
+
+    def uploadPoster(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/posters?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/posters?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setPoster(self, poster):
+        """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        key = poster._initpath[:-1]
+        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
+        self._server.query(data, method=self._server._session.put)

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -287,3 +287,22 @@ class Playlist(PlexPartialObject, Playable):
     def setPoster(self, poster):
         """ Set . :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
         poster.select()
+
+    def arts(self):
+        """ Returns list of available art objects. :class:`~plexapi.media.Poster`. """
+
+        return self.fetchItems('/library/metadata/%s/arts' % self.ratingKey)
+
+    def uploadArt(self, url=None, filepath=None):
+        """ Upload art from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '/library/metadata/%s/arts?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/arts?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setArt(self, art):
+        """ Set :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video` """
+        art.select()

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -401,7 +401,7 @@ class PlexServer(PlexObject):
             log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
             raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
         data = response.text.encode('utf8')
-        return ElementTree.fromstring(data) if data.strip() else None
+        return ElementTree.fromstring(data) if data.strip() and response.encoding else None
 
     def search(self, query, mediatype=None, limit=None):
         """ Returns a list of media items or filter categories from the resulting

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -401,7 +401,7 @@ class PlexServer(PlexObject):
             log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
             raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
         data = response.text.encode('utf8')
-        return ElementTree.fromstring(data) if data.strip() and response.encoding else None
+        return ElementTree.fromstring(data) if data.strip() else None
 
     def search(self, query, mediatype=None, limit=None):
         """ Returns a list of media items or filter categories from the resulting

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -121,26 +121,6 @@ class Video(PlexPartialObject):
             if streamID == stream.id or streamTitle == stream.title:
                 self._server.query(stream.key, self._server._session.delete)
 
-    def posters(self):
-        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
-
-        return self.fetchItems('%s/posters' % self.key, cls=media.Poster)
-
-    def uploadPoster(self, url=None, filepath=None):
-        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
-        if url:
-            key = '%s/posters?url=%s' % (self.key, quote_plus(url))
-            self._server.query(key, method=self._server._session.post)
-        elif filepath:
-            key = '%s/posters?' % self.key
-            data = open(filepath,'rb').read()
-            self._server.query(key, method=self._server._session.post, data=data)
-
-    def setPoster(self, poster):
-        key = poster._initpath[:-1]
-        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
-        self._server.query(data, method=self._server._session.put)
-
     def sync(self, videoQuality, client=None, clientId=None, limit=None, unwatched=False, title=None):
         """ Add current video (movie, tv-show, season or episode) as sync item for specified device.
             See :func:`plexapi.myplex.MyPlexAccount.sync()` for possible exceptions.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -136,6 +136,10 @@ class Video(PlexPartialObject):
             data = open(filepath,'rb').read()
             self._server.query(key, method=self._server._session.post, data=data)
 
+    def setPoster(self, poster):
+        key = poster._initpath[:-1]
+        data = '%s?url=%s' % (key, quote_plus(poster.ratingKey))
+        self._server.query(data, method=self._server._session.put)
 
     def sync(self, videoQuality, client=None, clientId=None, limit=None, unwatched=False, title=None):
         """ Add current video (movie, tv-show, season or episode) as sync item for specified device.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -126,6 +126,17 @@ class Video(PlexPartialObject):
 
         return self.fetchItems('%s/posters' % self.key, cls=media.Poster)
 
+    def uploadPoster(self, url=None, filepath=None):
+        """ Upload poster from url or filepath. :class:`~plexapi.media.Poster` to :class:`~plexapi.video.Video`. """
+        if url:
+            key = '%s/posters?url=%s' % (self.key, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '%s/posters?' % self.key
+            data = open(filepath,'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+
     def sync(self, videoQuality, client=None, clientId=None, limit=None, unwatched=False, title=None):
         """ Add current video (movie, tv-show, season or episode) as sync item for specified device.
             See :func:`plexapi.myplex.MyPlexAccount.sync()` for possible exceptions.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -122,7 +122,7 @@ class Video(PlexPartialObject):
                 self._server.query(stream.key, self._server._session.delete)
 
     def posters(self):
-        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`:"""
+        """ Returns list of available poster objects. :class:`~plexapi.media.Poster`. """
 
         return self.fetchItems('%s/posters' % self.key, cls=media.Poster)
 


### PR DESCRIPTION
Allow for selecting a poster from the available list of posters. Allow for uploading posters from url or filepath.
From issue #179
Poster selection currently causes a parser error
```
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 1, column 0
```
but the poster will still be selected.