### PR TITLE
Fix collection children

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -702,7 +702,7 @@ class Playable(object):
             'mediaIndex': params.get('mediaIndex', 0),
             'X-Plex-Platform': params.get('platform', 'Chrome'),
             'maxVideoBitrate': max(mvb, 64) if mvb else None,
-            'videoResolution': vr if re.match('^\d+x\d+$', vr) else None
+            'videoResolution': vr if re.match(r'^\d+x\d+$', vr) else None
         }
         # remove None values
         params = {k: v for k, v in params.items() if v is not None}

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1478,9 +1478,10 @@ class Collections(PlexPartialObject):
         self.type = data.attrib.get('type')
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
 
-    @property
     def children(self):
-        return self.fetchItems(self.key)
+        """ Returns a list of all items in the collection. """
+        key = '/library/metadata/%s/children' % self.ratingKey
+        return self.fetchItems(key)
 
     def __len__(self):
         return self.childCount

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1478,7 +1478,7 @@ class Collections(PlexPartialObject):
         self.type = data.attrib.get('type')
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
 
-    def children(self):
+    def items(self):
         """ Returns a list of all items in the collection. """
         key = '/library/metadata/%s/children' % self.ratingKey
         return self.fetchItems(key)

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -849,7 +849,7 @@ class LibrarySection(PlexObject):
 
     def collections(self, **kwargs):
         """ Returns a list of collections from this library section.
-            See description of :func:`plexapi.library.LibrarySection.search` for details about filtering / sorting.
+            See description of :func:`~plexapi.library.LibrarySection.search` for details about filtering / sorting.
         """
         return self.search(libtype='collection', **kwargs)
 

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import warnings
 from urllib.parse import quote, quote_plus, unquote, urlencode
 
 from plexapi import X_PLEX_CONTAINER_SIZE, log, utils
@@ -7,8 +6,7 @@ from plexapi.base import PlexObject, PlexPartialObject
 from plexapi.exceptions import BadRequest, NotFound
 from plexapi.media import MediaTag
 from plexapi.settings import Setting
-
-warnings.simplefilter('default', category=DeprecationWarning)
+from plexapi.utils import deprecated
 
 
 class Library(PlexObject):
@@ -845,10 +843,8 @@ class LibrarySection(PlexObject):
         """
         return self._server.history(maxresults=maxresults, mindate=mindate, librarySectionID=self.key, accountID=1)
 
+    @deprecated('use "collections" (plural) instead')
     def collection(self, **kwargs):
-        msg = 'LibrarySection.collection() will be deprecated in the future, use collections() (plural) instead.'
-        warnings.warn(msg, DeprecationWarning)
-        log.warning(msg)
         return self.collections()
 
     def collections(self, **kwargs):
@@ -1479,6 +1475,7 @@ class Collections(PlexPartialObject):
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
 
     @property
+    @deprecated('use "items" instead')
     def children(self):
         return self.fetchItems(self.key)
         

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1478,6 +1478,10 @@ class Collections(PlexPartialObject):
         self.type = data.attrib.get('type')
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
 
+    @property
+    def children(self):
+        return self.fetchItems(self.key)
+        
     def items(self):
         """ Returns a list of all items in the collection. """
         key = '/library/metadata/%s/children' % self.ratingKey

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -161,12 +161,12 @@ def searchType(libtype):
 
 
 def threaded(callback, listargs):
-    """ Returns the result of <callback> for each set of \*args in listargs. Each call
+    """ Returns the result of <callback> for each set of `*args` in listargs. Each call
         to <callback> is called concurrently in their own separate threads.
 
         Parameters:
-            callback (func): Callback function to apply to each set of \*args.
-            listargs (list): List of lists; \*args to pass each thread.
+            callback (func): Callback function to apply to each set of `*args`.
+            listargs (list): List of lists; `*args` to pass each thread.
     """
     threads, results = [], []
     job_is_done_event = Event()

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 import base64
+import functools
 import logging
 import os
 import re
 import time
+import warnings
 import zipfile
 from datetime import datetime
 from getpass import getpass
@@ -19,6 +21,7 @@ except ImportError:
     tqdm = None
 
 log = logging.getLogger('plexapi')
+warnings.simplefilter('default', category=DeprecationWarning)
 
 # Search Types - Plex uses these to filter specific media types when searching.
 # Library Types - Populated at runtime
@@ -445,3 +448,18 @@ def getAgentIdentifier(section, agent):
 
 def base64str(text):
     return base64.b64encode(text.encode('utf-8')).decode('utf-8')
+
+
+def deprecated(message):
+    def decorator(func):
+        """This is a decorator which can be used to mark functions
+        as deprecated. It will result in a warning being emitted
+        when the function is used."""
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            msg = 'Call to deprecated function or method "%s", %s.' % (func.__name__, message)
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
+            log.warning(msg)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -300,6 +300,11 @@ def test_library_Collection_delete(movies, movie):
     assert len(collections) == 0
 
 
+def test_library_Collection_children(collection):
+    children = collection.children()
+    assert len(children) == 1
+
+
 def test_search_with_weird_a(plex):
     ep_title = "Coup de Grâce"
     result_root = plex.search(ep_title)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -301,7 +301,7 @@ def test_library_Collection_delete(movies, movie):
 
 
 def test_library_Collection_children(collection):
-    children = collection.children()
+    children = collection.items()
     assert len(children) == 1
 
 


### PR DESCRIPTION
## Description

`Collection.children` was not working because of the change to the `key` by removing the `/children` path (9fb3eaf41c04f85165874aade8a9d90bb99522f9 and #50). This also changes the property to a method ~~`Collection.children()`~~ `Collection.items()` to be consistent with `Playlist.items()`, `Show.seasons()`, and `Season.episodes()`.

~~Unable to add a `DeprecationWarning` because the method is the same name as the property.~~

New `@deprecated` decorator helper function added to `utils`. `DeprecationWarning` added to `Collection.children`.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
