### PR TITLE
Fix Album iterator

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -213,7 +213,7 @@ class Album(Audio):
     TYPE = 'album'
 
     def __iter__(self):
-        for track in self.tracks:
+        for track in self.tracks():
             yield track
 
     def _loadData(self, data):


### PR DESCRIPTION
The `__iter__` method was iterating over the `Album.tracks` method instead of calling it and iterating through the returned list.