### PR TITLE
Fix disable settings for bootstrap test server

### DIFF
--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -463,9 +463,10 @@ if __name__ == "__main__":
                 server = PlexServer("http://%s:32400" % opts.advertise_ip)
             if opts.accept_eula:
                 server.settings.get("acceptedEULA").set(True)
+            if not opts.unclaimed:
+                server.settings.get("GenerateIntroMarkerBehavior").set("never")
             server.settings.get("GenerateBIFBehavior").set("never")
             server.settings.get("GenerateChapterThumbBehavior").set("never")
-            server.settings.get("GenerateIntroMarkerBehavior").set("never")
             server.settings.get("LoudnessAnalysisBehavior").set("never")
             server.settings.save()
 

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -461,9 +461,10 @@ if __name__ == "__main__":
                 server = account.device(opts.server_name).connect()
             else:
                 server = PlexServer("http://%s:32400" % opts.advertise_ip)
+
             if opts.accept_eula:
                 server.settings.get("acceptedEULA").set(True)
-            if not opts.unclaimed:
+            if not opts.unclaimed and account.subscriptionActive:
                 server.settings.get("GenerateIntroMarkerBehavior").set("never")
             server.settings.get("GenerateBIFBehavior").set("never")
             server.settings.get("GenerateChapterThumbBehavior").set("never")

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -462,27 +462,32 @@ if __name__ == "__main__":
             else:
                 server = PlexServer("http://%s:32400" % opts.advertise_ip)
 
-            if opts.accept_eula:
-                server.settings.get("acceptedEULA").set(True)
-            if not opts.unclaimed and account.subscriptionActive:
-                server.settings.get("GenerateIntroMarkerBehavior").set("never")
-            server.settings.get("GenerateBIFBehavior").set("never")
-            server.settings.get("GenerateChapterThumbBehavior").set("never")
-            server.settings.get("LoudnessAnalysisBehavior").set("never")
-            server.settings.save()
-
         except KeyboardInterrupt:
             break
 
         except Exception as err:
             print(err)
             time.sleep(1)
+
         runtime = time.time() - start
+
     if not server:
         raise SystemExit(
             "Server didnt appear in your account after %ss" % opts.bootstrap_timeout
         )
+
     print("Plex container started after %ss, setting up content" % int(runtime))
+
+    if opts.accept_eula:
+        server.settings.get("acceptedEULA").set(True)
+    # Disable settings for background tasks when using the test server.
+    # These tasks won't work on the test server since we are using fake media files
+    if not opts.unclaimed and account and account.subscriptionActive:
+        server.settings.get("GenerateIntroMarkerBehavior").set("never")
+    server.settings.get("GenerateBIFBehavior").set("never")
+    server.settings.get("GenerateChapterThumbBehavior").set("never")
+    server.settings.get("LoudnessAnalysisBehavior").set("never")
+    server.settings.save()
 
     sections = []
 


### PR DESCRIPTION
## Description

The settings for the background library tasks were not actually being disabled for the bootstrap test server on an unclaimed server. `GenerateIntroMarkerBehavior` is a Plex Pass setting so it was raising a `NotFound` exception which prevented the other settings from being saved.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
