### PR TITLE
Use Unauthorized exception

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -7,7 +7,7 @@ from plexapi import BASE_HEADERS, CONFIG, TIMEOUT
 from plexapi import log, logfilter, utils
 from plexapi.base import PlexObject
 from plexapi.compat import ElementTree
-from plexapi.exceptions import BadRequest, Unsupported
+from plexapi.exceptions import BadRequest, Unauthorized, Unsupported
 from plexapi.playqueue import PlayQueue
 
 
@@ -162,8 +162,11 @@ class PlexClient(PlexObject):
         if response.status_code not in (200, 201):
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
-            log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
-            raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
+            message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
+            if response.status_code == 401:
+                raise Unauthorized(message)
+            else:
+                raise BadRequest(message)
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
 

--- a/plexapi/exceptions.py
+++ b/plexapi/exceptions.py
@@ -26,6 +26,6 @@ class Unsupported(PlexApiException):
     pass
 
 
-class Unauthorized(PlexApiException):
-    """ Invalid username or password. """
+class Unauthorized(BadRequest):
+    """ Invalid username/password or token. """
     pass

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -6,7 +6,7 @@ from requests.status_codes import _codes as codes
 from plexapi import BASE_HEADERS, CONFIG, TIMEOUT, X_PLEX_IDENTIFIER, X_PLEX_ENABLE_FAST_CONNECT
 from plexapi import log, logfilter, utils
 from plexapi.base import PlexObject
-from plexapi.exceptions import BadRequest, NotFound
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.client import PlexClient
 from plexapi.compat import ElementTree
 from plexapi.library import LibrarySection
@@ -175,7 +175,11 @@ class MyPlexAccount(PlexObject):
         if response.status_code not in (200, 201, 204):  # pragma: no cover
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
-            raise BadRequest('(%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
+            message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
+            if response.status_code == 401:
+                raise Unauthorized(message)
+            else:
+                raise BadRequest(message)
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -7,7 +7,7 @@ from plexapi.alert import AlertListener
 from plexapi.base import PlexObject
 from plexapi.client import PlexClient
 from plexapi.compat import ElementTree, urlencode
-from plexapi.exceptions import BadRequest, NotFound
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.library import Library, Hub
 from plexapi.settings import Settings
 from plexapi.playlist import Playlist
@@ -399,7 +399,10 @@ class PlexServer(PlexObject):
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
             log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
-            raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
+            if response.status_code == 401:
+                raise Unauthorized('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
+            else:
+                raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -398,11 +398,11 @@ class PlexServer(PlexObject):
         if response.status_code not in (200, 201):
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
-            log.warning('BadRequest (%s) %s %s; %s' % (response.status_code, codename, response.url, errtext))
+            message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
             if response.status_code == 401:
-                raise Unauthorized('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
+                raise Unauthorized(message)
             else:
-                raise BadRequest('(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext))
+                raise BadRequest(message)
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
 


### PR DESCRIPTION
The `Unauthorized` exception was declared but never used. This will raise the exception when a 401 error is encountered.

The exception has been changed to inherit from `BadRequest` to preserve existing use cases that catch on `BadRequest`. Same with the error message in case there's existing reliance on parsing.