### PR TITLE
Add ability to browse and walk the Plex server system file directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ lib/
 pip-selfcheck.json
 pyvenv.cfg
 MANIFEST
+
+
+# path for the test lib.
+tools/plex

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1561,3 +1561,51 @@ class Collections(PlexPartialObject):
 
     # def edit(self, **kwargs):
     #    TODO
+
+
+@utils.registerPlexObject
+class Path(PlexObject):
+    """ Represents a single directory Path.
+
+        Attributes:
+            TAG (str): 'Path'
+
+            home (bool): True if the path is the home directory
+            key (str): API URL (/services/browse/<base64path>)
+            network (bool): True if path is a network location
+            path (str): Full path
+            title (str): Path folder
+    """
+
+    TAG = 'Path'
+
+    def _loadData(self, data):
+        self.home = utils.cast(bool, data.attrib.get('home'))
+        self.key = data.attrib.get('key')
+        self.network = utils.cast(bool, data.attrib.get('network'))
+        self.path = data.attrib.get('path')
+        self.title = data.attrib.get('title')
+
+    def browse(self):
+        key = '%s?includeFiles=1' % self.key
+        return self._server.fetchItems(key)
+
+
+@utils.registerPlexObject
+class File(PlexObject):
+    """ Represents a single File.
+
+        Attributes:
+            TAG (str): 'File'
+
+            key (str): API URL (/services/browse/<base64path>)
+            path (str): Full path
+            title (str): Path folder
+    """
+
+    TAG = 'File'
+
+    def _loadData(self, data):
+        self.key = data.attrib.get('key')
+        self.path = data.attrib.get('path')
+        self.title = data.attrib.get('title')

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1586,14 +1586,15 @@ class Path(PlexObject):
         self.path = data.attrib.get('path')
         self.title = data.attrib.get('title')
 
-    def browse(self):
+    def browse(self, includeFiles=True):
         """ Alias for :func:`~plexapi.server.PlexServer.browse()`. """
-        return self._server.browse(self)
+        return self._server.browse(self, includeFiles)
 
     def walk(self):
         """ Alias for :func:`~plexapi.server.PlexServer.walk()`. """
         for path, paths, files in self._server.walk(self):
             yield path, paths, files
+
 
 @utils.registerPlexObject
 class File(PlexObject):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1573,10 +1573,9 @@ class Path(PlexObject):
             home (bool): True if the path is the home directory
             key (str): API URL (/services/browse/<base64path>)
             network (bool): True if path is a network location
-            path (str): Full path
-            title (str): Path folder
+            path (str): Full path to folder
+            title (str): Folder name
     """
-
     TAG = 'Path'
 
     def _loadData(self, data):
@@ -1604,10 +1603,9 @@ class File(PlexObject):
             TAG (str): 'File'
 
             key (str): API URL (/services/browse/<base64path>)
-            path (str): Full path
-            title (str): Path folder
+            path (str): Full path to file
+            title (str): File name
     """
-
     TAG = 'File'
 
     def _loadData(self, data):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1586,11 +1586,11 @@ class Path(PlexObject):
         self.title = data.attrib.get('title')
 
     def browse(self, includeFiles=True):
-        """ Alias for :func:`~plexapi.server.PlexServer.browse()`. """
+        """ Alias for :func:`~plexapi.server.PlexServer.browse`. """
         return self._server.browse(self, includeFiles)
 
     def walk(self):
-        """ Alias for :func:`~plexapi.server.PlexServer.walk()`. """
+        """ Alias for :func:`~plexapi.server.PlexServer.walk`. """
         for path, paths, files in self._server.walk(self):
             yield path, paths, files
 

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1587,9 +1587,13 @@ class Path(PlexObject):
         self.title = data.attrib.get('title')
 
     def browse(self):
-        key = '%s?includeFiles=1' % self.key
-        return self._server.fetchItems(key)
+        """ Alias for :func:`~plexapi.server.PlexServer.browse()`. """
+        return self._server.browse(self)
 
+    def walk(self):
+        """ Alias for :func:`~plexapi.server.PlexServer.walk()`. """
+        for path, paths, files in self._server.walk(self):
+            yield path, paths, files
 
 @utils.registerPlexObject
 class File(PlexObject):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -252,7 +252,7 @@ class PlexServer(PlexObject):
             Returns list of :class:`~plexapi.library.Path` and :class:`~plexapi.library.File` objects.
 
             Parameters:
-                path (:class:`~plexapi.library.Path` or str, optional): Path to browse.
+                path (:class:`~plexapi.library.Path` or str, optional): Full path to browse.
                 includeFiles (bool): True to include files when browsing (Default).
                                      False to only return folders.
         """
@@ -264,7 +264,7 @@ class PlexServer(PlexObject):
         else:
             key = '/services/browse'
         if includeFiles:
-            key = '%s?includeFiles=1' % key
+            key += '?includeFiles=1'
         return self.fetchItems(key)
 
     def walk(self, path=None):
@@ -275,7 +275,7 @@ class PlexServer(PlexObject):
             `files` is a list of :class:`~plexapi.library.File` objects.
 
             Parameters:
-                path (:class:`~plexapi.library.Path` or str, optional): Path to walk.
+                path (:class:`~plexapi.library.Path` or str, optional): Full path to walk.
         """
         paths = []
         files = []

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -247,21 +247,24 @@ class PlexServer(PlexObject):
             log.warning('Unable to fetch client ports from myPlex: %s', err)
             return ports
 
-    def browse(self, path=None):
+    def browse(self, path=None, includeFiles=True):
         """ Browse the system file path using the Plex API.
             Returns list of :class:`~plexapi.library.Path` and :class:`~plexapi.library.File` objects.
 
             Parameters:
                 path (:class:`~plexapi.library.Path` or str, optional): Path to browse.
+                includeFiles (bool): True to include files when browsing (Default).
+                                     False to only return folders.
         """
-        if path is not None:
-            if isinstance(path, Path):
-                key = '%s?includeFiles=1' % path.key
-            else:
-                base64path = utils.base64str(path)
-                key = '/services/browse/%s?includeFiles=1' % base64path
+        if isinstance(path, Path):
+            key = path.key
+        elif path is not None:
+            base64path = utils.base64str(path)
+            key = '/services/browse/%s' % base64path
         else:
-            key = '/services/browse?includeFiles=1'
+            key = '/services/browse'
+        if includeFiles:
+            key = '%s?includeFiles=1' % key
         return self.fetchItems(key)
 
     def walk(self, path=None):

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import base64
 import logging
 import os
 import re
@@ -411,3 +412,7 @@ def getAgentIdentifier(section, agent):
         agents += identifiers
     raise NotFound('Couldnt find "%s" in agents list (%s)' %
                    (agent, ', '.join(agents)))
+
+
+def base64str(text):
+    return base64.b64encode(text.encode('utf-8')).decode('utf-8')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -287,6 +287,15 @@ def test_server_downloadDatabases(tmpdir, plex):
     assert len(tmpdir.listdir()) > 1
 
 
+def test_server_browse(plex, movies):
+    # browse root
+    paths = plex.browse()
+    assert len(paths)
+    # browse of the files of the movie lib.
+    for path, paths, files in plex.walk(movies.locations[0]):
+        assert len(files)
+
+
 def test_server_allowMediaDeletion(account):
     plex = PlexServer(utils.SERVER_BASEURL, account.authenticationToken)
     # Check server current allowMediaDeletion setting

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -288,12 +288,20 @@ def test_server_downloadDatabases(tmpdir, plex):
 
 
 def test_server_browse(plex, movies):
+    movies_path = movies.locations[0]
     # browse root
     paths = plex.browse()
     assert len(paths)
-    # browse of the files of the movie lib.
-    for path, paths, files in plex.walk(movies.locations[0]):
-        assert len(files)
+    # browse the path of the movie library
+    paths = plex.browse(movies_path)
+    assert len(paths)
+    # browse the path of the movie library without files
+    paths = plex.browse(movies_path, includeFiles=False)
+    assert not len([f for f in paths if f.TAG == 'File'])
+    # walk the path of the movie library
+    for path, paths, files in plex.walk(movies_path):
+        assert path.startswith(movies_path)
+        assert len(paths) or len(files)
 
 
 def test_server_allowMediaDeletion(account):


### PR DESCRIPTION
## Description

Add the ability to browse the Plex server system file directories through the Plex API. This uses the `/services/browse` endpoint when browsing to add a folder to a library.

![browse](https://i.imgur.com/rx5u6Q5.png)

## New methods

#### `plexapi.server.PlexServer.browse(path)`

- Browse the system file path using the Plex API.

#### Example

```python
from plexapi.server import PlexServer
plex = PlexServer('http://localhost:32400', token='xxxxxxxxxxxxxxxxxxxx')

# List all folders and files in a single path
print(plex.browse('/media/Movies'))
```

#### `plexapi.server.PlexServer.walk(path)`

- Walk the system file tree using the Plex API similar to `os.walk`.

#### Example

```py
from plexapi.server import PlexServer
plex = PlexServer('http://localhost:32400', token='xxxxxxxxxxxxxxxxxxxx')

# Walk through all folders and files in the library locations
for location in plex.library.section('Movies').locations:
    for root, folders, files in plex.walk(location):
        print(root, folders, files)
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
