### PR TITLE
Reduce timeout to expire Sonos resource cache

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -217,7 +217,7 @@ class MyPlexAccount(PlexObject):
             return []
 
         t = time.time()
-        if t - self._sonos_cache_timestamp > 60:
+        if t - self._sonos_cache_timestamp > 5:
             self._sonos_cache_timestamp = t
             data = self.query('https://sonos.plex.tv/resources')
             self._sonos_cache = [PlexSonosClient(self, elem) for elem in data]


### PR DESCRIPTION
The cache to avoid hammering the Plex endpoint for Sonos resources was set to 60s, which is a bit long. Reduced this to 5s so speaker group changes can be picked up quicker.