### PR TITLE
Playlist creation - check items are included, raise exception

### DIFF
--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -131,6 +131,9 @@ class Playlist(PlexPartialObject, Playable):
     @classmethod
     def _create(cls, server, title, items):
         """ Create a playlist. """
+        if not items:
+            raise BadRequest('Must include items to add when creating new playlist')
+            
         if items and not isinstance(items, (list, tuple)):
             items = [items]
         ratingKeys = []
@@ -162,6 +165,9 @@ class Playlist(PlexPartialObject, Playable):
             smart (bool): default False.
 
             **kwargs (dict): is passed to the filters. For a example see the search method.
+            
+        Raises:
+            :class:`plexapi.exceptions.BadRequest`: when no items are included in create request.
 
         Returns:
             :class:`plexapi.playlist.Playlist`: an instance of created Playlist.


### PR DESCRIPTION
List of items cannot be empty when creating a standard playlist.