### PR TITLE
Video optimize update

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1054,6 +1054,23 @@ class FilterChoice(PlexObject):
         self.title = data.attrib.get('title')
         self.type = data.attrib.get('type')
 
+@utils.registerPlexObject
+class Location(PlexObject):
+    """ Represents a single library Location.
+
+        Attributes:
+            TAG (str): 'Location'
+            id (int): Location path ID.
+            path (str): Path used for library..
+    """
+    TAG = 'Location'
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        self._data = data
+        self.id = utils.cast(int, data.attrib.get('id'))
+        self.path = data.attrib.get('path')
+
 
 @utils.registerPlexObject
 class Hub(PlexObject):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -350,7 +350,7 @@ class LibrarySection(PlexObject):
         self.filters = data.attrib.get('filters')
         self.key = data.attrib.get('key')  # invalid key from plex
         self.language = data.attrib.get('language')
-        self.locations = self.findItems(data, etag='Location')
+        self.locations = self.listAttrs(data, 'path', etag='Location')
         self.refreshing = utils.cast(bool, data.attrib.get('refreshing'))
         self.scanner = data.attrib.get('scanner')
         self.thumb = data.attrib.get('thumb')

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -657,6 +657,11 @@ class LibrarySection(PlexObject):
             raise BadRequest('Unknown sort dir: %s' % sdir)
         return '%s:%s' % (lookup[scol], sdir)
 
+    def _locations(self):
+        """ Returns a list of :class:`~plexapi.library.Location` objects
+        """
+        return self.findItems(self._data, etag='Location')
+
     def sync(self, policy, mediaSettings, client=None, clientId=None, title=None, sort=None, libtype=None,
              **kwargs):
         """ Add current library section as sync item for specified device.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -350,7 +350,7 @@ class LibrarySection(PlexObject):
         self.filters = data.attrib.get('filters')
         self.key = data.attrib.get('key')  # invalid key from plex
         self.language = data.attrib.get('language')
-        self.locations = self.listAttrs(data, 'path', etag='Location')
+        self.locations = self.findItems(data, etag='Location')
         self.refreshing = utils.cast(bool, data.attrib.get('refreshing'))
         self.scanner = data.attrib.get('scanner')
         self.thumb = data.attrib.get('thumb')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -157,6 +157,13 @@ class Video(PlexPartialObject):
         if targetTagID not in tagIDs and (deviceProfile is None or videoQuality is None):
             raise BadRequest('Unexpected or missing quality profile.')
 
+        libraryLocationIDs = [location.id for location in self.section().locations]
+        libraryLocationIDs.append(-1)
+
+        if locationID not in libraryLocationIDs:
+            raise BadRequest('Unexpected library path ID. %s not in %s' %
+                             (locationID, libraryLocationIDs))
+
         if isinstance(targetTagID, str):
             tagIndex = tagKeys.index(targetTagID)
             targetTagID = tagValues[tagIndex]

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -158,7 +158,7 @@ class Video(PlexPartialObject):
         if targetTagID not in tagIDs and (deviceProfile is None or videoQuality is None):
             raise BadRequest('Unexpected or missing quality profile.')
 
-        libraryLocationIDs = [location.id for location in self.section().locations]
+        libraryLocationIDs = [location.id for location in self.section()._locations()]
         libraryLocationIDs.append(-1)
 
         if locationID not in libraryLocationIDs:

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -126,8 +126,9 @@ class Video(PlexPartialObject):
                  policyValue="", policyUnwatched=0, videoQuality=None, deviceProfile=None):
         """ Optimize item
 
-            locationID (int): -1 in folder with orginal items
-                               2 library path
+            locationID (int): -1 in folder with original items
+                               2 library path id
+                                 library path id is found in library.locations[i].id
 
             target (str): custom quality name.
                           if none provided use "Custom: {deviceProfile}"


### PR DESCRIPTION
Initial PR for video.optimize had an incorrect assumption for the locationID usage. locationID uses the library's path id to determine where to place the optimized version. 

Added a check inside the method to only allow library locations based on the library location ID. Library location ID was initially missing from library.locations as this attribute only pulled the path and not the ID. Now location is it's own class and includes both ID and path. 