### PR TITLE
Remove 'timeline/subscribe' calls

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -199,7 +199,7 @@ class PlexClient(PlexObject):
             self._last_call = t
         elif t - self._last_call >= 80 and self.product in ('ptp', 'Plex Media Player'):
             self._last_call = t
-            self.timeline()
+            self.timeline(wait=0)
 
         params['commandID'] = self._nextCommandId()
         key = '/player/%s%s' % (command, utils.joinArgs(params))
@@ -540,7 +540,7 @@ class PlexClient(PlexObject):
 
     # -------------------
     # Timeline Commands
-    def timeline(self, wait=0):
+    def timeline(self, wait=1):
         """ Poll the current timeline and return the XML response. """
         return self.sendCommand('timeline/poll', wait=wait)
 
@@ -551,7 +551,7 @@ class PlexClient(PlexObject):
                 includePaused (bool): Set True to treat currently paused items
                     as playing (optional; default True).
         """
-        for mediatype in self.timeline():
+        for mediatype in self.timeline(wait=0):
             if mediatype.get('state') == 'playing':
                 return True
             if includePaused and mediatype.get('state') == 'paused':


### PR DESCRIPTION
Documented [here](https://github.com/plexinc/plex-media-player/wiki/Remote-control-API#new-remote-control-commands) and briefly described in [this comment](https://github.com/pkkid/python-plexapi/issues/435#issuecomment-592058172), setting up subscriptions using `timeline/subscribe` will always "fail" as it's requesting the client to send callbacks to the requester on the provided port. We never create a listener to handle the async timeline updates so they always get rejected at the socket level.

The original workaround for `ptp` and `Plex Media Player` re-subscription intervals have been left intact.