### PR TITLE
Fix Collections stuck as partial object after reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ syntax: glob
 .coverage
 .idea/
 .Python
+.vscode
 bin/
 build
 config.ini

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -334,9 +334,9 @@ class PlexPartialObject(PlexObject):
         """ Retruns True if this is already a full object. A full object means all attributes
             were populated from the api path representing only this item. For example, the
             search result for a movie often only contain a portion of the attributes a full
-            object (main url) for that movie contain.
+            object (main url) for that movie would contain.
         """
-        return not self.key or self.key == self._initpath
+        return not self.key or (self._details_key or self.key) == self._initpath
 
     def isPartialObject(self):
         """ Returns True if this is not a full object. """
@@ -611,14 +611,6 @@ class Playable(object):
         self.accountID = utils.cast(int, data.attrib.get('accountID'))              # history
         self.playlistItemID = utils.cast(int, data.attrib.get('playlistItemID'))    # playlist
         self.playQueueItemID = utils.cast(int, data.attrib.get('playQueueItemID'))  # playqueue
-
-    def isFullObject(self):
-        """ Retruns True if this is already a full object. A full object means all attributes
-            were populated from the api path representing only this item. For example, the
-            search result for a movie often only contain a portion of the attributes a full
-            object (main url) for that movie contain.
-        """
-        return self._details_key == self._initpath or not self.key
 
     def getStreamURL(self, **params):
         """ Returns a stream url that may be used by external applications such as VLC.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1491,7 +1491,7 @@ class Collections(PlexPartialObject):
                 collection = 'plexapi.library.Collections'
                 collection.updateMode(mode="hide")
         """
-        mode_dict = {'default': '-2',
+        mode_dict = {'default': '-1',
                      'hide': '0',
                      'hideItems': '1',
                      'showItems': '2'}

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -242,7 +242,7 @@ def test_library_editAdvanced_default(movies):
 
 
 def test_library_Collection_modeUpdate(collection):
-    mode_dict = {"default": "-2", "hide": "0", "hideItems": "1", "showItems": "2"}
+    mode_dict = {"default": "-1", "hide": "0", "hideItems": "1", "showItems": "2"}
     for key, value in mode_dict.items():
         collection.modeUpdate(key)
         collection.reload()
@@ -269,7 +269,7 @@ def test_library_Colletion_edit(collection):
     for field in collection.fields:
         if field.name == 'titleSort':
             assert collection.titleSort == 'New Title Sort'
-            assert field.locked == True
+            assert field.locked is True
     collection.edit(**{'titleSort.value': collectionTitleSort, 'titleSort.locked': 0})
 
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -909,7 +909,7 @@ def test_video_edits_locked(movie, episode):
     for field in movie.fields:
         if field.name == 'titleSort':
             assert movie.titleSort == 'New Title Sort'
-            assert field.locked == True
+            assert field.locked is True
     movie.edit(**{'titleSort.value': movieTitleSort, 'titleSort.locked': 0})
 
     episodeTitleSort = episode.titleSort
@@ -918,7 +918,7 @@ def test_video_edits_locked(movie, episode):
     for field in episode.fields:
         if field.name == 'titleSort':
             assert episode.titleSort == 'New Title Sort'
-            assert field.locked == True
+            assert field.locked is True
     episode.edit(**{'titleSort.value': episodeTitleSort, 'titleSort.locked': 0})
 
 


### PR DESCRIPTION
## Description

Fix Collections stuck as partial object after reloading.

* Removed `isFullObject()` from `Playable`.
* Check if either `_details_key` or `key` is equal to the `_initpath`.

From my testing, I don't think this breaks any existing functionality. Should there be tests added to check `isFullObject()` for all the other media types similar to movies (https://github.com/pkkid/python-plexapi/blob/master/tests/test_video.py#L66)?

Fixes #605

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
