### PR TITLE
Add library update path parameter

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -578,9 +578,15 @@ class LibrarySection(PlexObject):
         key = '/library/sections/%s/emptyTrash' % self.key
         self._server.query(key, method=self._server._session.put)
 
-    def update(self):
-        """ Scan this section for new media. """
+    def update(self, path=None):
+        """ Scan this section for new media.
+
+            Parameters:
+                path (str, optional): Full path to folder to scan.
+        """
         key = '/library/sections/%s/refresh' % self.key
+        if path is not None:
+            key += '?path=%s' % quote_plus(path)
         self._server.query(key)
 
     def cancelUpdate(self):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -139,6 +139,10 @@ def test_library_MovieSection_update(movies):
     movies.update()
 
 
+def test_library_MovieSection_update_path(movies):
+    movies.update(path=movies.locations[0])
+
+
 def test_library_ShowSection_all(tvshows):
     assert len(tvshows.all(title__iexact="The 100"))
 


### PR DESCRIPTION
## Description

Adds the `path` parameter for updating a library which was added in [Plex Media Server 1.20.0.3125](https://forums.plex.tv/t/plex-media-server/30447/357)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
