### PR TITLE
Add server handling of HTTP status code 204

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -438,7 +438,7 @@ class PlexServer(PlexObject):
         log.debug('%s %s', method.__name__.upper(), url)
         headers = self._headers(**headers or {})
         response = method(url, headers=headers, timeout=timeout, **kwargs)
-        if response.status_code not in (200, 201):
+        if response.status_code not in (200, 201, 204):
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')
             message = '(%s) %s; %s %s' % (response.status_code, codename, response.url, errtext)


### PR DESCRIPTION
It appears that newer versions of the Plex server now return HTTP status code 204 when deleting a playlist. It must have been 200 or 201 previously. The client and myplex endpoints already handle this code.

Found in today's CI runs of https://github.com/pkkid/python-plexapi/pull/530.