### PR TITLE
Add 'activities' endpoint support

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -190,6 +190,12 @@ class PlexServer(PlexObject):
         data = self.query(Account.key)
         return Account(self, data)
 
+    @property
+    def activities(self):
+        """ Returns a list of all server settings. """
+        for elem in self.query(Activities.key):
+            yield Activities(self, elem)
+
     def agents(self, mediaType=None):
         """ Returns the `:class:`~plexapi.media.Agent` objects this server has available. """
         key = '/system/agents'
@@ -599,6 +605,20 @@ class Account(PlexObject):
         self.subscriptionFeatures = utils.toList(data.attrib.get('subscriptionFeatures'))
         self.subscriptionActive = cast(bool, data.attrib.get('subscriptionActive'))
         self.subscriptionState = data.attrib.get('subscriptionState')
+
+
+class Activity(PlexObject):
+    """A currently running activity on the PlexServer."""
+    key = '/activities'
+
+    def _loadData(self, data):
+        self._data = data
+        self.cancellable = cast(bool, data.attrib.get('cancellable'))
+        self.progress = cast(int, data.attrib.get('progress'))
+        self.title = data.attrib.get('title')
+        self.subtitle = data.attrib.get('subtitle')
+        self.type = data.attrib.get('type')
+        self.uuid = data.attrib.get('uuid')
 
 
 class SystemAccount(PlexObject):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -192,9 +192,11 @@ class PlexServer(PlexObject):
 
     @property
     def activities(self):
-        """ Returns a list of all server settings. """
-        for elem in self.query(Activities.key):
-            yield Activities(self, elem)
+        """Returns all current PMS activities."""
+        activities = []
+        for elem in self.query(Activity.key):
+            activities.append(Activity(self, elem))
+        return activities
 
     def agents(self, mediaType=None):
         """ Returns the `:class:`~plexapi.media.Agent` objects this server has available. """

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import time
+
+import pytest
+
+MAX_ATTEMPTS = 60
+
+
+def wait_for_idle_server(server):
+    """Wait for PMS activities to complete with a timeout."""
+    attempts = 0
+    while server.activities and attempts < MAX_ATTEMPTS:
+        print(f"Watiing for activities to finish: {server.activities}")
+        time.sleep(1)
+        attempts += 1
+    assert attempts < MAX_ATTEMPTS, f"Server still busy after {MAX_ATTEMPTS}s"
+
+
+def test_ensure_metadata_scans_completed(plex):
+    wait_for_idle_server(plex)
+
+
+@pytest.mark.authenticated
+def test_ensure_metadata_scans_completed_authenticated(plex):
+    wait_for_idle_server(plex)

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -10,7 +10,7 @@ def wait_for_idle_server(server):
     """Wait for PMS activities to complete with a timeout."""
     attempts = 0
     while server.activities and attempts < MAX_ATTEMPTS:
-        print(f"Watiing for activities to finish: {server.activities}")
+        print(f"Waiting for activities to finish: {server.activities}")
         time.sleep(1)
         attempts += 1
     assert attempts < MAX_ATTEMPTS, f"Server still busy after {MAX_ATTEMPTS}s"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,17 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
-import time
 
 from . import conftest as utils
-
-def test_ensure_metadata_scans_completed(plex):
-    MAX_ATTEMPTS = 60
-    attempts = 0
-    while plex.activities and attempts < MAX_ATTEMPTS:
-        print(f"Watiing for activities to finish: {plex.activities}")
-        time.sleep(1)
-        attempts += 1
-    assert attempts < MAX_ATTEMPTS, f"Server still busy after {MAX_ATTEMPTS}s"
 
 
 def test_audio_Artist_attr(artist):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -5,7 +5,7 @@ import time
 from . import conftest as utils
 
 def test_ensure_metadata_scans_completed(plex):
-    MAX_ATTEMPTS = 1
+    MAX_ATTEMPTS = 60
     attempts = 0
     while plex.activities and attempts < MAX_ATTEMPTS:
         print(f"Watiing for activities to finish: {plex.activities}")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
+import time
 
 from . import conftest as utils
+
+def test_ensure_metadata_scans_completed(plex):
+    MAX_ATTEMPTS = 1
+    attempts = 0
+    while plex.activities and attempts < MAX_ATTEMPTS:
+        print(f"Watiing for activities to finish: {plex.activities}")
+        time.sleep(1)
+        attempts += 1
+    assert attempts < MAX_ATTEMPTS, f"Server still busy after {MAX_ATTEMPTS}s"
 
 
 def test_audio_Artist_attr(artist):


### PR DESCRIPTION
PMS reports back information on its currently running activities, such as scanning for metadata.

This is an MVP version which should allow querying to see if metadata activities are still in progress as suggested [here](https://github.com/pkkid/python-plexapi/issues/454#issuecomment-691329452).