### PR TITLE
PlayQueue: Add optional continuous arg to PlayQueue.create()

### DIFF
--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -42,7 +42,7 @@ class PlayQueue(PlexObject):
         self.items = self.findItems(data)
 
     @classmethod
-    def create(cls, server, item, shuffle=0, repeat=0, includeChapters=1, includeRelated=1):
+    def create(cls, server, item, shuffle=0, repeat=0, includeChapters=1, includeRelated=1, continuous=0):
         """ Create and returns a new :class:`~plexapi.playqueue.PlayQueue`.
 
             Paramaters:
@@ -52,12 +52,14 @@ class PlayQueue(PlexObject):
                 repeat (int, optional): Start the playqueue shuffled.
                 includeChapters (int, optional): include Chapters.
                 includeRelated (int, optional): include Related.
+                continuous (int, optional): include additional items after the initial item. For a show this would be the next episodes, for a movie it does nothing.
         """
         args = {}
         args['includeChapters'] = includeChapters
         args['includeRelated'] = includeRelated
         args['repeat'] = repeat
         args['shuffle'] = shuffle
+        args['continuous'] = continuous
         if item.type == 'playlist':
             args['playlistID'] = item.ratingKey
             args['type'] = item.playlistType


### PR DESCRIPTION
## Description
Add an optional `continuous` arg to the `PlayQueue.create()` function. It defaults to `continuous=0` so that the current behaviour remains the default so it's non-breaking.

## Why
This allows to much more easily queue up a an entire show starting at a particular episode and continuing from there, which is the behavior on most Plex clients.

- When `continuous=1` is set, the `PlayQueue` will be created starting at at the provided `item`, but will also automatically include the next episodes in a show if item is a show. It appears to do nothing if the item is a movie.
- When `continuous=0` or it is omitted, it just adds the single episode and then stops playing (current behavior).

## Examples

Implicit (continuous=0 by default):
```py
play_queue = PlayQueue.create(plex_server, example_tv_show_s03e02)
# play_queue.items has one item [example_tv_show_s03e02]
```

Explicit `continuous=0`:
```py
play_queue = PlayQueue.create(plex_server, example_tv_show_s03e02, continuous=0)
# play_queue.items has one item [example_tv_show_s03e02]
```

Explicit `continuous=1`:
```py
play_queue = PlayQueue.create(plex_server, example_tv_show_s03e02, continuous=1)
# play_queue.items has many items, [example_tv_show_s03e02, example_tv_show_s03e03, example_tv_show_s03e04, ...]
```

Fixes https://github.com/pkkid/python-plexapi/issues/560