### PR TITLE
Don't overwrite existing attributes with an empty list

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -283,7 +283,7 @@ class PlexPartialObject(PlexObject):
     """
 
     def __eq__(self, other):
-        return other is not None and self.key == other.key
+        return other not in [None, []] and self.key == other.key
 
     def __hash__(self):
         return hash(repr(self))

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -54,8 +54,8 @@ class PlexObject(object):
         return '<%s>' % ':'.join([p for p in [self.__class__.__name__, uid, name] if p])
 
     def __setattr__(self, attr, value):
-        # dont overwrite an attr with None unless its a private variable
-        if value is not None or attr.startswith('_') or attr not in self.__dict__:
+        # Don't overwrite an attr with None or [] unless it's a private variable
+        if value not in [None, []] or attr.startswith('_') or attr not in self.__dict__:
             self.__dict__[attr] = value
 
     def _clean(self, value):


### PR DESCRIPTION
As reported in #591, reloading objects to update missing attributes can cause list attributes to be lost. This is easiest to reproduce when accessing a missing attribute on a `Playable` object that was built from a `PlexServer.session()` call. Any existing `players`, `usernames`, `session`, `transcodeSessions`, etc are lost when reloading the object from the associated media item.