### PR TITLE
Add Library timeline support

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -466,6 +466,12 @@ class LibrarySection(PlexObject):
         data = self._server.query(key)
         return self.findItems(data, cls=Setting)
 
+    def timeline(self):
+        """ Returns a timeline query for this library section. """
+        key = '/library/sections/%s/timeline' % self.key
+        data = self._server.query(key)
+        return LibraryTimeline(self, data)
+
     def onDeck(self):
         """ Returns a list of media items on deck from this library section. """
         key = '/library/sections/%s/onDeck' % self.key
@@ -1058,6 +1064,46 @@ class FilterChoice(PlexObject):
         self.thumb = data.attrib.get('thumb')
         self.title = data.attrib.get('title')
         self.type = data.attrib.get('type')
+
+
+@utils.registerPlexObject
+class LibraryTimeline(PlexObject):
+    """Represents a LibrarySection timeline.
+
+        Attributes:
+            TAG (str): 'LibraryTimeline'
+            size (int): Unknown
+            allowSync (bool): Unknown
+            art (str): Relative path to art image.
+            content (str): "secondary"
+            identifier (str): "com.plexapp.plugins.library"
+            latestEntryTime (int): Epoch timestamp
+            mediaTagPrefix (str): "/system/bundle/media/flags/"
+            mediaTagVersion (int): Unknown
+            thumb (str): Relative path to library thumb image.
+            title1 (str): Name of library section.
+            updateQueueSize (int): Number of items queued to update.
+            viewGroup (str): "secondary"
+            viewMode (int): Unknown
+    """
+    TAG = 'LibraryTimeline'
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        self._data = data
+        self.size = utils.cast(int, data.attrib.get('size'))
+        self.allowSync = utils.cast(bool, data.attrib.get('allowSync'))
+        self.art = data.attrib.get('art')
+        self.content = data.attrib.get('content')
+        self.identifier = data.attrib.get('identifier')
+        self.latestEntryTime = utils.cast(int, data.attrib.get('latestEntryTime'))
+        self.mediaTagPrefix = data.attrib.get('mediaTagPrefix')
+        self.mediaTagVersion = utils.cast(int, data.attrib.get('mediaTagVersion'))
+        self.thumb = data.attrib.get('thumb')
+        self.title1 = data.attrib.get('title1')
+        self.updateQueueSize = utils.cast(int, data.attrib.get('updateQueueSize'))
+        self.viewGroup = data.attrib.get('viewGroup')
+        self.viewMode = utils.cast(int, data.attrib.get('viewMode'))
 
 
 @utils.registerPlexObject

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -27,7 +27,6 @@ def wait_for_metadata_processing(server):
             if tl.updateQueueSize > 0:
                 busy = True
                 print(f"{section.title}: {tl.updateQueueSize} items left")
-                assert not busy, f"{section.title}: {tl.updateQueueSize} items left"
         if not busy or attempts > MAX_ATTEMPTS:
             break
         time.sleep(1)
@@ -35,13 +34,13 @@ def wait_for_metadata_processing(server):
     assert attempts < MAX_ATTEMPTS, f"Metadata still processing after {MAX_ATTEMPTS}s"
 
 
-#def test_ensure_activities_completed(plex):
-#    wait_for_idle_server(plex)
+def test_ensure_activities_completed(plex):
+    wait_for_idle_server(plex)
 
 
-#@pytest.mark.authenticated
-#def test_ensure_activities_completed_authenticated(plex):
-#    wait_for_idle_server(plex)
+@pytest.mark.authenticated
+def test_ensure_activities_completed_authenticated(plex):
+    wait_for_idle_server(plex)
 
 
 def test_ensure_metadata_scans_completed(plex):

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -16,10 +16,38 @@ def wait_for_idle_server(server):
     assert attempts < MAX_ATTEMPTS, f"Server still busy after {MAX_ATTEMPTS}s"
 
 
-def test_ensure_metadata_scans_completed(plex):
+def wait_for_metadata_processing(server):
+    """Wait for async metadata processing to complete."""
+    attempts = 0
+
+    while True:
+        busy = False
+        for section in server.library.sections():
+            tl = section.timeline()
+            if tl.updateQueueSize > 0:
+                busy = True
+                print(f"{section.title}: {tl.queue_size} items left")
+        if not busy or attempts > MAX_ATTEMPTS:
+            break
+        time.sleep(1)
+        attempts += 1
+    #assert attempts < MAX_ATTEMPTS, f"Metadata still processing after {MAX_ATTEMPTS}s"
+    assert "always assert" == True, f"Metadata still processing after {MAX_ATTEMPTS}s"
+
+
+def test_ensure_activities_completed(plex):
     wait_for_idle_server(plex)
 
 
 @pytest.mark.authenticated
-def test_ensure_metadata_scans_completed_authenticated(plex):
+def test_ensure_activities_completed_authenticated(plex):
     wait_for_idle_server(plex)
+
+
+def test_ensure_metadata_scans_completed(plex):
+    wait_for_metadata_processing(plex)
+
+
+@pytest.mark.authenticated
+def test_ensure_metadata_scans_completed_authenticated(plex):
+    wait_for_metadata_processing(plex)

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -26,13 +26,13 @@ def wait_for_metadata_processing(server):
             tl = section.timeline()
             if tl.updateQueueSize > 0:
                 busy = True
-                print(f"{section.title}: {tl.queue_size} items left")
+                print(f"{section.title}: {tl.updateQueueSize} items left")
+                assert not busy, f"{section.title}: {tl.updateQueueSize} items left"
         if not busy or attempts > MAX_ATTEMPTS:
             break
         time.sleep(1)
         attempts += 1
-    #assert attempts < MAX_ATTEMPTS, f"Metadata still processing after {MAX_ATTEMPTS}s"
-    assert "always assert" == True, f"Metadata still processing after {MAX_ATTEMPTS}s"
+    assert attempts < MAX_ATTEMPTS, f"Metadata still processing after {MAX_ATTEMPTS}s"
 
 
 def test_ensure_activities_completed(plex):

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -35,13 +35,13 @@ def wait_for_metadata_processing(server):
     assert attempts < MAX_ATTEMPTS, f"Metadata still processing after {MAX_ATTEMPTS}s"
 
 
-def test_ensure_activities_completed(plex):
-    wait_for_idle_server(plex)
+#def test_ensure_activities_completed(plex):
+#    wait_for_idle_server(plex)
 
 
-@pytest.mark.authenticated
-def test_ensure_activities_completed_authenticated(plex):
-    wait_for_idle_server(plex)
+#@pytest.mark.authenticated
+#def test_ensure_activities_completed_authenticated(plex):
+#    wait_for_idle_server(plex)
 
 
 def test_ensure_metadata_scans_completed(plex):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
 import pytest
 from plexapi.exceptions import NotFound
 
@@ -277,3 +278,22 @@ def test_crazy_search(plex, movie):
     assert len(movies.search(container_size=1)) == 4
     assert len(movies.search(container_start=9999, container_size=1)) == 0
     assert len(movies.search(container_start=2, container_size=1)) == 2
+
+
+def test_library_section_timeline(plex):
+    movies = plex.library.section("Movies")
+    tl = movies.timeline()
+    assert tl.TAG == "LibraryTimeline"
+    assert tl.size > 0
+    assert tl.allowSync is False
+    assert tl.art == "/:/resources/movie-fanart.jpg"
+    assert tl.content == "secondary"
+    assert tl.identifier == "com.plexapp.plugins.library"
+    assert datetime.fromtimestamp(tl.latestEntryTime).date() == datetime.today().date()
+    assert tl.mediaTagPrefix == "/system/bundle/media/flags/"
+    assert tl.mediaTagVersion > 1
+    assert tl.thumb == "/:/resources/movie.png"
+    assert tl.title1 == "Movies"
+    assert tl.updateQueueSize == 0
+    assert tl.viewGroup == "secondary"
+    assert tl.viewMode == 65592


### PR DESCRIPTION
Adds support for querying the `/library/sections/<SECTION_ID>/timeline` endpoint. The useful information here is `updateQueueSize` which represents the number of items in the library section which are still being processed.

The `/activities` calls added in #569 will report the agents/scanners in progress, but it appears that item metadata may be processed asynchronously after those activities have completed. This adds a test which runs before all other tests which rely on stable metadata and ensures these item processing queues are empty before proceeding.