### PR TITLE
Fix sync tests when using a token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,11 +176,6 @@ jobs:
 
     - name: Sync tests with ${{ matrix.plex }} server
       if: matrix.plex == 'claimed'
-      env:
-        PLEXAPI_HEADER_PROVIDES: 'controller,sync-target'
-        PLEXAPI_HEADER_PLATFORM: iOS
-        PLEXAPI_HEADER_PLATFORM_VERSION: 11.4.1
-        PLEXAPI_HEADER_DEVICE: iPhone
       run: |
         . venv/bin/activate
         pytest \

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -95,7 +95,7 @@ class PlexObject(object):
             or disable each parameter individually by setting it to False or 0.
         """
         details_key = self.key
-        if hasattr(self, '_INCLUDES'):
+        if details_key and hasattr(self, '_INCLUDES'):
             includes = {}
             for k, v in self._INCLUDES.items():
                 value = kwargs.get(k, v)

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -8,7 +8,7 @@ from plexapi.exceptions import BadRequest, NotFound
 from plexapi.media import MediaTag
 from plexapi.settings import Setting
 
-warnings.simplefilter('default')
+warnings.simplefilter('default', category=DeprecationWarning)
 
 
 class Library(PlexObject):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -153,14 +153,15 @@ class MyPlexAccount(PlexObject):
         self.services = None
         self.joined_at = None
 
-    def device(self, name):
+    def device(self, name=None, clientIdentifier=None):
         """ Returns the :class:`~plexapi.myplex.MyPlexDevice` that matches the name specified.
 
             Parameters:
                 name (str): Name to match against.
+                clientIdentifier (str): clientIdentifier to match against.
         """
         for device in self.devices():
-            if device.name.lower() == name.lower():
+            if (name and device.name.lower() == name.lower() or device.clientIdentifier == clientIdentifier):
                 return device
         raise NotFound('Unable to find device %s' % name)
 

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -379,7 +379,7 @@ def getMyPlexAccount(opts=None):  # pragma: no cover
     return MyPlexAccount(username, password)
 
 
-def createMyPlexDevice(headers, timeout=None):
+def createMyPlexDevice(headers, timeout=None):  # pragma: no cover
     """ Helper function to create a new MyPlexDevice.
 
         Parameters:

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -11,7 +11,7 @@ from threading import Event, Thread
 from urllib.parse import quote
 
 import requests
-from plexapi.exceptions import NotFound
+from plexapi.exceptions import BadRequest, NotFound
 
 try:
     from tqdm import tqdm
@@ -377,6 +377,31 @@ def getMyPlexAccount(opts=None):  # pragma: no cover
     password = getpass('What is your plex.tv password: ')
     print('Authenticating with Plex.tv as %s..' % username)
     return MyPlexAccount(username, password)
+
+
+def createMyPlexDevice(headers, timeout=None):
+    """ Helper function to create a new MyPlexDevice.
+
+        Parameters:
+            headers (dict): Provide the X-Plex- headers for the new device.
+                A unique X-Plex-Client-Identifier is required.
+            timeout (int): Timeout in seconds to wait for device login.
+    """
+    from plexapi.myplex import MyPlexPinLogin
+
+    if 'X-Plex-Client-Identifier' not in headers:
+        raise BadRequest('The X-Plex-Client-Identifier header is required.')
+
+    clientIdentifier = headers['X-Plex-Client-Identifier']
+
+    pinlogin = MyPlexPinLogin(headers=headers)
+    pinlogin.run(timeout=timeout)
+    pinlogin.link()
+    pinlogin.waitForLogin()
+
+    account = getMyPlexAccount()
+    device = account.device(clientIdentifier=clientIdentifier)
+    return device
 
 
 def choose(msg, items, attr):  # pragma: no cover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ ENTITLEMENTS = {
     "windows",
     "windows_phone",
 }
-SYNC_DEVICE_IDENTIFIER = "sync-client-%s" % plexapi.X_PLEX_IDENTIFIER
+SYNC_DEVICE_IDENTIFIER = "test-sync-client-%s" % plexapi.X_PLEX_IDENTIFIER
 SYNC_DEVICE_HEADERS = {
     "X-Plex-Provides": "sync-target",
     "X-Plex-Platform": "iOS",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import time
-import uuid
 from datetime import datetime
 from functools import partial
 from os import environ

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -56,10 +56,7 @@ def test_myplex_devices(account):
 
 
 def test_myplex_device(account, plex):
-    from plexapi import X_PLEX_DEVICE_NAME
-
     assert account.device(plex.friendlyName)
-    assert account.device(X_PLEX_DEVICE_NAME)
 
 
 def _test_myplex_connect_to_device(account):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,15 +5,15 @@ from plexapi.sync import (AUDIO_BITRATE_192_KBPS, PHOTO_QUALITY_MEDIUM,
 from . import conftest as utils
 
 
-def get_sync_item_from_server(device, sync_item):
-    sync_list = device.syncItems()
+def get_sync_item_from_server(sync_device, sync_item):
+    sync_list = sync_device.syncItems()
     for item in sync_list.items:
         if item.id == sync_item.id:
             return item
 
 
-def is_sync_item_missing(device, sync_item):
-    return not get_sync_item_from_server(device, sync_item)
+def is_sync_item_missing(sync_device, sync_item):
+    return not get_sync_item_from_server(sync_device, sync_item)
 
 
 def test_current_device_got_sync_target(clear_sync_device):
@@ -38,7 +38,7 @@ def test_add_movie_to_sync(clear_sync_device, movie):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -55,7 +55,7 @@ def test_delete_sync_item(clear_sync_device, movie):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     sync_items = clear_sync_device.syncItems()
@@ -65,7 +65,7 @@ def test_delete_sync_item(clear_sync_device, movie):
         is_sync_item_missing,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item_in_myplex,
     )
 
@@ -77,7 +77,7 @@ def test_add_show_to_sync(clear_sync_device, show):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     episodes = show.episodes()
@@ -96,7 +96,7 @@ def test_add_season_to_sync(clear_sync_device, show):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     episodes = season.episodes()
@@ -114,7 +114,7 @@ def test_add_episode_to_sync(clear_sync_device, episode):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -134,7 +134,7 @@ def test_limited_watched(clear_sync_device, show):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     episodes = show.episodes()[:5]
@@ -162,7 +162,7 @@ def test_limited_unwatched(clear_sync_device, show):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     episodes = show.episodes(viewCount=0)[:5]
@@ -191,7 +191,7 @@ def test_unlimited_and_watched(clear_sync_device, show):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     episodes = show.episodes()
@@ -220,7 +220,7 @@ def test_unlimited_and_unwatched(clear_sync_device, show):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     episodes = show.episodes(viewCount=0)
@@ -246,7 +246,7 @@ def test_add_music_artist_to_sync(clear_sync_device, artist):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     tracks = artist.tracks()
@@ -264,7 +264,7 @@ def test_add_music_album_to_sync(clear_sync_device, album):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     tracks = album.tracks()
@@ -282,7 +282,7 @@ def test_add_music_track_to_sync(clear_sync_device, track):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -300,7 +300,7 @@ def test_add_photo_to_sync(clear_sync_device, photoalbum):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -317,7 +317,7 @@ def test_sync_entire_library_movies(clear_sync_device, movies):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     section_content = movies.all()
@@ -335,7 +335,7 @@ def test_sync_entire_library_tvshows(clear_sync_device, tvshows):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     section_content = tvshows.searchEpisodes()
@@ -353,7 +353,7 @@ def test_sync_entire_library_music(clear_sync_device, music):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     section_content = music.searchTracks()
@@ -371,7 +371,7 @@ def test_sync_entire_library_photos(clear_sync_device, photos):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     # It's not that easy, to just get all the photos within the library, so let`s query for photos with device!=0x0
@@ -394,7 +394,7 @@ def test_playlist_movie_sync(plex, clear_sync_device, movies):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -416,7 +416,7 @@ def test_playlist_tvshow_sync(plex, clear_sync_device, show):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -438,7 +438,7 @@ def test_playlist_mixed_sync(plex, clear_sync_device, movie, episode):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -460,7 +460,7 @@ def test_playlist_music_sync(plex, clear_sync_device, artist):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(
@@ -482,7 +482,7 @@ def test_playlist_photos_sync(plex, clear_sync_device, photoalbum):
         get_sync_item_from_server,
         delay=0.5,
         timeout=3,
-        device=clear_sync_device,
+        sync_device=clear_sync_device,
         sync_item=new_item,
     )
     media_list = utils.wait_until(

--- a/tools/plex-teardowntest.py
+++ b/tools/plex-teardowntest.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
             device.delete()
 
     # Remove the test sync client
-    sync_client_identifier = 'sync-client-%s' % X_PLEX_IDENTIFIER
+    sync_client_identifier = 'test-sync-client-%s' % X_PLEX_IDENTIFIER
     for device in plex.myPlexAccount().devices():
         if device.clientIdentifier == sync_client_identifier:
             print('Removing device "%s", with id "%s"' % (device.name, device. clientIdentifier))

--- a/tools/plex-teardowntest.py
+++ b/tools/plex-teardowntest.py
@@ -11,10 +11,20 @@ from plexapi import X_PLEX_IDENTIFIER
 if __name__ == '__main__':
     myplex = MyPlexAccount()
     plex = PlexServer(token=myplex.authenticationToken)
+
+    # Remove the test server
     for device in plex.myPlexAccount().devices():
         if device.clientIdentifier == plex.machineIdentifier:
             print('Removing device "%s", with id "%s"' % (device.name, device. clientIdentifier))
             device.delete()
+
+    # Remove the test sync client
+    sync_client_identifier = 'sync-client-%s' % X_PLEX_IDENTIFIER
+    for device in plex.myPlexAccount().devices():
+        if device.clientIdentifier == sync_client_identifier:
+            print('Removing device "%s", with id "%s"' % (device.name, device. clientIdentifier))
+            device.delete()
+            break
 
     # If we suddenly remove the client first we wouldn't be able to authenticate to delete the server
     for device in plex.myPlexAccount().devices():


### PR DESCRIPTION
## Description

Sync tests could fail because of conflicting parallel CI tests using the same token. When a token is created it is associated with a specific `X-Plex-Client-Identifier`. Using the token with different `X-Plex-` headers will update the device attributes at `https://plex.tv/devices.xml` _except_ for the `clientIdentifier`. This causes issues because one CI could be running main tests which sets the header `X-Plex-Provides=controller` while another parallel CI running sync test sets the header `X-Plex-Provides=sync-target`. Depending on which API requests are being made at the time the sync tests could fail because it will suddenly be missing `sync-target` for the device.

This PR:
* Updates `MyPlexPinLogin` to use `https://plex.tv/api/v2` endpoint.
* Adds helper function `createMyPlexDevice` that uses `MyPlexPinLogin` to create a new device on the Plex account.
* Updates sync tests to create a separate sync device with a unique `clientIdentifier`. This gives the sync tests it's own sync device which won't conflict with the device associated with the token.

See workflow run here: https://github.com/JonnyWong16/python-plexapi/actions/runs/404885213


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
