### PR TITLE
Fix timestamp assertion in tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,4 +81,4 @@ def test_utils_download(plex, episode):
 
 def test_millisecondToHumanstr():
     res = utils.millisecondToHumanstr(1000)
-    assert res == "00:00:01:0000"
+    assert res == "00:00:01.0000"


### PR DESCRIPTION
Timestamp punctuation was breaking a test.
```
=================================== FAILURES ===================================
__________________________ test_millisecondToHumanstr __________________________
Traceback (most recent call last):
  File "/home/travis/build/pkkid/python-[secure]/tests/test_utils.py", line 84, in test_millisecondToHumanstr
    assert res == "00:00:01:0000"
AssertionError: assert '00:00:01.0000' == '00:00:01:0000'
  - 00:00:01:0000
  ?         ^
  + 00:00:01.0000
  ?         ^
```