### PR TITLE
Add method to keep track of the parent PlexObject as children are built

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -108,7 +108,7 @@ class PlexObject(object):
                 details_key += '?' + urlencode(sorted(includes.items()))
         return details_key
 
-    def _findParent(self, cls):
+    def _isChildOf(self, cls):
         """ Returns True if this object is a child of the given class.
         
             Parameters:

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -36,6 +36,7 @@ class PlexObject(object):
             server (:class:`~plexapi.server.PlexServer`): PlexServer this client is connected to (optional)
             data (ElementTree): Response from PlexServer used to build this object (optional).
             initpath (str): Relative path requested when retrieving specified `data` (optional).
+            parent (:class:`~plexapi.base.PlexObject`): The parent object that this object is built from (optional).
     """
     TAG = None      # xml element tag
     TYPE = None     # xml element type


### PR DESCRIPTION
## Description

Adds a private `_parent` attribute to `PlexObject` which is a `weakref` to the parent object that was used to build the child object.

Intended to be applied to #590 so that object attributes can be made available to specific media types. See example of it being used here:
https://github.com/JonnyWong16/python-plexapi/blob/c5c45d74d97d61197d057f2c7a435219c7f2f31d/plexapi/media.py#L288

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
