### PR TITLE
Collection fields not pulling locked fields

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -717,6 +717,7 @@ class Marker(PlexObject):
         self.end = cast(int, data.attrib.get('endTimeOffset'))
 
 
+@utils.registerPlexObject
 class Field(PlexObject):
     """ Represents a single Field.
 


### PR DESCRIPTION
## Description

Collection fields not pulling locked fields.

```python
>>> collections = plex.library.section("Movies").collection()
>>> collection = collections[0]
>>> collection.fields
[]
```

Fixes #587

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

No additional tests required as there is already a test touching this area (test_library/test_library_Colletion_edit).
