### PR TITLE
Fix docstrings for tests

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -476,13 +476,10 @@ class PlexPartialObject(PlexObject):
         key = '/library/metadata/%s/unmatch' % self.ratingKey
         self._server.query(key, method=self._server._session.put)
 
-    def matches(self, auto=False, agent=None, title=None, year=None, language=None):
-        """ Return list of (:class:`~plexapi.media.SearchResult) metadata matches.
+    def matches(self, agent=None, title=None, year=None, language=None):
+        """ Return list of (:class:`~plexapi.media.SearchResult`) metadata matches.
 
              Parameters:
-                 auto (bool): True searches for matches automatically
-                    False allows for user to provide additional parameters to search
-                    *Auto searching
                 agent (str): Agent name to be used (imdb, thetvdb, themoviedb, etc.)
                 title (str): Title of item to search for
                 year (str): Year of item to search in
@@ -538,8 +535,7 @@ class PlexPartialObject(PlexObject):
             Parameters:
                 auto (bool): True uses first match from matches
                     False allows user to provide the match
-                    *Auto matching
-                searchResult (:class:`~plexapi.media.SearchResult): Search result from
+                searchResult (:class:`~plexapi.media.SearchResult`): Search result from
                     ~plexapi.base.matches()
         """
         key = '/library/metadata/%s/match' % self.ratingKey

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -456,7 +456,7 @@ class Conversion(PlexObject):
                     Move 5th conversion Item to active conversion
                         conversions[4].move('-1')
 
-                    Move 4th conversion Item to 2nd in conversion queue
+                    Move 4th conversion Item to 3rd in conversion queue
                         conversions[3].move(conversions[1].playQueueItemID)
         """
 

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -450,10 +450,7 @@ class Conversion(PlexObject):
 
     def move(self, after):
         """ Move Conversion items position in queue
-            after (int): Positional integer to move item
-                    -1 Active conversion
-                OR
-                    Use another conversion items playQueueItemID to move in front of
+            after (int): Place item after specified playQueueItemID. '-1' is the active conversion.
 
                 Example:
                     Move 5th conversion Item to active conversion


### PR DESCRIPTION
Minor fixes to allow documentation generation to pass tests.

Found and removed an unused param in `PlexPartialObject.matches()`.