### PR TITLE
Sonos lookup fixes and tests

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -225,10 +225,10 @@ class MyPlexAccount(PlexObject):
         return self._sonos_cache
 
     def sonos_speaker(self, name):
-        return [x for x in self.sonos_speakers() if x.title == name][0]
+        return next((x for x in self.sonos_speakers() if x.title.split("+")[0].strip() == name), None)
 
     def sonos_speaker_by_id(self, identifier):
-        return [x for x in self.sonos_speakers() if x.machineIdentifier == identifier][0]
+        return next((x for x in self.sonos_speakers() if x.machineIdentifier == identifier), None)
 
     def inviteFriend(self, user, server, sections=None, allowSync=False, allowCameraUpload=False,
                      allowChannels=False, filterMovies=None, filterTelevision=None, filterMusic=None):

--- a/tests/payloads.py
+++ b/tests/payloads.py
@@ -18,7 +18,7 @@ ACCOUNT_XML = """<?xml version="1.0" encoding="UTF-8"?>
 
 SONOS_RESOURCES = """<MediaContainer size="3">
   <Player title="Speaker 1" machineIdentifier="RINCON_12345678901234567:1234567891" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.11"/>
-  <Player title="Speaker 2" machineIdentifier="RINCON_12345678901234567:1234567892" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.12"/>
+  <Player title="Speaker 2 + 1" machineIdentifier="RINCON_12345678901234567:1234567892" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.12"/>
   <Player title="Speaker 3" machineIdentifier="RINCON_12345678901234567:1234567893" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.13"/>
 </MediaContainer>
 """

--- a/tests/test_sonos.py
+++ b/tests/test_sonos.py
@@ -8,8 +8,17 @@ def test_sonos_resources(mocked_account, requests_mock):
     speakers = mocked_account.sonos_speakers()
     assert len(speakers) == 3
 
+    # Finds individual speaker by name
     speaker1 = mocked_account.sonos_speaker("Speaker 1")
     assert speaker1.machineIdentifier == "RINCON_12345678901234567:1234567891"
 
+    # Finds speaker as part of group
+    speaker1 = mocked_account.sonos_speaker("Speaker 2")
+    assert speaker1.machineIdentifier == "RINCON_12345678901234567:1234567892"
+
+    # Finds speaker by identifier
     speaker3 = mocked_account.sonos_speaker_by_id("RINCON_12345678901234567:1234567893")
     assert speaker3.title == "Speaker 3"
+
+    assert mocked_account.sonos_speaker("Speaker X") is None
+    assert mocked_account.sonos_speaker_by_id("ID_DOES_NOT_EXIST") is None


### PR DESCRIPTION
The Sonos lookup methods would fail if you passed in a non-existent name or identifier. This will fix that and add tests to validate.