### PR TITLE
 guids collection to movie and GuidTag PlexObject

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -510,6 +510,29 @@ class MediaTag(PlexObject):
             raise BadRequest('Key is not defined for this tag: %s' % self.tag)
         return self.fetchItems(self.key)
 
+class GuidTag(PlexObject):
+    """ Base class for guid tags used only for Guids, as they contain only a string identifier
+
+        Attributes:
+            server (:class:`~plexapi.server.PlexServer`): Server this client is connected to.
+            id (id): Tag ID (Used as a unique id, except for Guid's, used for external systems
+                to plex identifiers, like imdb and tmdb).
+    """
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        self._data = data
+        self.id = data.attrib.get('id')
+        self.tag = data.attrib.get('tag')
+
+    def items(self, *args, **kwargs):
+        """ Return the list of items within this tag. This function is only applicable
+            in search results from PlexServer :func:`~plexapi.server.PlexServer.search()`.
+        """
+        if not self.key:
+            raise BadRequest('Key is not defined for this tag: %s' % self.tag)
+        return self.fetchItems(self.key)
+
 
 @utils.registerPlexObject
 class Collection(MediaTag):
@@ -589,6 +612,10 @@ class Genre(MediaTag):
     TAG = 'Genre'
     FILTER = 'genre'
 
+@utils.registerPlexObject
+class Guid(GuidTag):
+    """ Represents a single Guid media tag. """
+    TAG = "Guid"
 
 @utils.registerPlexObject
 class Mood(MediaTag):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -276,6 +276,7 @@ class Movie(Playable, Video):
             directors (List<:class:`~plexapi.media.Director`>): List of director objects.
             fields (List<:class:`~plexapi.media.Field`>): List of field objects.
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
+            guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             producers (List<:class:`~plexapi.media.Producer`>): List of producers objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
@@ -319,6 +320,7 @@ class Movie(Playable, Video):
         self.directors = self.findItems(data, media.Director)
         self.fields = self.findItems(data, media.Field)
         self.genres = self.findItems(data, media.Genre)
+        self.guids = self.findItems(data, media.Guid)
         self.media = self.findItems(data, media.Media)
         self.producers = self.findItems(data, media.Producer)
         self.roles = self.findItems(data, media.Role)


### PR DESCRIPTION
Suggested implementation for Movie guids collection and GuidTag PlexObject in reference to new Plex movie agent, which is still in beta.

MediaTag's id expects type int, so I figured a specific version might be better.  Might be worth implementing parsing of the expected id's (tmdb or imdb), but for now this fits to the existing tag collection model