### PR TITLE
Remove playlist created during tests

### DIFF
--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -95,6 +95,9 @@ def test_copyToUser(plex, show, fresh_plex, shared_username):
 
 
 def test_smart_playlist(plex, movies):
-    pl = plex.createPlaylist(title='smart_playlist', smart=True, limit=1, section=movies, year=2008)
-    assert len(pl.items()) == 1
-    assert pl.smart
+    try:
+        pl = plex.createPlaylist(title='smart_playlist', smart=True, limit=1, section=movies, year=2008)
+        assert len(pl.items()) == 1
+        assert pl.smart
+    finally:
+        pl.delete()


### PR DESCRIPTION
Playlists were created but not deleted during test runs, leaving the Plex server in a different state.