### PR TITLE
Fix country metadata test

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -8,7 +8,7 @@ def test_audio_Artist_attr(artist):
     artist.reload()
     assert utils.is_datetime(artist.addedAt)
     if artist.countries:
-        assert "United States" in [i.tag for i in artist.countries]
+        assert "United States of America" in [i.tag for i in artist.countries]
     #assert "Electronic" in [i.tag for i in artist.genres]
     assert utils.is_string(artist.guid, gte=5)
     assert artist.index == "1"


### PR DESCRIPTION
Attempt to fix audio metadata test failures for claimed servers.

Example (https://github.com/pkkid/python-plexapi/runs/1494821152):
```
=================================== FAILURES ===================================
____________________ test_audio_Artist_attr[authenticated] _____________________
Traceback (most recent call last):
  File "/home/runner/work/python-***/python-***/tests/test_audio.py", line 11, in test_audio_Artist_attr
    assert "United States" in [i.tag for i in artist.countries]
AssertionError: assert 'United States' in ['United States of America']
```