### PR TITLE
New bootstrap music scanner

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -7,7 +7,8 @@ from . import conftest as utils
 def test_audio_Artist_attr(artist):
     artist.reload()
     assert utils.is_datetime(artist.addedAt)
-    assert "United States" in [i.tag for i in artist.countries]
+    if artist.countries:
+        assert "United States" in [i.tag for i in artist.countries]
     #assert "Electronic" in [i.tag for i in artist.genres]
     assert utils.is_string(artist.guid, gte=5)
     assert artist.index == "1"
@@ -217,7 +218,7 @@ def test_audio_Track_attrs(album):
     if track.grandparentThumb:
         assert utils.is_metadata(track.grandparentThumb, contains="/thumb/")
     assert track.grandparentTitle == "Broke For Free"
-    assert track.guid.startswith("plex://track/")
+    assert track.guid.startswith("mbid://") or track.guid.startswith("plex://track/")
     assert int(track.index) == 1
     assert utils.is_metadata(track._initpath)
     assert utils.is_metadata(track.key)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -21,7 +21,8 @@ def test_audio_Artist_attr(artist):
     assert artist.ratingKey >= 1
     assert artist._server._baseurl == utils.SERVER_BASEURL
     assert isinstance(artist.similar, list)
-    assert "Alias" in artist.summary
+    if artist.summary:
+        assert "Alias" in artist.summary
     assert artist.title == "Broke For Free"
     assert artist.titleSort == "Broke For Free"
     assert artist.type == "artist"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -7,8 +7,8 @@ from . import conftest as utils
 def test_audio_Artist_attr(artist):
     artist.reload()
     assert utils.is_datetime(artist.addedAt)
-    assert artist.countries == []
-    assert "Electronic" in [i.tag for i in artist.genres]
+    assert "United States" in [i.tag for i in artist.countries]
+    #assert "Electronic" in [i.tag for i in artist.genres]
     assert utils.is_string(artist.guid, gte=5)
     assert artist.index == "1"
     assert utils.is_metadata(artist._initpath)
@@ -75,7 +75,7 @@ def test_audio_Album_attrs(album):
     assert album.parentTitle == "Broke For Free"
     assert album.ratingKey >= 1
     assert album._server._baseurl == utils.SERVER_BASEURL
-    assert album.studio is None
+    assert album.studio == "[no label]"
     assert album.summary == ""
     if album.thumb:
         assert utils.is_metadata(album.thumb, contains="/thumb/")
@@ -120,7 +120,8 @@ def test_audio_Album_tracks(album):
     assert utils.is_int(track.ratingKey)
     assert track._server._baseurl == utils.SERVER_BASEURL
     assert track.summary == ""
-    assert utils.is_metadata(track.thumb, contains="/thumb/")
+    if track.thumb:
+        assert utils.is_metadata(track.thumb, contains="/thumb/")
     assert track.title == "As Colourful as Ever"
     assert track.titleSort == "As Colourful as Ever"
     assert not track.transcodeSessions
@@ -156,7 +157,8 @@ def test_audio_Album_track(album, track=None):
     assert utils.is_int(track.ratingKey)
     assert track._server._baseurl == utils.SERVER_BASEURL
     assert track.summary == ""
-    assert utils.is_metadata(track.thumb, contains="/thumb/")
+    if track.thumb:
+        assert utils.is_metadata(track.thumb, contains="/thumb/")
     assert track.title == "As Colourful as Ever"
     assert track.titleSort == "As Colourful as Ever"
     assert not track.transcodeSessions
@@ -215,7 +217,7 @@ def test_audio_Track_attrs(album):
     if track.grandparentThumb:
         assert utils.is_metadata(track.grandparentThumb, contains="/thumb/")
     assert track.grandparentTitle == "Broke For Free"
-    assert track.guid.startswith("local://")
+    assert track.guid.startswith("plex://track/")
     assert int(track.index) == 1
     assert utils.is_metadata(track._initpath)
     assert utils.is_metadata(track.key)
@@ -240,7 +242,8 @@ def test_audio_Track_attrs(album):
     assert track._server._baseurl == utils.SERVER_BASEURL
     assert track.sessionKey is None
     assert track.summary == ""
-    assert utils.is_metadata(track.thumb, contains="/thumb/")
+    if track.thumb:
+        assert utils.is_metadata(track.thumb, contains="/thumb/")
     assert track.title == "As Colourful as Ever"
     assert track.titleSort == "As Colourful as Ever"
     assert not track.transcodeSessions

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -541,8 +541,8 @@ if __name__ == "__main__":
                 name="Music",
                 type="artist",
                 location="/data/Music" if opts.no_docker is False else music_path,
-                agent="com.plexapp.agents.lastfm",
-                scanner="Plex Music Scanner",
+                agent="tv.plex.agents.music",
+                scanner="Plex Music",
                 expected_media_count=song_c,
             )
         )


### PR DESCRIPTION
Since the method to prevent metadata errors in #569 didn't pan out, here's another attempt.

This updates the bootstrap script to use the new "Plex Music" scanner/agent instead of the legacy "Plex Music Scanner"/last.fm combo in the testing environment. Also updates the audio tests to match the new expected metadata.