### PR TITLE
Use Github Actions as CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,13 +33,13 @@ jobs:
       with:
         path: venv
         key: >-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
           steps.python.outputs.python-version }}-${{
           hashFiles('requirements_dev.txt') }}
         restore-keys: |
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
 
-    - name: Create Python ${{ env.DEFAULT_PYTHON}} virtual environment
+    - name: Create Python virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv
@@ -85,19 +85,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
+    - name: Restore Python ${{ matrix.python-version }} virtual environment
       id: cache-venv
       uses: actions/cache@v2
       with:
         path: venv
         key: >-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
           steps.python.outputs.python-version }}-${{
           hashFiles('requirements_dev.txt') }}
         restore-keys: |
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
 
-    - name: Create Python ${{ matrix.python-version }} virtual environment
+    - name: Create Python virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,8 @@ jobs:
         # The GitHub editor is 127 chars wide
         flake8 plexapi --count --max-complexity=12 --max-line-length=127 --statistics
 
-  pytest:
+  pytest-unclaimed:
+    name: pytest (unclaimed)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,6 +61,7 @@ jobs:
         PLEXAPI_HEADER_PLATFORM: iOS
         PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
         PLEXAPI_HEADER_DEVICE: iPhone
+        TEST_ACCOUNT_ONCE: 1
       run: |
         # Set up docker PMS instance
         python \
@@ -69,6 +71,61 @@ jobs:
           --bootstrap-timeout 540 \
           --docker-tag ${{ env.PLEX_CONTAINER_TAG }} \
           --unclaimed
+        # Run main tests
+        pytest \
+          -rxXs \
+          --ignore=tests/test_sync.py \
+          --tb=native \
+          --verbose \
+          --cov-config .coveragerc \
+          --cov=plexapi \
+          tests 
+        # Run sync tests
+        pytest \
+          -rxXs \
+          --tb=native \
+          --verbose \
+          --cov-config .coveragerc \
+          --cov=plexapi \
+          --cov-append \
+          tests/test_sync.py
+
+
+  pytest-claimed:
+    name: pytest (claimed)
+    runs-on: ubuntu-latest
+    env:
+      PLEXAPI_AUTH_MYPLEX_USERNAME: ''
+    strategy:
+      matrix:
+#        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install -U pip
+        pip install -r requirements_dev.txt
+        pip install -e .
+    - name: Test with claimed Plex server
+      env:
+        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
+        PLEXAPI_HEADER_PLATFORM: iOS
+        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
+        PLEXAPI_HEADER_DEVICE: iPhone
+      run: |
+        # Set up docker PMS instance
+        python \
+          -u tools/plex-bootstraptest.py \
+          --destination plex \
+          --advertise-ip=127.0.0.1 \
+          --bootstrap-timeout 540 \
+          --docker-tag ${{ env.PLEX_CONTAINER_TAG }}
         # Run main tests
         pytest \
           -rxXs \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,9 @@ name: CI
 
 on:
   push:
+    branches: [ $default-branch ]
   pull_request:
+    branches: [ $default-branch ]
 
 env:
   DEFAULT_PYTHON: 3.7
@@ -145,6 +147,8 @@ jobs:
           --cov=plexapi \
           --cov-append \
           tests/test_sync.py
+    - name: Unlink PMS from MyPlex account
+      run: python -u tools/plex-teardowntest.py
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,14 @@ on:
 
 env:
   DEFAULT_PYTHON: 3.7
-  PLEXAPI_AUTH_SERVER_BASEURL: http://127.0.0.1:32400
-  PLEX_CONTAINER_TAG: latest
 
 jobs:
   lint-flake8:
     name: Check flake8
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out code from Github
+      uses: actions/checkout@v2
 
     - name: Set up Python ${{ env.DEFAULT_PYTHON }}
       uses: actions/setup-python@v2
@@ -30,8 +29,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
-        restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
+        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-flake8
 
     - name: Install dependencies
       run: |
@@ -51,7 +49,8 @@ jobs:
     needs: lint-flake8
     runs-on: ubuntu-latest
     env:
-      TEST_ACCOUNT_ONCE: 1
+      PLEXAPI_AUTH_SERVER_BASEURL: http://127.0.0.1:32400
+      PLEX_CONTAINER_TAG: latest
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +62,8 @@ jobs:
           - is-master: false
             plex: claimed
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out code from Github
+      uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -75,7 +75,7 @@ jobs:
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements_dev.txt') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip
+        restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip-
 
     - name: Install dependencies
       run: |
@@ -86,7 +86,7 @@ jobs:
     - name: Set Plex credentials
       if: matrix.plex == 'claimed'
       run: |
-        echo "PLEXAPI_AUTH_MYPLEX_USERNAME=${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}" > $GITHUB_ENV
+        echo "PLEXAPI_AUTH_MYPLEX_USERNAME=${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}" >> $GITHUB_ENV
         echo "PLEXAPI_AUTH_MYPLEX_PASSWORD=${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}" >> $GITHUB_ENV
 
     - name: Bootstrap ${{ matrix.plex }} Plex server
@@ -142,6 +142,7 @@ jobs:
     name: Process test coverage
     runs-on: ubuntu-latest
     needs: pytest
+    if: always()
     steps:
     - name: Check out code from GitHub
       uses: actions/checkout@v2
@@ -150,8 +151,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
-        restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
+        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-coverage
 
     - name: Set up Python ${{ env.DEFAULT_PYTHON }}
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,7 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
   pull_request:
-    branches: [ $default-branch ]
 
 env:
   DEFAULT_PYTHON: 3.7
@@ -40,6 +38,8 @@ jobs:
     name: pytest ${{ matrix.python-version }} (unclaimed)
     needs: lint-flake8
     runs-on: ubuntu-latest
+    env:
+      TEST_ACCOUNT_ONCE: 1
     strategy:
       matrix:
         python-version: [3.6]
@@ -54,15 +54,8 @@ jobs:
         pip install -U pip
         pip install -r requirements_dev.txt
         pip install -e .
-    - name: Test with unclaimed Plex server
-      env:
-        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
-        PLEXAPI_HEADER_PLATFORM: iOS
-        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
-        PLEXAPI_HEADER_DEVICE: iPhone
-        TEST_ACCOUNT_ONCE: 1
+    - name: Bootstrap Plex server
       run: |
-        # Set up docker PMS instance
         python \
           -u tools/plex-bootstraptest.py \
           --destination plex \
@@ -70,31 +63,43 @@ jobs:
           --bootstrap-timeout 540 \
           --docker-tag ${{ env.PLEX_CONTAINER_TAG }} \
           --unclaimed
-        # Run main tests
+    - name: Main tests with unclaimed server
+      run: |
         pytest \
           -rxXs \
           --ignore=tests/test_sync.py \
           --tb=native \
           --verbose \
-          --cov-config .coveragerc \
           --cov=plexapi \
           tests 
-        # Run sync tests
+    - name: Sync tests with unclaimed server
+      env:
+        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
+        PLEXAPI_HEADER_PLATFORM: iOS
+        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
+        PLEXAPI_HEADER_DEVICE: iPhone
+      run: |
         pytest \
           -rxXs \
           --tb=native \
           --verbose \
-          --cov-config .coveragerc \
           --cov=plexapi \
           --cov-append \
           tests/test_sync.py
-
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-${{ matrix.python-version }}-unclaimed
+        path: .coverage
 
   pytest-claimed:
     name: pytest (claimed)
     needs: pytest-unclaimed
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    env:
+      PLEXAPI_AUTH_MYPLEX_USERNAME: ${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}
+      PLEXAPI_AUTH_MYPLEX_PASSWORD: ${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}
     strategy:
       matrix:
         python-version: [3.6]
@@ -109,37 +114,67 @@ jobs:
         pip install -U pip
         pip install -r requirements_dev.txt
         pip install -e .
-    - name: Test with claimed Plex server
-      env:
-        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
-        PLEXAPI_HEADER_PLATFORM: iOS
-        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
-        PLEXAPI_HEADER_DEVICE: iPhone
-        PLEXAPI_AUTH_MYPLEX_USERNAME: ${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}
-        PLEXAPI_AUTH_MYPLEX_PASSWORD: ${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}
+    - name: Bootstrap Plex server
       run: |
-        # Set up docker PMS instance
         python \
           -u tools/plex-bootstraptest.py \
           --destination plex \
           --advertise-ip=127.0.0.1 \
           --bootstrap-timeout 540 \
           --docker-tag ${{ env.PLEX_CONTAINER_TAG }}
-        # Run main tests
+    - name: Test with claimed Plex server
+      run: |
         pytest \
           -rxXs \
           --ignore=tests/test_sync.py \
           --tb=native \
           --verbose \
-          --cov-config .coveragerc \
           --cov=plexapi \
           tests 
-        # Run sync tests
+    - name: Test with claimed Plex server
+      env:
+        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
+        PLEXAPI_HEADER_PLATFORM: iOS
+        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
+        PLEXAPI_HEADER_DEVICE: iPhone
+      run: |
         pytest \
           -rxXs \
           --tb=native \
           --verbose \
-          --cov-config .coveragerc \
           --cov=plexapi \
           --cov-append \
           tests/test_sync.py
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-${{ matrix.python-version }}-claimed
+        path: .coverage
+
+  coverage:
+    name: Process test coverage
+    runs-on: ubuntu-latest
+    needs: pytest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install coverage
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v2
+      - name: Combine coverage results
+        run: |
+          coverage combine coverage*/.coverage*
+          coverage report --fail-under=50
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,9 +183,9 @@ jobs:
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
-      path: ~/.cache/pip
-      key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
-      restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
+        restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
     - name: Set up Python ${{ env.DEFAULT_PYTHON }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,12 +37,11 @@ jobs:
         flake8 plexapi --count --max-complexity=12 --max-line-length=127 --statistics
 
   pytest-unclaimed:
-    name: pytest (unclaimed)
+    name: pytest ${{ matrix.pytest-version }} (unclaimed)
     needs: lint-flake8
     runs-on: ubuntu-latest
     strategy:
       matrix:
-#        python-version: [3.5, 3.6, 3.7, 3.8]
         python-version: [3.6]
 
     steps:
@@ -93,12 +92,12 @@ jobs:
 
 
   pytest-claimed:
-    name: pytest (claimed)
+    name: pytest ${{ matrix.python-version }} (claimed)
     needs: pytest-unclaimed
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-#        python-version: [3.5, 3.6, 3.7, 3.8]
         python-version: [3.6]
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,33 @@ on:
 #    branches: [ $default-branch ]
 
 env:
+  DEFAULT_PYTHON: 3.7
   PLEXAPI_AUTH_SERVER_BASEURL: http://127.0.0.1:32400
   PLEX_CONTAINER_TAG: latest
 
 jobs:
-  build:
+  lint-flake8:
+    name: Check flake8
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.DEFAULT_PYTHON }}
+    - name: Install dependencies
+      run: |
+        pip install -U pip
+        pip install -r requirements_dev.txt
+        pip install -e .
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # The GitHub editor is 127 chars wide
+        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
 
+  pytest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,16 +51,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+        pip install -U pip
+        pip install -r requirements_dev.txt
         pip install -e .
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unclaimed Plex server
       env:
         PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
     branches: [ $default-branch ]
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 0
   DEFAULT_PYTHON: 3.7
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,26 +85,11 @@ jobs:
           --verbose \
           --cov=plexapi \
           tests 
-    - name: Sync tests with unclaimed server
-      env:
-        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
-        PLEXAPI_HEADER_PLATFORM: iOS
-        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
-        PLEXAPI_HEADER_DEVICE: iPhone
-      run: |
-        pytest \
-          -rxXs \
-          --tb=native \
-          --verbose \
-          --cov=plexapi \
-          --cov-append \
-          tests/test_sync.py
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
       with:
         name: coverage-unclaimed-${{ matrix.python-version }}
         path: .coverage
-
 
   pytest-claimed:
     name: pytest ${{ matrix.python-version }} (claimed)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ $default-branch, add_github_actions ]
   pull_request:
     branches: [ $default-branch ]
 
@@ -20,15 +20,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.DEFAULT_PYTHON }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
+        restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
     - name: Install dependencies
       run: |
         pip install -U pip
-        pip install -r requirements_dev.txt
-        pip install -e .
+        pip install flake8
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -44,13 +49,19 @@ jobs:
       TEST_ACCOUNT_ONCE: 1
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements_dev.txt') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip
     - name: Install dependencies
       run: |
         pip install -U pip
@@ -91,32 +102,39 @@ jobs:
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
       with:
-        name: coverage-${{ matrix.python-version }}-unclaimed
+        name: coverage-unclaimed-${{ matrix.python-version }}
         path: .coverage
 
+
   pytest-claimed:
-    name: pytest (claimed)
+    name: pytest ${{ matrix.python-version }} (claimed)
+    runs-on: ubuntu-latest
     needs: pytest-unclaimed
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
     env:
       PLEXAPI_AUTH_MYPLEX_USERNAME: ${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}
       PLEXAPI_AUTH_MYPLEX_PASSWORD: ${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements_dev.txt') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip
     - name: Install dependencies
       run: |
         pip install -U pip
         pip install -r requirements_dev.txt
         pip install -e .
-    - name: Bootstrap Plex server
+    - name: Bootstrap claimed Plex server
       run: |
         python \
           -u tools/plex-bootstraptest.py \
@@ -124,7 +142,7 @@ jobs:
           --advertise-ip=127.0.0.1 \
           --bootstrap-timeout 540 \
           --docker-tag ${{ env.PLEX_CONTAINER_TAG }}
-    - name: Test with claimed Plex server
+    - name: Main tests with claimed Plex server
       run: |
         pytest \
           -rxXs \
@@ -133,7 +151,7 @@ jobs:
           --verbose \
           --cov=plexapi \
           tests 
-    - name: Test with claimed Plex server
+    - name: Sync tests with claimed Plex server
       env:
         PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
         PLEXAPI_HEADER_PLATFORM: iOS
@@ -152,33 +170,36 @@ jobs:
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
       with:
-        name: coverage-${{ matrix.python-version }}-claimed
+        name: coverage-claimed-${{ matrix.python-version }}
         path: .coverage
 
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest
     needs: pytest-unclaimed
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          pip install -U pip
-          pip install coverage
-      - name: Download all coverage artifacts
-        uses: actions/download-artifact@v2
-      - name: Combine coverage results
-        run: |
-          coverage combine coverage*/.coverage*
-          coverage report --fail-under=50
-          coverage xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+    - name: Check out code from GitHub
+      uses: actions/checkout@v2
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+      path: ~/.cache/pip
+      key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
+      restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
+    - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.DEFAULT_PYTHON }}
+    - name: Install dependencies
+      run: |
+        pip install -U pip
+        pip install coverage
+    - name: Download all coverage artifacts
+      uses: actions/download-artifact@v2
+    - name: Combine coverage results
+      run: |
+        coverage combine coverage*/.coverage*
+        coverage report --fail-under=50
+        coverage xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,15 +41,22 @@ jobs:
         # The GitHub editor is 127 chars wide
         flake8 plexapi --count --max-complexity=12 --max-line-length=127 --statistics
 
-  pytest-unclaimed:
-    name: pytest ${{ matrix.python-version }} (unclaimed)
+  pytest:
+    name: pytest (${{ matrix.python-version }}-${{ matrix.plex }})
     needs: lint-flake8
     runs-on: ubuntu-latest
     env:
       TEST_ACCOUNT_ONCE: 1
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7]
+        plex: ['unclaimed', 'claimed']
+        is-master:
+          - ${{ github.ref == 'refs/heads/master' }}
+        exclude:
+          - is-master: false
+            plex: claimed
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -67,7 +74,12 @@ jobs:
         pip install -U pip
         pip install -r requirements_dev.txt
         pip install -e .
-    - name: Bootstrap Plex server
+    - name: Set Plex credentials
+      if: matrix.plex == 'claimed'
+      run: |
+        echo "PLEXAPI_AUTH_MYPLEX_USERNAME=${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}" > $GITHUB_ENV
+        echo "PLEXAPI_AUTH_MYPLEX_PASSWORD=${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}" >> $GITHUB_ENV
+    - name: Bootstrap Plex server (${{ matrix.plex }})
       run: |
         python \
           -u tools/plex-bootstraptest.py \
@@ -75,8 +87,10 @@ jobs:
           --advertise-ip=127.0.0.1 \
           --bootstrap-timeout 540 \
           --docker-tag ${{ env.PLEX_CONTAINER_TAG }} \
-          --unclaimed
-    - name: Main tests with unclaimed server
+          --${{ matrix.plex }}
+    - name: Main tests with ${{ matrix.plex }} server
+      env:
+        TEST_ACCOUNT_ONCE: ${{ matrix.plex == 'unclaimed' }}
       run: |
         pytest \
           -rxXs \
@@ -85,58 +99,8 @@ jobs:
           --verbose \
           --cov=plexapi \
           tests 
-    - name: Upload coverage artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: coverage-unclaimed-${{ matrix.python-version }}
-        path: .coverage
-
-  pytest-claimed:
-    name: pytest ${{ matrix.python-version }} (claimed)
-    runs-on: ubuntu-latest
-    needs: pytest-unclaimed
-    if: github.ref == 'refs/heads/master'
-    env:
-      PLEXAPI_AUTH_MYPLEX_USERNAME: ${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}
-      PLEXAPI_AUTH_MYPLEX_PASSWORD: ${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements_dev.txt') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install -r requirements_dev.txt
-        pip install -e .
-    - name: Bootstrap claimed Plex server
-      run: |
-        python \
-          -u tools/plex-bootstraptest.py \
-          --destination plex \
-          --advertise-ip=127.0.0.1 \
-          --bootstrap-timeout 540 \
-          --docker-tag ${{ env.PLEX_CONTAINER_TAG }}
-    - name: Main tests with claimed Plex server
-      run: |
-        pytest \
-          -rxXs \
-          --ignore=tests/test_sync.py \
-          --tb=native \
-          --verbose \
-          --cov=plexapi \
-          tests 
-    - name: Sync tests with claimed Plex server
+    - name: Sync tests with ${{ matrix.plex }} server
+      if: matrix.plex == 'claimed'
       env:
         PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
         PLEXAPI_HEADER_PLATFORM: iOS
@@ -151,17 +115,18 @@ jobs:
           --cov-append \
           tests/test_sync.py
     - name: Unlink PMS from MyPlex account
+      if: matrix.plex == 'claimed' && always()
       run: python -u tools/plex-teardowntest.py
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
       with:
-        name: coverage-claimed-${{ matrix.python-version }}
+        name: coverage-${{ matrix.plex }}-${{ matrix.python-version }}
         path: .coverage
 
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest
-    needs: pytest-unclaimed
+    needs: pytest
     steps:
     - name: Check out code from GitHub
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
     branches: [ $default-branch ]
 
 env:
+  CACHE_VERSION: 1
   DEFAULT_PYTHON: 3.7
 
 jobs:
@@ -57,6 +58,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+      id: python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ on:
 #    branches: [ $default-branch ]
 
 env:
-  PLEXAPI_AUTH_SERVER_BASEURL=http://127.0.0.1:32400
-  PLEX_CONTAINER_TAG=latest
+  PLEXAPI_AUTH_SERVER_BASEURL: http://127.0.0.1:32400
+  PLEX_CONTAINER_TAG: latest
 
 jobs:
   build:
@@ -41,10 +41,10 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unclaimed Plex server
       env:
-        PLEXAPI_HEADER_PROVIDES='controller,sync-target'
-        PLEXAPI_HEADER_PLATFORM=iOS
-        PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1
-        PLEXAPI_HEADER_DEVICE=iPhone
+        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
+        PLEXAPI_HEADER_PLATFORM: iOS
+        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
+        PLEXAPI_HEADER_DEVICE: iPhone
       run: |
         # Set up docker PMS instance
         python \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,8 @@ jobs:
         PLEXAPI_HEADER_PLATFORM: iOS
         PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
         PLEXAPI_HEADER_DEVICE: iPhone
+        PLEXAPI_AUTH_MYPLEX_USERNAME: ${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}
+        PLEXAPI_AUTH_MYPLEX_PASSWORD: ${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}
       run: |
         # Set up docker PMS instance
         python \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -99,7 +98,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,7 @@ jobs:
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest
-    needs: pytest
+    needs: pytest-unclaimed
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,20 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ env.DEFAULT_PYTHON }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}
+
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
         restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
+
     - name: Install dependencies
       run: |
         pip install -U pip
         pip install flake8
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -41,8 +45,9 @@ jobs:
         # The GitHub editor is 127 chars wide
         flake8 plexapi --count --max-complexity=12 --max-line-length=127 --statistics
 
+
   pytest:
-    name: pytest (${{ matrix.python-version }}-${{ matrix.plex }})
+    name: pytest ${{ matrix.python-version }} (${{ matrix.plex }})
     needs: lint-flake8
     runs-on: ubuntu-latest
     env:
@@ -50,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         plex: ['unclaimed', 'claimed']
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
@@ -59,27 +64,32 @@ jobs:
             plex: claimed
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements_dev.txt') }}
         restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip
+
     - name: Install dependencies
       run: |
         pip install -U pip
         pip install -r requirements_dev.txt
         pip install -e .
+
     - name: Set Plex credentials
       if: matrix.plex == 'claimed'
       run: |
         echo "PLEXAPI_AUTH_MYPLEX_USERNAME=${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}" > $GITHUB_ENV
         echo "PLEXAPI_AUTH_MYPLEX_PASSWORD=${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}" >> $GITHUB_ENV
-    - name: Bootstrap Plex server (${{ matrix.plex }})
+
+    - name: Bootstrap ${{ matrix.plex }} Plex server
       run: |
         python \
           -u tools/plex-bootstraptest.py \
@@ -88,6 +98,7 @@ jobs:
           --bootstrap-timeout 540 \
           --docker-tag ${{ env.PLEX_CONTAINER_TAG }} \
           --${{ matrix.plex }}
+
     - name: Main tests with ${{ matrix.plex }} server
       env:
         TEST_ACCOUNT_ONCE: ${{ matrix.plex == 'unclaimed' }}
@@ -99,6 +110,7 @@ jobs:
           --verbose \
           --cov=plexapi \
           tests 
+
     - name: Sync tests with ${{ matrix.plex }} server
       if: matrix.plex == 'claimed'
       env:
@@ -114,14 +126,17 @@ jobs:
           --cov=plexapi \
           --cov-append \
           tests/test_sync.py
+
     - name: Unlink PMS from MyPlex account
       if: matrix.plex == 'claimed' && always()
       run: python -u tools/plex-teardowntest.py
+
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
       with:
         name: coverage-${{ matrix.plex }}-${{ matrix.python-version }}
         path: .coverage
+
 
   coverage:
     name: Process test coverage
@@ -130,26 +145,32 @@ jobs:
     steps:
     - name: Check out code from GitHub
       uses: actions/checkout@v2
+
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-${{ hashFiles('requirements_dev.txt') }}
         restore-keys: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip
+
     - name: Set up Python ${{ env.DEFAULT_PYTHON }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}
+
     - name: Install dependencies
       run: |
         pip install -U pip
         pip install coverage
+
     - name: Download all coverage artifacts
       uses: actions/download-artifact@v2
+
     - name: Combine coverage results
       run: |
         coverage combine coverage*/.coverage*
         coverage report --fail-under=50
         coverage xml
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-#    branches: [ $default-branch ]
-#  pull_request:
-#    branches: [ $default-branch ]
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
 
 env:
   DEFAULT_PYTHON: 3.7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,41 +14,6 @@ env:
   DEFAULT_PYTHON: 3.7
 
 jobs:
-  prepare-venv:
-    name: Prepare Python ${{ matrix.python-version }} virtual environment
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-    steps:
-    - name: Check out code from GitHub
-      uses: actions/checkout@v2
-
-    - name: Set up Python ${{ matrix.python-version }}
-      id: python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Restore Python virtual environment
-      id: cache-venv
-      uses: actions/cache@v2
-      with:
-        path: venv
-        key: ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements_dev.txt') }}
-        restore-keys: |
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-
-    - name: Create Python virtual environment
-      if: steps.cache-venv.outputs.cache-hit != 'true'
-      run: |
-        python -m venv venv
-        . venv/bin/activate
-        pip install -U pip
-        pip install -r requirements_dev.txt
-        pip install -e .
-
-
   lint-flake8:
     name: Check flake8
     needs: prepare-venv
@@ -75,11 +40,14 @@ jobs:
         restore-keys: |
           ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
 
-    - name: Fail job if Python cache restore failed
+    - name: Create Python ${{ env.DEFAULT_PYTHON}} virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        echo "Failed to restore Python virtual environment from cache"
-        exit 1
+        python -m venv venv
+        . venv/bin/activate
+        pip install -U pip
+        pip install -r requirements_dev.txt
+        pip install -e .
 
     - name: Lint with flake8
       run: |
@@ -130,11 +98,14 @@ jobs:
         restore-keys: |
           ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
 
-    - name: Fail job if Python cache restore failed
+    - name: Create Python ${{ matrix.python-version }} virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        echo "Failed to restore Python virtual environment from cache"
-        exit 1
+        python -m venv venv
+        . venv/bin/activate
+        pip install -U pip
+        pip install -r requirements_dev.txt
+        pip install -e .
 
     - name: Get PMS Docker image digest
       id: docker-digest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
           -rxXs \
           --ignore=tests/test_sync.py \
           --tb=native \
-          --verbose 
+          --verbose \
           --cov-config .coveragerc \
           --cov=plexapi \
           tests 
@@ -71,5 +71,5 @@ jobs:
           --verbose \
           --cov-config .coveragerc \
           --cov=plexapi \
-          --cov-append
+          --cov-append \
           tests/test_sync.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
 
   pytest-unclaimed:
     name: pytest (unclaimed)
+    needs: lint-flake8
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -93,9 +94,8 @@ jobs:
 
   pytest-claimed:
     name: pytest (claimed)
+    needs: pytest-unclaimed
     runs-on: ubuntu-latest
-    env:
-      PLEXAPI_AUTH_MYPLEX_USERNAME: ''
     strategy:
       matrix:
 #        python-version: [3.5, 3.6, 3.7, 3.8]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 plexapi --count --select=E9,F63,F7,F82 --show-source --statistics
         # The GitHub editor is 127 chars wide
-        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+        flake8 plexapi --count --max-complexity=10 --max-line-length=127 --statistics
 
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         flake8 plexapi --count --max-complexity=12 --max-line-length=127 --statistics
 
   pytest-unclaimed:
-    name: pytest ${{ matrix.pytest-version }} (unclaimed)
+    name: pytest ${{ matrix.python-version }} (unclaimed)
     needs: lint-flake8
     runs-on: ubuntu-latest
     strategy:
@@ -92,7 +92,7 @@ jobs:
 
 
   pytest-claimed:
-    name: pytest ${{ matrix.python-version }} (claimed)
+    name: pytest (claimed)
     needs: pytest-unclaimed
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,11 +81,9 @@ jobs:
         echo "Failed to restore Python virtual environment from cache"
         exit 1
 
-    - name: Activate Python ${{ env.DEFAULT_PYTHON }} virtual environment
-      run: . venv/bin/activate
-
     - name: Lint with flake8
       run: |
+        . venv/bin/activate
         # stop the build if there are Python syntax errors or undefined names
         flake8 plexapi --count --select=E9,F63,F7,F82 --show-source --statistics
         # The GitHub editor is 127 chars wide
@@ -138,9 +136,6 @@ jobs:
         echo "Failed to restore Python virtual environment from cache"
         exit 1
 
-    - name: Activate Python ${{ matrix.python-version }} virtual environment
-      run: . venv/bin/activate
-
     - name: Get PMS Docker image digest
       id: docker-digest
       run: |
@@ -187,6 +182,7 @@ jobs:
 
     - name: Bootstrap ${{ matrix.plex }} Plex server
       run: |
+        . venv/bin/activate
         python \
           -u tools/plex-bootstraptest.py \
           --destination plex \
@@ -199,6 +195,7 @@ jobs:
       env:
         TEST_ACCOUNT_ONCE: ${{ matrix.plex == 'unclaimed' }}
       run: |
+        . venv/bin/activate
         pytest \
           -rxXs \
           --ignore=tests/test_sync.py \
@@ -215,6 +212,7 @@ jobs:
         PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
         PLEXAPI_HEADER_DEVICE: iPhone
       run: |
+        . venv/bin/activate
         pytest \
           -rxXs \
           --tb=native \
@@ -225,7 +223,9 @@ jobs:
 
     - name: Unlink PMS from MyPlex account
       if: matrix.plex == 'claimed' && always()
-      run: python -u tools/plex-teardowntest.py
+      run: |
+        . venv/bin/activate
+        python -u tools/plex-teardowntest.py
 
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
@@ -267,14 +267,12 @@ jobs:
         echo "Failed to restore Python virtual environment from cache"
         exit 1
 
-    - name: Activate Python ${{ env.DEFAULT_PYTHON }} virtual environment
-      run: . venv/bin/activate
-
     - name: Download all coverage artifacts
       uses: actions/download-artifact@v2
 
     - name: Combine coverage results
       run: |
+        . venv/bin/activate
         coverage combine coverage*/.coverage*
         coverage report --fail-under=50
         coverage xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
+#    branches: [ $default-branch ]
+#  pull_request:
+#    branches: [ $default-branch ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           --destination plex \
           --advertise-ip=127.0.0.1 \
           --bootstrap-timeout 540 \
-          --docker-tag {{ $env.PLEX_CONTAINER_TAG }} \
+          --docker-tag {{ env.PLEX_CONTAINER_TAG }} \
           --unclaimed
         # Run main tests
         pytest \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,13 +9,18 @@ on:
 #  pull_request:
 #    branches: [ $default-branch ]
 
+env:
+  PLEXAPI_AUTH_SERVER_BASEURL=http://127.0.0.1:32400
+  PLEX_CONTAINER_TAG=latest
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+#        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6]
 
     steps:
     - uses: actions/checkout@v2
@@ -34,6 +39,36 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with unclaimed Plex server
+      env:
+        PLEXAPI_HEADER_PROVIDES='controller,sync-target'
+        PLEXAPI_HEADER_PLATFORM=iOS
+        PLEXAPI_HEADER_PLATFORM_VERSION=11.4.1
+        PLEXAPI_HEADER_DEVICE=iPhone
       run: |
-        pytest
+        # Set up docker PMS instance
+        python \
+          -u tools/plex-bootstraptest.py \
+          --destination plex \
+          --advertise-ip=127.0.0.1 \
+          --bootstrap-timeout 540 \
+          --docker-tag {{ $env.PLEX_CONTAINER_TAG }} \
+          --unclaimed
+        # Run main tests
+        pytest \
+          -rxXs \
+          --ignore=tests/test_sync.py \
+          --tb=native \
+          --verbose 
+          --cov-config .coveragerc \
+          --cov=plexapi \
+          tests 
+        # Run sync tests
+        pytest \
+          -rxXs \
+          --tb=native \
+          --verbose \
+          --cov-config .coveragerc \
+          --cov=plexapi \
+          --cov-append
+          tests/test_sync.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           --destination plex \
           --advertise-ip=127.0.0.1 \
           --bootstrap-timeout 540 \
-          --docker-tag {{ env.PLEX_CONTAINER_TAG }} \
+          --docker-tag ${{ env.PLEX_CONTAINER_TAG }} \
           --unclaimed
         # Run main tests
         pytest \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,9 @@ jobs:
         echo "Failed to restore Python virtual environment from cache"
         exit 1
 
+    - name: Activate Python ${{ env.DEFAULT_PYTHON }} virtual environment
+      run: . venv/bin/activate
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -134,6 +137,9 @@ jobs:
       run: |
         echo "Failed to restore Python virtual environment from cache"
         exit 1
+
+    - name: Activate Python ${{ matrix.python-version }} virtual environment
+      run: . venv/bin/activate
 
     - name: Get PMS Docker image digest
       id: docker-digest
@@ -260,6 +266,9 @@ jobs:
       run: |
         echo "Failed to restore Python virtual environment from cache"
         exit 1
+
+    - name: Activate Python ${{ env.DEFAULT_PYTHON }} virtual environment
+      run: . venv/bin/activate
 
     - name: Download all coverage artifacts
       uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,12 +5,12 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch, add_github_actions ]
+    branches: [ $default-branch ]
   pull_request:
     branches: [ $default-branch ]
 
 env:
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
   DEFAULT_PYTHON: 3.7
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PLEXAPI_AUTH_SERVER_BASEURL: http://127.0.0.1:32400
+      PLEX_CONTAINER: plexinc/pms-docker
       PLEX_CONTAINER_TAG: latest
     strategy:
       fail-fast: false
@@ -83,6 +84,44 @@ jobs:
         pip install -r requirements_dev.txt
         pip install -e .
 
+    - name: Get PMS Docker image digest
+      id: docker-digest
+      run: |
+        mkdir -p ~/.cache/docker/${{ env.PLEX_CONTAINER }}
+        echo "Image: ${{ env.PLEX_CONTAINER }}"
+        echo "Tag: ${{ env.PLEX_CONTAINER_TAG }}"
+        token=$(curl \
+          --silent \
+          "https://auth.docker.io/token?scope=repository:${{ env.PLEX_CONTAINER }}:pull&service=registry.docker.io" \
+          | jq -r '.token')
+        digest=$(curl \
+          --silent \
+          --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+          --header "Authorization: Bearer $token" \
+          "https://registry-1.docker.io/v2/${{ env.PLEX_CONTAINER }}/manifests/${{ env.PLEX_CONTAINER_TAG }}" \
+          | jq -r '.config.digest')
+        echo "Digest: $digest"
+        echo ::set-output name=digest::$digest
+
+    - name: Cache PMS Docker image
+      id: docker-cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/docker/plexinc
+        key: ${{ runner.os }}-docker-pms-${{ steps.docker-digest.outputs.digest }}
+
+    - name: Pull PMS Docker image
+      if: steps.docker-cache.outputs.cache-hit != 'true'
+      run: |
+        docker pull ${{ env.PLEX_CONTAINER }}:${{ env.PLEX_CONTAINER_TAG }}
+        docker save -o ~/.cache/docker/${{ env.PLEX_CONTAINER }}-${{ env.PLEX_CONTAINER_TAG }}.tar ${{ env.PLEX_CONTAINER }}:${{ env.PLEX_CONTAINER_TAG }}
+        echo "Saved image: ${{ env.PLEX_CONTAINER }}:${{ env.PLEX_CONTAINER_TAG }}"
+
+    - name: Load PMS Docker image
+      if: steps.docker-cache.outputs.cache-hit == 'true'
+      run: |
+        docker load -i ~/.cache/docker/${{ env.PLEX_CONTAINER }}-${{ env.PLEX_CONTAINER_TAG }}.tar
+
     - name: Set Plex credentials
       if: matrix.plex == 'claimed'
       run: |
@@ -94,7 +133,7 @@ jobs:
         python \
           -u tools/plex-bootstraptest.py \
           --destination plex \
-          --advertise-ip=127.0.0.1 \
+          --advertise-ip 127.0.0.1 \
           --bootstrap-timeout 540 \
           --docker-tag ${{ env.PLEX_CONTAINER_TAG }} \
           --${{ matrix.plex }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,44 @@ env:
   DEFAULT_PYTHON: 3.7
 
 jobs:
+  prepare-venv:
+    name: Prepare Python ${{ matrix.python-version }} virtual environment
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - name: Check out code from GitHub
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      id: python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Restore Python virtual environment
+      id: cache-venv
+      uses: actions/cache@v2
+      with:
+        path: venv
+        key: ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-${{ hashFiles('requirements_dev.txt') }}
+        restore-keys: |
+          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
+
+    - name: Create Python virtual environment
+      if: steps.cache-venv.outputs.cache-hit != 'true'
+      run: |
+        python -m venv venv
+        . venv/bin/activate
+        pip install -U pip
+        pip install -r requirements_dev.txt
+        pip install -e .
+
+
   lint-flake8:
     name: Check flake8
+    needs: prepare-venv
     runs-on: ubuntu-latest
     steps:
     - name: Check out code from Github
@@ -25,16 +61,23 @@ jobs:
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}
 
-    - name: Cache dependencies
+    - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
+      id: cache-venv
       uses: actions/cache@v2
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-flake8
+        path: venv
+        key: >-
+          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+          steps.python.outputs.python-version }}-${{
+          hashFiles('requirements_dev.txt') }}
+        restore-keys: |
+          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
 
-    - name: Install dependencies
+    - name: Fail job if Python cache restore failed
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        pip install -U pip
-        pip install flake8
+        echo "Failed to restore Python virtual environment from cache"
+        exit 1
 
     - name: Lint with flake8
       run: |
@@ -67,22 +110,28 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
+      id: python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Cache dependencies
+    - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
+      id: cache-venv
       uses: actions/cache@v2
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements_dev.txt') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip-
+        path: venv
+        key: >-
+          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+          steps.python.outputs.python-version }}-${{
+          hashFiles('requirements_dev.txt') }}
+        restore-keys: |
+          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
 
-    - name: Install dependencies
+    - name: Fail job if Python cache restore failed
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        pip install -U pip
-        pip install -r requirements_dev.txt
-        pip install -e .
+        echo "Failed to restore Python virtual environment from cache"
+        exit 1
 
     - name: Get PMS Docker image digest
       id: docker-digest
@@ -186,21 +235,29 @@ jobs:
     - name: Check out code from GitHub
       uses: actions/checkout@v2
 
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-pip-coverage
-
     - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+      id: python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}
 
-    - name: Install dependencies
+    - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
+      id: cache-venv
+      uses: actions/cache@v2
+      with:
+        path: venv
+        key: >-
+          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+          steps.python.outputs.python-version }}-${{
+          hashFiles('requirements_dev.txt') }}
+        restore-keys: |
+          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
+
+    - name: Fail job if Python cache restore failed
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        pip install -U pip
-        pip install coverage
+        echo "Failed to restore Python virtual environment from cache"
+        exit 1
 
     - name: Download all coverage artifacts
       uses: actions/download-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ env:
 jobs:
   lint-flake8:
     name: Check flake8
-    needs: prepare-venv
     runs-on: ubuntu-latest
     steps:
     - name: Check out code from Github

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 plexapi --count --select=E9,F63,F7,F82 --show-source --statistics
         # The GitHub editor is 127 chars wide
-        flake8 plexapi --count --max-complexity=10 --max-line-length=127 --statistics
+        flake8 plexapi --count --max-complexity=12 --max-line-length=127 --statistics
 
   pytest:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Python-PlexAPI
     :target: http://python-plexapi.readthedocs.io/en/latest/?badge=latest
 .. image:: https://travis-ci.org/pkkid/python-plexapi.svg?branch=master
     :target: https://travis-ci.org/pkkid/python-plexapi
-.. image:: https://coveralls.io/repos/github/pkkid/python-plexapi/badge.svg?branch=master
-    :target: https://coveralls.io/github/pkkid/python-plexapi?branch=master
+.. image:: https://codecov.io/gh/pkkid/python-plexapi/branch/master/graph/badge.svg?token=fOECznuMtw
+    :target: https://codecov.io/gh/pkkid/python-plexapi
 .. image:: https://img.shields.io/github/tag/pkkid/python-plexapi.svg?label=github+release
     :target: https://github.com/pkkid/python-plexapi/releases
 .. image:: https://badge.fury.io/py/PlexAPI.svg

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,13 +14,7 @@ requests
 requests-mock
 sphinx
 sphinxcontrib-napoleon
+sphinx-rtd-theme
 tqdm
 websocket-client
 mock; python_version < '3.3'
-
-
-# Installing sphinx-rtd-theme directly from github above is used until a point release
-# above 0.4.3 is released. https://github.com/readthedocs/sphinx_rtd_theme/issues/739
-#sphinx-rtd-theme
--e git+https://github.com/readthedocs/sphinx_rtd_theme.git@feb0beb44a444f875f3369a945e6055965ee993f#egg=sphinx_rtd_theme
-

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,19 +2,18 @@
 # PlexAPI requirements to run py.test.
 # pip install -r requirements_dev.txt
 #---------------------------------------------------------
-coveralls
-flake8
-pillow
-pytest
-pytest-cache
-pytest-cov
+coveralls==2.2.0
+flake8==3.8.4
+pillow==8.0.1
+pytest==6.1.2
+pytest-cache==1.0
+pytest-cov==2.10.1
 pytest-mock<=1.11.1
-recommonmark
-requests
-requests-mock
-sphinx
-sphinxcontrib-napoleon
-sphinx-rtd-theme
-tqdm
-websocket-client
-mock; python_version < '3.3'
+recommonmark==0.6.0
+requests==2.25.0
+requests-mock==1.8.0
+sphinx==3.3.1
+sphinxcontrib-napoleon==0.7
+sphinx-rtd-theme==0.5.0
+tqdm==4.54.0
+websocket-client==0.57.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def account():
 
 @pytest.fixture(scope="session")
 def account_once(account):
-    if environ.get("TEST_ACCOUNT_ONCE") != "1" and environ.get("CI") == "true":
+    if environ.get("TEST_ACCOUNT_ONCE") not in ("1", "true") and environ.get("CI") == "true":
         pytest.skip("Do not forget to test this by providing TEST_ACCOUNT_ONCE=1")
     return account
 

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-MAX_ATTEMPTS = 180
+MAX_ATTEMPTS = 60
 
 
 def wait_for_idle_server(server):
@@ -27,7 +27,6 @@ def wait_for_metadata_processing(server):
             if tl.updateQueueSize > 0:
                 busy = True
                 print("{title}: {updateQueueSize} items left".format(title=section.title, updateQueueSize=tl.updateQueueSize))
-                print(tl._data.attrib)
         if not busy or attempts > MAX_ATTEMPTS:
             break
         time.sleep(1)

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-MAX_ATTEMPTS = 60
+MAX_ATTEMPTS = 180
 
 
 def wait_for_idle_server(server):

--- a/tests/test__prepare.py
+++ b/tests/test__prepare.py
@@ -27,6 +27,7 @@ def wait_for_metadata_processing(server):
             if tl.updateQueueSize > 0:
                 busy = True
                 print("{title}: {updateQueueSize} items left".format(title=section.title, updateQueueSize=tl.updateQueueSize))
+                print(tl._data.attrib)
         if not busy or attempts > MAX_ATTEMPTS:
             break
         time.sleep(1)

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -412,7 +412,7 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
     )  # noqa
-    opts = parser.parse_args()
+    opts, _ = parser.parse_known_args()
 
     account = get_plex_account(opts)
     path = os.path.realpath(os.path.expanduser(opts.destination))


### PR DESCRIPTION
Travis has recently introduced a new pricing model which has impacted the CI runs for free plans. I've observed CI runs for this repo queued for over an hour before executing.

This PR provides the necessary config to use Github Actions as our CI instead. An example run of this config on my fork is available here: https://github.com/jjlawren/python-plexapi/actions/runs/369388047.

A few outstanding items that need to be addressed:
- [x] Set repo env secrets for ` PLEXAPI_AUTH_MYPLEX_USERNAME` and `PLEXAPI_AUTH_MYPLEX_PASSWORD` (@pkkid)
- [x] Add teardown step to remove temporary CI PMS/client from myplex account
- [x] Add [coveralls.io](coveralls.io) (or [codecov.io](codecov.io)) integration
- [ ] Add an action to publish to PyPI (currently handled by Travis) (#443)
- [ ] Remove Travis configuration