### PR TITLE
Fix client control on unclaimed servers

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -193,6 +193,9 @@ class PlexServer(PlexObject):
 
     def createToken(self, type='delegation', scope='all'):
         """Create a temp access token for the server."""
+        if not self._token:
+            # Handle unclaimed servers
+            return None
         q = self.query('/security/token?type=%s&scope=%s' % (type, scope))
         return q.attrib.get('token')
 


### PR DESCRIPTION
Some client commands unconditionally try to get a temporary token, which will fail on an unclaimed server. This allows certain client commands (e.g., `playMedia()`) to succeed.