### PR TITLE
Change LibrarySection collections method to plural and add playlists method

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import warnings
 from urllib.parse import quote, quote_plus, unquote, urlencode
 
 from plexapi import X_PLEX_CONTAINER_SIZE, log, utils
@@ -842,6 +843,20 @@ class LibrarySection(PlexObject):
         """
         return self._server.history(maxresults=maxresults, mindate=mindate, librarySectionID=self.key, accountID=1)
 
+    def collection(self, **kwargs):
+        warnings.simplefilter('always')
+        warnings.warn(
+            'collection() will be deprecated in the future, use collections() (plural) instead.',
+            DeprecationWarning
+        )
+        return self.collections()
+
+    def collections(self, **kwargs):
+        """ Returns a list of collections from this library section.
+            See description of :func:`plexapi.library.LibrarySection.search()` for details about filtering / sorting.
+        """
+        return self.search(libtype='collection', **kwargs)
+
 
 class MovieSection(LibrarySection):
     """ Represents a :class:`~plexapi.library.LibrarySection` section containing movies.
@@ -854,10 +869,6 @@ class MovieSection(LibrarySection):
     TYPE = 'movie'
     METADATA_TYPE = 'movie'
     CONTENT_TYPE = 'video'
-
-    def collection(self, **kwargs):
-        """ Returns a list of collections from this library section. """
-        return self.search(libtype='collection', **kwargs)
 
     def sync(self, videoQuality, limit=None, unwatched=False, **kwargs):
         """ Add current Movie library section as sync item for specified device.
@@ -923,10 +934,6 @@ class ShowSection(LibrarySection):
                 maxresults (int): Max number of items to return (default 50).
         """
         return self.search(sort='episode.addedAt:desc', libtype=libtype, maxresults=maxresults)
-
-    def collection(self, **kwargs):
-        """ Returns a list of collections from this library section. """
-        return self.search(libtype='collection', **kwargs)
 
     def sync(self, videoQuality, limit=None, unwatched=False, **kwargs):
         """ Add current Show library section as sync item for specified device.
@@ -999,10 +1006,6 @@ class MusicSection(LibrarySection):
         """ Search for a track. See :func:`~plexapi.library.LibrarySection.search` for usage. """
         return self.search(libtype='track', **kwargs)
 
-    def collection(self, **kwargs):
-        """ Returns a list of collections from this library section. """
-        return self.search(libtype='collection', **kwargs)
-
     def sync(self, bitrate, limit=None, **kwargs):
         """ Add current Music library section as sync item for specified device.
             See description of :func:`~plexapi.library.LibrarySection.search` for details about filtering / sorting and
@@ -1049,6 +1052,9 @@ class PhotoSection(LibrarySection):
     TYPE = 'photo'
     CONTENT_TYPE = 'photo'
     METADATA_TYPE = 'photo'
+
+    def collections(self, **kwargs):
+        raise NotImplementedError('Collections are not available for a Photo library.')
 
     def searchAlbums(self, title, **kwargs):
         """ Search for an album. See :func:`~plexapi.library.LibrarySection.search` for usage. """

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -8,6 +8,8 @@ from plexapi.exceptions import BadRequest, NotFound
 from plexapi.media import MediaTag
 from plexapi.settings import Setting
 
+warnings.simplefilter('default')
+
 
 class Library(PlexObject):
     """ Represents a PlexServer library. This contains all sections of media defined
@@ -844,11 +846,9 @@ class LibrarySection(PlexObject):
         return self._server.history(maxresults=maxresults, mindate=mindate, librarySectionID=self.key, accountID=1)
 
     def collection(self, **kwargs):
-        warnings.simplefilter('always')
-        warnings.warn(
-            'collection() will be deprecated in the future, use collections() (plural) instead.',
-            DeprecationWarning
-        )
+        msg = 'LibrarySection.collection() will be deprecated in the future, use collections() (plural) instead.'
+        warnings.warn(msg, DeprecationWarning)
+        log.warning(msg)
         return self.collections()
 
     def collections(self, **kwargs):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -853,7 +853,7 @@ class LibrarySection(PlexObject):
 
     def collections(self, **kwargs):
         """ Returns a list of collections from this library section.
-            See description of :func:`plexapi.library.LibrarySection.search()` for details about filtering / sorting.
+            See description of :func:`plexapi.library.LibrarySection.search` for details about filtering / sorting.
         """
         return self.search(libtype='collection', **kwargs)
 

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -857,6 +857,11 @@ class LibrarySection(PlexObject):
         """
         return self.search(libtype='collection', **kwargs)
 
+    def playlists(self, **kwargs):
+        """ Returns a list of playlists from this library section. """
+        key = '/playlists?type=15&playlistType=%s&sectionID=%s' % (self.CONTENT_TYPE, self.key)
+        return self.fetchItems(key, **kwargs)
+
 
 class MovieSection(LibrarySection):
     """ Represents a :class:`~plexapi.library.LibrarySection` section containing movies.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,13 +222,13 @@ def movie(movies):
 @pytest.fixture()
 def collection(plex):
     try:
-        return plex.library.section("Movies").collection()[0]
+        return plex.library.section("Movies").collections()[0]
     except IndexError:
         movie = plex.library.section("Movies").get("Elephants Dream")
         movie.addCollection(["marvel"])
 
         n = plex.library.section("Movies").reload()
-        return n.collection()[0]
+        return n.collections()[0]
 
 
 @pytest.fixture()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -290,10 +290,14 @@ def test_library_Colletion_edit(collection):
     collection.edit(**{'titleSort.value': collectionTitleSort, 'titleSort.locked': 0})
 
 
-def test_library_Collection_delete(movies, collection):
-    collection.delete()
-    movies.reload()
-    assert len(movies.collections()) == 0
+def test_library_Collection_delete(movies, movie):
+    delete_collection = 'delete_collection'
+    movie.addCollection(delete_collection)
+    collections = movies.collections(title=delete_collection)
+    assert len(collections) == 1
+    collections[0].delete()
+    collections = movies.collections(title=delete_collection)
+    assert len(collections) == 0
 
 
 def test_search_with_weird_a(plex):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -181,6 +181,10 @@ def test_library_MovieSection_analyze(movies):
     movies.analyze()
 
 
+def test_library_MovieSection_collections(movies, collection):
+    assert len(movies.collections())
+
+
 def test_library_ShowSection_searchShows(tvshows):
     assert tvshows.searchShows(title="The 100")
 
@@ -191,6 +195,15 @@ def test_library_ShowSection_searchEpisodes(tvshows):
 
 def test_library_ShowSection_recentlyAdded(tvshows):
     assert len(tvshows.recentlyAdded())
+
+
+def test_library_ShowSection_playlists(plex, tvshows, show):
+    episodes = show.episodes()
+    playlist = plex.createPlaylist("test_library_ShowSection_playlists", episodes[:3])
+    try:
+        assert len(tvshows.playlists())
+    finally:
+        playlist.delete()
 
 
 def test_library_MusicSection_albums(music):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -290,6 +290,12 @@ def test_library_Colletion_edit(collection):
     collection.edit(**{'titleSort.value': collectionTitleSort, 'titleSort.locked': 0})
 
 
+def test_library_Collection_delete(movies, collection):
+    collection.delete()
+    movies.reload()
+    assert len(movies.collections()) == 0
+
+
 def test_search_with_weird_a(plex):
     ep_title = "Coup de Grâce"
     result_root = plex.search(ep_title)


### PR DESCRIPTION
## Description

This changes the `LibrarySection.collections()` method to plural to be consistent with the other methods such as `Show.seasons()`, `Season.episodes()`, etc. A `DeprecationWarning` is added to the old `collection()` method. A `NotImplementedError` is raised for `PhotoSection.collections()`.

It also adds a `LibrarySection.playlists()` method to retrieve all playlists in a library.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
