### PR TITLE
Raise NotFound on 404 errors

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -7,7 +7,7 @@ from plexapi import BASE_HEADERS, CONFIG, TIMEOUT
 from plexapi import log, logfilter, utils
 from plexapi.base import PlexObject
 from plexapi.compat import ElementTree
-from plexapi.exceptions import BadRequest, Unauthorized, Unsupported
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized, Unsupported
 from plexapi.playqueue import PlayQueue
 
 
@@ -165,6 +165,8 @@ class PlexClient(PlexObject):
             message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
             if response.status_code == 401:
                 raise Unauthorized(message)
+            elif response.status_code == 404:
+                raise NotFound(message)
             else:
                 raise BadRequest(message)
         data = response.text.encode('utf8')

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -185,6 +185,8 @@ class MyPlexAccount(PlexObject):
             message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
             if response.status_code == 401:
                 raise Unauthorized(message)
+            elif response.status_code == 404:
+                raise NotFound(message)
             else:
                 raise BadRequest(message)
         data = response.text.encode('utf8')

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -427,6 +427,8 @@ class PlexServer(PlexObject):
             message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)
             if response.status_code == 401:
                 raise Unauthorized(message)
+            elif response.status_code == 404:
+                raise NotFound(message)
             else:
                 raise BadRequest(message)
         data = response.text.encode('utf8')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -85,6 +85,11 @@ def _detect_color_image(file, thumb_size=150, MSE_cutoff=22, adjust_color_bias=T
         return 'blackandwhite'
 
 
+def test_server_fetchitem_notfound(plex):
+    with pytest.raises(NotFound):
+        plex.fetchItem(123456789)
+
+
 def test_server_search(plex, movie):
     title = movie.title
     assert plex.search(title)


### PR DESCRIPTION
Raise a more appropriate `NotFound` exception instead of a `BadRequest` when encountering a 404 error.