### PR TITLE
Add Plex dashboard bandwidth and resources

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -67,6 +67,7 @@ class PlexObject(object):
             value = str(value).replace('/library/metadata/', '')
             value = value.replace('/children', '')
             value = value.replace('/accounts/', '')
+            value = value.replace('/devices/', '')
             return value.replace(' ', '-')[:20]
 
     def _buildItem(self, elem, cls=None, initpath=None):

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -66,6 +66,7 @@ class PlexObject(object):
         if value:
             value = str(value).replace('/library/metadata/', '')
             value = value.replace('/children', '')
+            value = value.replace('/accounts/', '')
             return value.replace(' ', '-')[:20]
 
     def _buildItem(self, elem, cls=None, initpath=None):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -658,7 +658,7 @@ class LibrarySection(PlexObject):
                         * year: List of years to search within ([yyyy, ...]). [all]
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: when applying unknown filter
+                :exc:`~plexapi.exceptions.BadRequest`: When applying an unknown filter.
         """
         # cleanup the core arguments
         args = {}
@@ -779,7 +779,7 @@ class LibrarySection(PlexObject):
                 :class:`~plexapi.sync.SyncItem`: an instance of created syncItem.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: when the library is not allowed to sync
+                :exc:`~plexapi.exceptions.BadRequest`: When the library is not allowed to sync.
 
             Example:
 

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -580,8 +580,8 @@ class MyPlexAccount(PlexObject):
                 :class:`~plexapi.sync.SyncItem`: an instance of created syncItem.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: when client with provided clientId wasn`t found.
-                :exc:`~plexapi.exceptions.BadRequest`: provided client doesn`t provides `sync-target`.
+                :exc:`~plexapi.exceptions.BadRequest`: When client with provided clientId wasn`t found.
+                :exc:`~plexapi.exceptions.BadRequest`: Provided client doesn`t provides `sync-target`.
         """
         if not client and not clientId:
             clientId = X_PLEX_IDENTIFIER
@@ -1155,8 +1155,8 @@ class MyPlexPinLogin(object):
                 timeout (int): Timeout in seconds waiting for the PIN login to succeed (optional).
 
             Raises:
-                :class:`RuntimeError`: if the thread is already running.
-                :class:`RuntimeError`: if the PIN login for the current PIN has expired.
+                :class:`RuntimeError`: If the thread is already running.
+                :class:`RuntimeError`: If the PIN login for the current PIN has expired.
         """
         if self._thread and not self._abort:
             raise RuntimeError('MyPlexPinLogin thread is already running')

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -43,7 +43,7 @@ class MyPlexAccount(PlexObject):
             guest (bool): Unknown.
             home (bool): Unknown.
             homeSize (int): Unknown.
-            id (str): Your Plex account ID.
+            id (int): Your Plex account ID.
             locale (str): Your Plex locale
             mailing_list_status (str): Your current mailing list status.
             maxHomeSize (int): Unknown.
@@ -115,7 +115,7 @@ class MyPlexAccount(PlexObject):
         self.guest = utils.cast(bool, data.attrib.get('guest'))
         self.home = utils.cast(bool, data.attrib.get('home'))
         self.homeSize = utils.cast(int, data.attrib.get('homeSize'))
-        self.id = data.attrib.get('id')
+        self.id = utils.cast(int, data.attrib.get('id'))
         self.locale = data.attrib.get('locale')
         self.mailing_list_status = data.attrib.get('mailing_list_status')
         self.maxHomeSize = utils.cast(int, data.attrib.get('maxHomeSize'))

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -272,8 +272,8 @@ class Playlist(PlexPartialObject, Playable):
                              generated from metadata of current photo.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: when playlist is not allowed to sync.
-                :exc:`~plexapi.exceptions.Unsupported`: when playlist content is unsupported.
+                :exc:`~plexapi.exceptions.BadRequest`: When playlist is not allowed to sync.
+                :exc:`~plexapi.exceptions.Unsupported`: When playlist content is unsupported.
 
             Returns:
                 :class:`~plexapi.sync.SyncItem`: an instance of created syncItem.

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -107,6 +107,8 @@ class PlexServer(PlexObject):
         self._library = None   # cached library
         self._settings = None   # cached settings
         self._myPlexAccount = None   # cached myPlexAccount
+        self._systemAccounts = None # cached list of SystemAccount
+        self._systemDevices = None # cached list of SystemDevice
         data = self.query(self.key, timeout=timeout)
         super(PlexServer, self).__init__(self, data, self.key)
 
@@ -215,13 +217,17 @@ class PlexServer(PlexObject):
 
     def systemAccounts(self):
         """ Returns a list of :class:`~plexapi.server.SystemAccounts` objects this server contains. """
-        data = self.query('/accounts')
-        return self.findItems(data, SystemAccount)
+        if self._systemAccounts is None:
+            data = self.query('/accounts')
+            self._systemAccounts = self.findItems(data, SystemAccount)
+        return self._systemAccounts
 
     def systemDevices(self):
         """ Returns a list of :class:`~plexapi.server.SystemDevices` objects this server contains. """
-        data = self.query('/devices')
-        return self.findItems(data, SystemDevice)
+        if self._systemDevices is None:
+            data = self.query('/devices')
+            self._systemDevices = self.findItems(data, SystemDevice)
+        return self._systemDevices
 
     def myPlexAccount(self):
         """ Returns a :class:`~plexapi.myplex.MyPlexAccount` object using the same

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -611,25 +611,26 @@ class PlexServer(PlexObject):
         """ Returns a :class:`~plexapi.server.DashboardBandwidth` object with the Plex server dashboard bandwidth data.
 
             Parameters:
-                timespan (str, optional): The timespan to group the bandwidth data. Default returns bandwidth
-                    for all available timespans. Available options are seconds, hours, days, weeks, months.
+                timespan (str, optional): The timespan to bin the bandwidth data. Default returns bandwidth
+                    for all available timespans. Available timespans: seconds, hours, days, weeks, months.
                 **kwargs (dict, optional): Any of the available filters that can be applied to the bandwidth data.
                     The time frame (at) and bytes can also be filtered using less than or greater than (see examples below).
 
                     * accountID (int): The :class:`~plexapi.server.StatisticsAccount` ID to filter.
-                    * at (datetime): The time frame to filter (inclusive). The time frame can either be:
+                    * at (datetime): The time frame to filter (inclusive). The time frame can be either:
                         1. An exact time frame (e.g. Only December 1st 2020 `at=datetime(2020, 12, 1)`)
                         2. Before a specific time (e.g. Before and including December 2020 `at<=datetime(2020, 12, 1)`)
                         3. After a specific time (e.g. After and including January 2021 `at>=datetime(2021, 1, 1)`)
-                    * bytes (int): The amount of bytes to filter (inclusive).
+                    * bytes (int): The amount of bytes to filter (inclusive). The bytes can be either:
                         1. An exact number of bytes (not very useful) (e.g. `bytes=1024**3`)
                         2. Less than or equal number of bytes (e.g. `bytes<=1024**3`)
                         3. Greater than or equal number of bytes (e.g. `bytes>=1024**3`)
                     * deviceID (int): The :class:`~plexapi.server.StatisticsDevice` ID to filter.
                     * lan (bool): True to only retrieve local bandwidth, False to only retrieve remote bandwidth.
+                        Default returns all local and remote bandwidth.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: When applying an unknown filter.
+                :exc:`~plexapi.exceptions.BadRequest`: When applying an invalid timespan or unknown filter.
 
             Example:
 
@@ -671,8 +672,8 @@ class PlexServer(PlexObject):
             try:
                 params['timespan'] = timespans[timespan]
             except KeyError:
-                raise BadRequest('Invalid bandwidth timespan specified: %s. '
-                    'Available options are: %s' % (timespan, ', '.join(timespans.keys())))
+                raise BadRequest('Invalid timespan specified: %s. '
+                    'Available timespans: %s' % (timespan, ', '.join(timespans.keys())))
 
         filters = {'accountID', 'at', 'at<', 'at>', 'bytes', 'bytes<', 'bytes>', 'deviceID', 'lan'}
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -218,15 +218,15 @@ class PlexServer(PlexObject):
     def systemAccounts(self):
         """ Returns a list of :class:`~plexapi.server.SystemAccounts` objects this server contains. """
         if self._systemAccounts is None:
-            data = self.query('/accounts')
-            self._systemAccounts = self.findItems(data, SystemAccount)
+            key = '/accounts'
+            self._systemAccounts = self.fetchItems(key, SystemAccount)
         return self._systemAccounts
 
     def systemDevices(self):
         """ Returns a list of :class:`~plexapi.server.SystemDevices` objects this server contains. """
         if self._systemDevices is None:
-            data = self.query('/devices')
-            self._systemDevices = self.findItems(data, SystemDevice)
+            key = '/devices'
+            self._systemDevices = self.fetchItems(key, SystemDevice)
         return self._systemDevices
 
     def myPlexAccount(self):
@@ -705,15 +705,13 @@ class PlexServer(PlexObject):
             params[key] = value
 
         key = '/statistics/bandwidth?%s' % urlencode(params)
-        data = self.query(key)
-        return self.findItems(data, StatisticsBandwidth)
+        return self.fetchItems(key, StatisticsBandwidth)
 
     def resources(self):
         """ Returns a list of :class:`~plexapi.server.StatisticsResources` objects
             with the Plex server dashboard resources data. """
         key = '/statistics/resources?timespan=6'
-        data = self.query(key)
-        return self.findItems(data, StatisticsResources)
+        return self.fetchItems(key, StatisticsResources)
 
 
 class Account(PlexObject):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -628,13 +628,13 @@ class PlexServer(PlexObject):
 
                     * accountID (int): The :class:`~plexapi.server.SystemAccount` ID to filter.
                     * at (datetime): The time frame to filter (inclusive). The time frame can be either:
-                        1. An exact time frame (e.g. Only December 1st 2020 `at=datetime(2020, 12, 1)`)
-                        2. Before a specific time (e.g. Before and including December 2020 `at<=datetime(2020, 12, 1)`)
-                        3. After a specific time (e.g. After and including January 2021 `at>=datetime(2021, 1, 1)`)
+                        1. An exact time frame (e.g. Only December 1st 2020 `at=datetime(2020, 12, 1)`).
+                        2. Before a specific time (e.g. Before and including December 2020 `at<=datetime(2020, 12, 1)`).
+                        3. After a specific time (e.g. After and including January 2021 `at>=datetime(2021, 1, 1)`).
                     * bytes (int): The amount of bytes to filter (inclusive). The bytes can be either:
-                        1. An exact number of bytes (not very useful) (e.g. `bytes=1024**3`)
-                        2. Less than or equal number of bytes (e.g. `bytes<=1024**3`)
-                        3. Greater than or equal number of bytes (e.g. `bytes>=1024**3`)
+                        1. An exact number of bytes (not very useful) (e.g. `bytes=1024**3`).
+                        2. Less than or equal number of bytes (e.g. `bytes<=1024**3`).
+                        3. Greater than or equal number of bytes (e.g. `bytes>=1024**3`).
                     * deviceID (int): The :class:`~plexapi.server.SystemDevice` ID to filter.
                     * lan (bool): True to only retrieve local bandwidth, False to only retrieve remote bandwidth.
                         Default returns all local and remote bandwidth.
@@ -649,7 +649,7 @@ class PlexServer(PlexObject):
                     from plexapi.server import PlexServer
                     plex = PlexServer('http://localhost:32400', token='xxxxxxxxxxxxxxxxxxxx')
 
-                    # Filter bandwidth data for December 2020 and later and more than 1 GB used.
+                    # Filter bandwidth data for December 2020 and later, and more than 1 GB used.
                     filters = {
                         'at>': datetime(2020, 12, 1),
                         'bytes>': 1024**3
@@ -658,7 +658,7 @@ class PlexServer(PlexObject):
                     # Retrieve bandwidth data in one day timespans.
                     bandwidthData = plex.bandwidth(timespan='days', **filters)
 
-                    # Print out bandwidth usage for each account and device combination
+                    # Print out bandwidth usage for each account and device combination.
                     for bandwidth in sorted(bandwidthData, key=lambda x: x.at):
                         account = bandwidth.account()
                         device = bandwidth.device()
@@ -815,7 +815,7 @@ class SystemDevice(PlexObject):
         Attributes:
             TAG (str): 'Device'
             createdAt (datatime): Datetime the device was created.
-            id (int): The ID of the device.
+            id (int): The ID of the device (not the same as :class:`~plexapi.myplex.MyPlexDevice` ID).
             key (str): API URL (/devices/<id>)
             name (str): The name of the device.
             platform (str): OS the device is running (Linux, Windows, Chrome, etc.)

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -865,12 +865,18 @@ class StatisticsBandwidth(PlexObject):
     def account(self):
         """ Returns the :class:`~plexapi.server.SystemAccount` associated with the bandwidth data. """
         accounts = self._server.systemAccounts()
-        return next(account for account in accounts if account.id == self.accountID)
+        try:
+            return next(account for account in accounts if account.id == self.accountID)
+        except StopIteration:
+            raise NotFound('Unknown account for this bandwidth data: accountID=%s' % self.accountID)
 
     def device(self):
         """ Returns the :class:`~plexapi.server.SystemDevice` associated with the bandwidth data. """
         devices = self._server.systemDevices()
-        return next(device for device in devices if device.id == self.deviceID)
+        try:
+            return next(device for device in devices if device.id == self.deviceID)
+        except StopIteration:
+            raise NotFound('Unknown device for this bandwidth data: deviceID=%s' % self.deviceID)
 
 
 class StatisticsResources(PlexObject):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -671,7 +671,9 @@ class PlexServer(PlexObject):
         """
         params = {}
 
-        if timespan is not None:
+        if timespan is None:
+            params['timespan'] = 6  # Default to seconds
+        else:
             timespans = {
                 'seconds': 6,
                 'hours': 4,
@@ -684,8 +686,6 @@ class PlexServer(PlexObject):
             except KeyError:
                 raise BadRequest('Invalid timespan specified: %s. '
                     'Available timespans: %s' % (timespan, ', '.join(timespans.keys())))
-        else:
-            params['timespan'] = 6  # Default to seconds
 
         filters = {'accountID', 'at', 'at<', 'at>', 'bytes', 'bytes<', 'bytes>', 'deviceID', 'lan'}
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -621,8 +621,8 @@ class PlexServer(PlexObject):
             with the Plex server dashboard bandwidth data.
 
             Parameters:
-                timespan (str, optional): The timespan to bin the bandwidth data. Default returns bandwidth
-                    for all available timespans. Available timespans: seconds, hours, days, weeks, months.
+                timespan (str, optional): The timespan to bin the bandwidth data. Default is seconds.
+                    Available timespans: seconds, hours, days, weeks, months.
                 **kwargs (dict, optional): Any of the available filters that can be applied to the bandwidth data.
                     The time frame (at) and bytes can also be filtered using less than or greater than (see examples below).
 
@@ -684,6 +684,8 @@ class PlexServer(PlexObject):
             except KeyError:
                 raise BadRequest('Invalid timespan specified: %s. '
                     'Available timespans: %s' % (timespan, ', '.join(timespans.keys())))
+        else:
+            params['timespan'] = 6  # Default to seconds
 
         filters = {'accountID', 'at', 'at<', 'at>', 'bytes', 'bytes<', 'bytes>', 'deviceID', 'lan'}
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -860,7 +860,8 @@ class StatisticsBandwidth(PlexObject):
         return '<%s>' % ':'.join([p for p in [
             self.__class__.__name__,
             self._clean(self.accountID),
-            self._clean(self.deviceID)
+            self._clean(self.deviceID),
+            self._clean(int(self.at.timestamp()))
         ] if p])
 
     def account(self):
@@ -900,5 +901,5 @@ class StatisticsResources(PlexObject):
     def __repr__(self):
         return '<%s>' % ':'.join([p for p in [
             self.__class__.__name__,
-            self._clean(self.at)
+            self._clean(int(self.at.timestamp()))
         ] if p])

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -107,8 +107,8 @@ class PlexServer(PlexObject):
         self._library = None   # cached library
         self._settings = None   # cached settings
         self._myPlexAccount = None   # cached myPlexAccount
-        self._systemAccounts = None # cached list of SystemAccount
-        self._systemDevices = None # cached list of SystemDevice
+        self._systemAccounts = None   # cached list of SystemAccount
+        self._systemDevices = None   # cached list of SystemDevice
         data = self.query(self.key, timeout=timeout)
         super(PlexServer, self).__init__(self, data, self.key)
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -317,7 +317,7 @@ class PlexServer(PlexObject):
                 name (str): Name of the client to return.
 
             Raises:
-                :exc:`~plexapi.exceptions.NotFound`: Unknown client name
+                :exc:`~plexapi.exceptions.NotFound`: Unknown client name.
         """
         for client in self.clients():
             if client and client.title == name:
@@ -440,7 +440,7 @@ class PlexServer(PlexObject):
                 title (str): Title of the playlist to return.
 
             Raises:
-                :exc:`~plexapi.exceptions.NotFound`: Invalid playlist title
+                :exc:`~plexapi.exceptions.NotFound`: Invalid playlist title.
         """
         return self.fetchItem('/playlists', title=title)
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -616,7 +616,7 @@ class PlexServer(PlexObject):
         value = 1 if toggle is True else 0
         return self.query('/:/prefs?allowMediaDeletion=%s' % value, self._session.put)
 
-    def dashboardBandwidth(self, timespan=None, **kwargs):
+    def bandwidth(self, timespan=None, **kwargs):
         """ Returns a list of :class:`~plexapi.server.StatisticsBandwidth` objects
             with the Plex server dashboard bandwidth data.
 
@@ -656,10 +656,10 @@ class PlexServer(PlexObject):
                     }
 
                     # Retrieve bandwidth data in one day timespans.
-                    dashboardBandwidth = plex.dashboardBandwidth(timespan='days', **filters)
+                    bandwidthData = plex.bandwidth(timespan='days', **filters)
 
                     # Print out bandwidth usage for each account and device combination
-                    for bandwidth in sorted(dashboardBandwidth, key=lambda x: x.at):
+                    for bandwidth in sorted(bandwidthData, key=lambda x: x.at):
                         account = bandwidth.account()
                         device = bandwidth.device()
                         gigabytes = round(bandwidth.bytes / 1024**3, 3)
@@ -706,7 +706,7 @@ class PlexServer(PlexObject):
         data = self.query(key)
         return self.findItems(data, StatisticsBandwidth)
 
-    def dashboardResources(self):
+    def resources(self):
         """ Returns a list of :class:`~plexapi.server.StatisticsResources` objects
             with the Plex server dashboard resources data. """
         key = '/statistics/resources?timespan=6'

--- a/plexapi/sync.py
+++ b/plexapi/sync.py
@@ -201,7 +201,7 @@ class MediaSettings(object):
                 videoQuality (int): idx of quality of the video, one of VIDEO_QUALITY_* values defined in this module.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: when provided unknown video quality.
+                :exc:`~plexapi.exceptions.BadRequest`: When provided unknown video quality.
         """
         if videoQuality == VIDEO_QUALITY_ORIGINAL:
             return MediaSettings('', '', '')
@@ -231,7 +231,7 @@ class MediaSettings(object):
                                   module.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest` when provided unknown video quality.
+                :exc:`~plexapi.exceptions.BadRequest`: When provided unknown video quality.
         """
         if resolution in PHOTO_QUALITIES:
             return MediaSettings(photoQuality=PHOTO_QUALITIES[resolution], photoResolution=resolution)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,6 +341,10 @@ def is_float(value, gte=1.0):
     return float(value) >= gte
 
 
+def is_bool(value):
+    return value is True or value is False
+
+
 def is_metadata(key, prefix="/library/metadata/", contains="", suffix=""):
     try:
         assert key.startswith(prefix)

--- a/tests/payloads.py
+++ b/tests/payloads.py
@@ -22,3 +22,10 @@ SONOS_RESOURCES = """<MediaContainer size="3">
   <Player title="Speaker 3" machineIdentifier="RINCON_12345678901234563:1234567893" deviceClass="speaker" product="Sonos" platform="Sonos" platformVersion="56.0-76060" protocol="plex" protocolVersion="1" protocolCapabilities="timeline,playback,playqueues,provider-playback" lanIP="192.168.1.13"/>
 </MediaContainer>
 """
+
+SERVER_RESOURCES = """<MediaContainer size="3">
+<StatisticsResources timespan="6" at="1609708609" hostCpuUtilization="0.000" processCpuUtilization="0.207" hostMemoryUtilization="64.946" processMemoryUtilization="3.665"/>
+<StatisticsResources timespan="6" at="1609708614" hostCpuUtilization="5.000" processCpuUtilization="0.713" hostMemoryUtilization="64.939" processMemoryUtilization="3.666"/>
+<StatisticsResources timespan="6" at="1609708619" hostCpuUtilization="10.000" processCpuUtilization="4.415" hostMemoryUtilization="64.281" processMemoryUtilization="3.669"/>
+</MediaContainer>
+"""


### PR DESCRIPTION
## Description

Adds support for the bandwidth and resources data on the Plex dashboard.

#### New objects:
* `server.SystemAccount` is an account associated with the server. (Updated existing object)
* `server.SystemDevice` is a device associated with the server.
* `server.StatisticsBandwidth` is the bandwidth data for a single account / device / timestamp combination.
* `server.StatisticsResources` is the resource data for a single timestamp.

#### New methods:
* `PlexServer.systemAccounts()` returns a list of accounts associated with the Plex server. (Updated existing method)
* `PlexServer.systemDevices()` returns a list of devices associated with the Plex server.
* `PlexServer.bandwidth()` will return a list of the dashboard bandwidth data. The `timespan` parameter will bin the bandwidth data and `**kwargs` can be used to filter the bandwidth data.
* `PlexServer.resources()` will return a list of the dashboard CPU and RAM usage data. Only live data (1 second intervals) is available.

#### Other changes:
* `MyPlexAccount.id` casted to an `int` instead of a `str`.

#### Example:
```py
from plexapi.server import PlexServer
plex = PlexServer('http://localhost:32400', token='xxxxxxxxxxxxxxxxxxxx')

# Filter bandwidth data for December 2020 and later and more than 1 GB used.
filters = {
    'at>': datetime(2020, 12, 1),
    'bytes>': 1024**3
}

# Retrieve bandwidth data in one day timespans.
bandwidthData = plex.bandwidth(timespan='days', **filters)

# Print out bandwidth usage for each account and device combination
for bandwidth in sorted(bandwidthData, key=lambda x: x.at):
    account = bandwidth.account()
    device = bandwidth.device()
    gigabytes = round(bandwidth.bytes / 1024**3, 3)
    local = 'local' if bandwidth.lan else 'remote'
    date = bandwidth.at.strftime('%Y-%m-%d')
    print('%s used %s GB of %s bandwidth on %s from %s'
          % (account.name, gigabytes, local, date, device.name))
```

Partially addresses #356

TODO: Add some tests. I don't know if bandwidth tests will work since the test server won't have any history. Maybe just check that the dashboard returns *something* using the live `seconds` interval.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
