### PR TITLE
Allow setting token env in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,8 +148,7 @@ jobs:
     - name: Set Plex credentials
       if: matrix.plex == 'claimed'
       run: |
-        echo "PLEXAPI_AUTH_MYPLEX_USERNAME=${{ secrets.PLEXAPI_AUTH_MYPLEX_USERNAME }}" >> $GITHUB_ENV
-        echo "PLEXAPI_AUTH_MYPLEX_PASSWORD=${{ secrets.PLEXAPI_AUTH_MYPLEX_PASSWORD }}" >> $GITHUB_ENV
+        echo "PLEXAPI_AUTH_SERVER_TOKEN=${{ secrets.PLEXAPI_AUTH_SERVER_TOKEN }}" >> $GITHUB_ENV
 
     - name: Bootstrap ${{ matrix.plex }} Plex server
       run: |

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -87,7 +87,7 @@ class MyPlexAccount(PlexObject):
     key = 'https://plex.tv/users/account'
 
     def __init__(self, username=None, password=None, token=None, session=None, timeout=None):
-        self._token = token or CONFIG.get('auth.myplex_token')
+        self._token = token or CONFIG.get('auth.server_token')
         self._session = session or requests.Session()
         self._sonos_cache = []
         self._sonos_cache_timestamp = 0

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -87,7 +87,7 @@ class MyPlexAccount(PlexObject):
     key = 'https://plex.tv/users/account'
 
     def __init__(self, username=None, password=None, token=None, session=None, timeout=None):
-        self._token = token
+        self._token = token or CONFIG.get('auth.myplex_token')
         self._session = session or requests.Session()
         self._sonos_cache = []
         self._sonos_cache_timestamp = 0

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -368,6 +368,10 @@ def getMyPlexAccount(opts=None):  # pragma: no cover
     if config_username and config_password:
         print('Authenticating with Plex.tv as %s..' % config_username)
         return MyPlexAccount(config_username, config_password)
+    config_token = CONFIG.get('auth.myplex_token')
+    if config_token:
+        print('Authenticating with Plex.tv with token')
+        return MyPlexAccount(token=config_token)
     # 3. Prompt for username and password on the command line
     username = input('What is your plex.tv username: ')
     password = getpass('What is your plex.tv password: ')

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -368,7 +368,7 @@ def getMyPlexAccount(opts=None):  # pragma: no cover
     if config_username and config_password:
         print('Authenticating with Plex.tv as %s..' % config_username)
         return MyPlexAccount(config_username, config_password)
-    config_token = CONFIG.get('auth.myplex_token')
+    config_token = CONFIG.get('auth.server_token')
     if config_token:
         print('Authenticating with Plex.tv with token')
         return MyPlexAccount(token=config_token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ except ImportError:
 SERVER_BASEURL = plexapi.CONFIG.get("auth.server_baseurl")
 MYPLEX_USERNAME = plexapi.CONFIG.get("auth.myplex_username")
 MYPLEX_PASSWORD = plexapi.CONFIG.get("auth.myplex_password")
+MYPLEX_TOKEN = plexapi.CONFIG.get("auth.myplex_token")
 CLIENT_BASEURL = plexapi.CONFIG.get("auth.client_baseurl")
 CLIENT_TOKEN = plexapi.CONFIG.get("auth.client_token")
 
@@ -76,15 +77,15 @@ def pytest_runtest_setup(item):
     if "client" in item.keywords and not item.config.getvalue("client"):
         return pytest.skip("Need --client option to run.")
     if TEST_AUTHENTICATED in item.keywords and not (
-        MYPLEX_USERNAME and MYPLEX_PASSWORD
+        MYPLEX_USERNAME and MYPLEX_PASSWORD or MYPLEX_TOKEN
     ):
         return pytest.skip(
-            "You have to specify MYPLEX_USERNAME and MYPLEX_PASSWORD to run authenticated tests"
+            "You have to specify MYPLEX_USERNAME and MYPLEX_PASSWORD or MYPLEX_TOKEN to run authenticated tests"
         )
-    if TEST_ANONYMOUSLY in item.keywords and MYPLEX_USERNAME and MYPLEX_PASSWORD:
+    if TEST_ANONYMOUSLY in item.keywords and (MYPLEX_USERNAME and MYPLEX_PASSWORD or MYPLEX_TOKEN):
         return pytest.skip(
             "Anonymous tests should be ran on unclaimed server, without providing MYPLEX_USERNAME and "
-            "MYPLEX_PASSWORD"
+            "MYPLEX_PASSWORD or MYPLEX_TOKEN"
         )
 
 
@@ -99,6 +100,8 @@ def get_account():
 
 @pytest.fixture(scope="session")
 def account():
+    if MYPLEX_TOKEN:
+        return get_account()
     assert MYPLEX_USERNAME, "Required MYPLEX_USERNAME not specified."
     assert MYPLEX_PASSWORD, "Required MYPLEX_PASSWORD not specified."
     return get_account()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ except ImportError:
 SERVER_BASEURL = plexapi.CONFIG.get("auth.server_baseurl")
 MYPLEX_USERNAME = plexapi.CONFIG.get("auth.myplex_username")
 MYPLEX_PASSWORD = plexapi.CONFIG.get("auth.myplex_password")
-MYPLEX_TOKEN = plexapi.CONFIG.get("auth.myplex_token")
+SERVER_TOKEN = plexapi.CONFIG.get("auth.server_token")
 CLIENT_BASEURL = plexapi.CONFIG.get("auth.client_baseurl")
 CLIENT_TOKEN = plexapi.CONFIG.get("auth.client_token")
 
@@ -77,15 +77,15 @@ def pytest_runtest_setup(item):
     if "client" in item.keywords and not item.config.getvalue("client"):
         return pytest.skip("Need --client option to run.")
     if TEST_AUTHENTICATED in item.keywords and not (
-        MYPLEX_USERNAME and MYPLEX_PASSWORD or MYPLEX_TOKEN
+        MYPLEX_USERNAME and MYPLEX_PASSWORD or SERVER_TOKEN
     ):
         return pytest.skip(
-            "You have to specify MYPLEX_USERNAME and MYPLEX_PASSWORD or MYPLEX_TOKEN to run authenticated tests"
+            "You have to specify MYPLEX_USERNAME and MYPLEX_PASSWORD or SERVER_TOKEN to run authenticated tests"
         )
-    if TEST_ANONYMOUSLY in item.keywords and (MYPLEX_USERNAME and MYPLEX_PASSWORD or MYPLEX_TOKEN):
+    if TEST_ANONYMOUSLY in item.keywords and (MYPLEX_USERNAME and MYPLEX_PASSWORD or SERVER_TOKEN):
         return pytest.skip(
             "Anonymous tests should be ran on unclaimed server, without providing MYPLEX_USERNAME and "
-            "MYPLEX_PASSWORD or MYPLEX_TOKEN"
+            "MYPLEX_PASSWORD or SERVER_TOKEN"
         )
 
 
@@ -100,7 +100,7 @@ def get_account():
 
 @pytest.fixture(scope="session")
 def account():
-    if MYPLEX_TOKEN:
+    if SERVER_TOKEN:
         return get_account()
     assert MYPLEX_USERNAME, "Required MYPLEX_USERNAME not specified."
     assert MYPLEX_PASSWORD, "Required MYPLEX_PASSWORD not specified."


### PR DESCRIPTION
Instead of requiring `PLEXAPI_AUTH_MYPLEX_USERNAME` and `PLEXAPI_AUTH_MYPLEX_PASSWORD`, allow use of `PLEXAPI_AUTH_SERVER_TOKEN` for test runs. Useful for testing accounts that have the new 2FA functionality enabled. 