### PR TITLE
Improve clips handling

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -787,10 +787,9 @@ class Clip(Playable, Video):
         self.duration = utils.cast(int, data.attrib.get('duration'))
         self.extraType = utils.cast(int, data.attrib.get('extraType'))
         self.guid = data.attrib.get('guid')
+        self.index = utils.cast(int, data.attrib.get('index'))
         self.originallyAvailableAt = data.attrib.get('originallyAvailableAt')
-        self.skipDetails = utils.cast(int, data.attrib.get('skipDetails'))
         self.subtype = data.attrib.get('subtype')
-        self.thumbAspectRatio = data.attrib.get('thumbAspectRatio')
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
 
     def section(self):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -795,6 +795,6 @@ class Clip(Playable, Video):
 
     def section(self):
         """ Returns the :class:`~plexapi.library.LibrarySection` this item belongs to. """
-        if self.librarySectionID is not None:
-            return self._server.library.sectionByID(self.librarySectionID)
+        # Clip payloads currently do not contain 'librarySectionID'.
+        # Return None to avoid unnecessary attribute lookup attempts.
         return None

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -785,13 +785,13 @@ class Clip(Playable, Video):
         Video._loadData(self, data)
         Playable._loadData(self, data)
         self.duration = utils.cast(int, data.attrib.get('duration'))
+        self.extraType = utils.cast(int, data.attrib.get('extraType'))
         self.guid = data.attrib.get('guid')
         self.originallyAvailableAt = data.attrib.get('originallyAvailableAt')
         self.skipDetails = utils.cast(int, data.attrib.get('skipDetails'))
         self.subtype = data.attrib.get('subtype')
         self.thumbAspectRatio = data.attrib.get('thumbAspectRatio')
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
-        self.year = utils.cast(int, data.attrib.get('year'))
 
     def section(self):
         """ Returns the :class:`~plexapi.library.LibrarySection` this item belongs to. """

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -10,7 +10,7 @@ from plexapi.exceptions import BadRequest, NotFound
 class Video(PlexPartialObject):
     """ Base class for all video objects including :class:`~plexapi.video.Movie`,
         :class:`~plexapi.video.Show`, :class:`~plexapi.video.Season`,
-        :class:`~plexapi.video.Episode`.
+        :class:`~plexapi.video.Episode`, :class:`~plexapi.video.Clip`.
 
         Attributes:
             addedAt (datetime): Datetime this item was added to the library.
@@ -774,14 +774,26 @@ class Episode(Playable, Video):
 
 @utils.registerPlexObject
 class Clip(Playable, Video):
-    """ Represents a single Clip."""
+    """Represents a single Clip.
+
+    Attributes:
+        TAG (str): 'Video'
+        TYPE (str): 'clip'
+        duration (int): Duration of movie in milliseconds.
+        extraType (int): Unknown
+        guid: Plex GUID (com.plexapp.agents.imdb://tt4302938?lang=en).
+        index (int): Plex index (?)
+        originallyAvailableAt (datetime): Datetime movie was released.
+        subtype (str): Type of clip
+        viewOffset (int): View offset in milliseconds.
+    """
 
     TAG = 'Video'
     TYPE = 'clip'
     METADATA_TYPE = 'clip'
 
     def _loadData(self, data):
-        """ Load attribute values from Plex XML response. """
+        """Load attribute values from Plex XML response."""
         Video._loadData(self, data)
         Playable._loadData(self, data)
         self.duration = utils.cast(int, data.attrib.get('duration'))
@@ -793,7 +805,7 @@ class Clip(Playable, Video):
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
 
     def section(self):
-        """ Returns the :class:`~plexapi.library.LibrarySection` this item belongs to. """
+        """Return the :class:`~plexapi.library.LibrarySection` this item belongs to."""
         # Clip payloads currently do not contain 'librarySectionID'.
         # Return None to avoid unnecessary attribute lookup attempts.
         return None

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -781,17 +781,20 @@ class Clip(Playable, Video):
     METADATA_TYPE = 'clip'
 
     def _loadData(self, data):
-        self._data = data
-        self.addedAt = data.attrib.get('addedAt')
-        self.duration = data.attrib.get('duration')
+        """ Load attribute values from Plex XML response. """
+        Video._loadData(self, data)
+        Playable._loadData(self, data)
+        self.duration = utils.cast(int, data.attrib.get('duration'))
         self.guid = data.attrib.get('guid')
-        self.key = data.attrib.get('key')
         self.originallyAvailableAt = data.attrib.get('originallyAvailableAt')
-        self.ratingKey = data.attrib.get('ratingKey')
         self.skipDetails = utils.cast(int, data.attrib.get('skipDetails'))
         self.subtype = data.attrib.get('subtype')
-        self.thumb = data.attrib.get('thumb')
         self.thumbAspectRatio = data.attrib.get('thumbAspectRatio')
-        self.title = data.attrib.get('title')
-        self.type = data.attrib.get('type')
-        self.year = data.attrib.get('year')
+        self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
+        self.year = utils.cast(int, data.attrib.get('year'))
+
+    def section(self):
+        """ Returns the :class:`~plexapi.library.LibrarySection` this item belongs to. """
+        if self.librarySectionID is not None:
+            return self._server.library.sectionByID(self.librarySectionID)
+        return None


### PR DESCRIPTION
Some minor changes to populate the available attributes on `clip` media types, mostly by using the parent class methods.

Used an override method for `section()` as `librarySectionID` doesn't seem to be populated in any of the `clip` session examples I reviewed. Will likely always return `None`. If it _does_ show up for someone else or gets added in the future it should return the proper library section.