### PR TITLE
Improve Sonos ID lookup

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -228,7 +228,7 @@ class MyPlexAccount(PlexObject):
         return next((x for x in self.sonos_speakers() if x.title.split("+")[0].strip() == name), None)
 
     def sonos_speaker_by_id(self, identifier):
-        return next((x for x in self.sonos_speakers() if x.machineIdentifier == identifier), None)
+        return next((x for x in self.sonos_speakers() if x.machineIdentifier.startswith(identifier)), None)
 
     def inviteFriend(self, user, server, sections=None, allowSync=False, allowCameraUpload=False,
                      allowChannels=False, filterMovies=None, filterTelevision=None, filterMusic=None):

--- a/tests/payloads.py
+++ b/tests/payloads.py
@@ -17,8 +17,8 @@ ACCOUNT_XML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 SONOS_RESOURCES = """<MediaContainer size="3">
-  <Player title="Speaker 1" machineIdentifier="RINCON_12345678901234567:1234567891" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.11"/>
-  <Player title="Speaker 2 + 1" machineIdentifier="RINCON_12345678901234567:1234567892" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.12"/>
-  <Player title="Speaker 3" machineIdentifier="RINCON_12345678901234567:1234567893" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.13"/>
+  <Player title="Speaker 1" machineIdentifier="RINCON_12345678901234561:1234567891" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.11"/>
+  <Player title="Speaker 2 + 1" machineIdentifier="RINCON_12345678901234562:1234567892" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.12"/>
+  <Player title="Speaker 3" machineIdentifier="RINCON_12345678901234563:1234567893" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.13"/>
 </MediaContainer>
 """

--- a/tests/test_sonos.py
+++ b/tests/test_sonos.py
@@ -10,14 +10,18 @@ def test_sonos_resources(mocked_account, requests_mock):
 
     # Finds individual speaker by name
     speaker1 = mocked_account.sonos_speaker("Speaker 1")
-    assert speaker1.machineIdentifier == "RINCON_12345678901234567:1234567891"
+    assert speaker1.machineIdentifier == "RINCON_12345678901234561:1234567891"
 
     # Finds speaker as part of group
     speaker1 = mocked_account.sonos_speaker("Speaker 2")
-    assert speaker1.machineIdentifier == "RINCON_12345678901234567:1234567892"
+    assert speaker1.machineIdentifier == "RINCON_12345678901234562:1234567892"
 
-    # Finds speaker by identifier
-    speaker3 = mocked_account.sonos_speaker_by_id("RINCON_12345678901234567:1234567893")
+    # Finds speaker by Plex identifier
+    speaker3 = mocked_account.sonos_speaker_by_id("RINCON_12345678901234563:1234567893")
+    assert speaker3.title == "Speaker 3"
+
+    # Finds speaker by Sonos identifier
+    speaker3 = mocked_account.sonos_speaker_by_id("RINCON_12345678901234563")
     assert speaker3.title == "Speaker 3"
 
     assert mocked_account.sonos_speaker("Speaker X") is None


### PR DESCRIPTION
Plex's API to request available Sonos speakers reports device IDs in the format of "RINCON_12345678901234567:1234567893". However, the Sonos speakers themselves don't report a trailing identifier.

This change allows to use the Sonos-provided ID to look up a matching speaker provided on the Plex API.