### PR TITLE
Fix ElementTree warnings

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -69,7 +69,7 @@ class PlexClient(PlexObject):
         self._proxyThroughServer = False
         self._commandId = 0
         self._last_call = 0
-        if not any([data, initpath, baseurl, token]):
+        if not any([data is not None, initpath, baseurl, token]):
             self._baseurl = CONFIG.get('auth.client_baseurl', 'http://localhost:32433')
             self._token = logfilter.add_secret(CONFIG.get('auth.client_token'))
         if connect and self._baseurl:

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -139,7 +139,7 @@ class MyPlexAccount(PlexObject):
 
         roles = data.find('roles')
         self.roles = []
-        if roles:
+        if roles is not None:
             for role in roles.iter('role'):
                 self.roles.append(role.attrib.get('id'))
 


### PR DESCRIPTION
As seen in #515 there are warnings similar to this printed when a plain boolean check is made on an `ElementTree` object:
```
/srv/homeassistant-3.7/lib/python3.7/site-packages/plexapi/client.py:72: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if not any([data, initpath, baseurl, token]):
```
This PR makes more explicit checks against `None` to avoid these warnings.