### PR TITLE
Disable media scanning jobs in bootstrap

### DIFF
--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -463,7 +463,9 @@ if __name__ == "__main__":
                 server = PlexServer("http://%s:32400" % opts.advertise_ip)
             if opts.accept_eula:
                 server.settings.get("acceptedEULA").set(True)
-                server.settings.save()
+            server.settings.get("GenerateBIFBehavior").set("never")
+            server.settings.get("GenerateIntroMarkerBehavior").set("never")
+            server.settings.save()
 
         except KeyboardInterrupt:
             break

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -464,7 +464,9 @@ if __name__ == "__main__":
             if opts.accept_eula:
                 server.settings.get("acceptedEULA").set(True)
             server.settings.get("GenerateBIFBehavior").set("never")
+            server.settings.get("GenerateChapterThumbBehavior").set("never")
             server.settings.get("GenerateIntroMarkerBehavior").set("never")
+            server.settings.get("LoudnessAnalysisBehavior").set("never")
             server.settings.save()
 
         except KeyboardInterrupt:


### PR DESCRIPTION
To reduce overhead and avoid CI issues when testing with a claimed server and a valid Plex Pass.