### PR TITLE
Add **kwargs to LibrarySection.get() for arbitrary query parameters.

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -433,13 +433,15 @@ class LibrarySection(PlexObject):
             if s.key == self.key:
                 return s
 
-    def get(self, title):
+    def get(self, title, **kwargs):
         """ Returns the media item with the specified title.
 
             Parameters:
                 title (str): Title of the item to return.
         """
         key = '/library/sections/%s/all?title=%s' % (self.key, quote(title, safe=''))
+        for keyword, value in kwargs.items():
+            key = key + '&%s=%s' % (keyword, value)
         return self.fetchItem(key, title__iexact=title)
 
     def all(self, sort=None, **kwargs):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -441,7 +441,7 @@ class LibrarySection(PlexObject):
         """
         key = '/library/sections/%s/all?title=%s' % (self.key, quote(title, safe=''))
         for keyword, value in kwargs.items():
-            key = key + '&%s=%s' % (keyword, value)
+            key = key + '&%s=%s' % (keyword, quote(value, safe=''))
         return self.fetchItem(key, title__iexact=title)
 
     def all(self, sort=None, **kwargs):


### PR DESCRIPTION
Whenever there are title collisions when calling LibrarySection.get(), the first matching element from the query is returned. This patch adds arbitrary key / value pairs to .get() to support optional parameters beyond just "title", enabling more complex searches by adding the additional search parameters to the key; this (hopefully) should enable the correct element to be returned. This is supported already in the Plex XML API but doesn't look to be implemented here. This shouldn't break any existing queries.

Example using "The Killers" originally from 1946 and remade in 1964; the query without additional parameters returns the first element which in this case is the 1946 version:

```
>>> plex.library.section('Films').get('The Killers')
<Movie:1563:The-Killers>

>>> plex.library.section('Films').get('The Killers', year="1964")
<Movie:1562:The-Killers>

>>> plex.library.section('Films').get('The Killers', year="1946")                                                                     
<Movie:1563:The-Killers>
```

Other parameters beyond year:
```
>>> plex.library.section('Films').get('The Killers', guid="com.plexapp.agents.imdb://tt0038669?lang=en")                                                                                                                                                                     
<Movie:1563:The-Killers>
```

Combinations:
```
>>> plex.library.section('Films').get('The Killers', year="1946", guid="com.plexapp.agents.imdb://tt0038669?lang=en")                                                                                                                                                                     
<Movie:1563:The-Killers>
```
