### PR TITLE
Fix playMedia() calls with a PlayQueue

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -472,10 +472,12 @@ class PlexClient(PlexObject):
 
         if hasattr(media, "playlistType"):
             mediatype = media.playlistType
-        elif media.listType == "audio":
-            mediatype = "music"
         else:
-            mediatype = "video"
+            if isinstance(media, PlayQueue):
+                listType = media.items[0].listType
+            else:
+                listType = media.listType
+            mediatype = "music" if listType == "audio" else "video"
 
         if self.product != 'OpenPHT':
             try:

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -474,10 +474,13 @@ class PlexClient(PlexObject):
             mediatype = media.playlistType
         else:
             if isinstance(media, PlayQueue):
-                listType = media.items[0].listType
+                mediatype = media.items[0].listType
             else:
-                listType = media.listType
-            mediatype = "music" if listType == "audio" else "video"
+                mediatype = media.listType
+
+        # mediatype must be in ["video", "music", "photo"]
+        if mediatype == "audio":
+            mediatype = "music"
 
         if self.product != 'OpenPHT':
             try:


### PR DESCRIPTION
I was getting exceptions when calling `PlexClient.playMedia()` with a `PlayQueue`:
```
  File "/usr/local/lib/python3.7/site-packages/plexapi/client.py", line 472, in playMedia
    elif media.listType == "audio":
AttributeError: 'PlayQueue' object has no attribute 'listType'
```
This gets the media type of the first item in the playqueue. Not perfect if someone has a playqueue mixed with music and video, but I don't see a better alternative.