### PR TITLE
Add thumbUrl and artUrl properties to Collections

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1595,7 +1595,17 @@ class Collections(PlexPartialObject):
     @deprecated('use "items" instead')
     def children(self):
         return self.fetchItems(self.key)
-        
+
+    @property
+    def thumbUrl(self):
+        """ Return the thumbnail url for the collection."""
+        return self._server.url(self.thumb, includeToken=True) if self.thumb else None
+
+    @property
+    def artUrl(self):
+        """ Return the art url for the collection."""
+        return self._server.url(self.art, includeToken=True) if self.art else None
+
     def item(self, title):
         """ Returns the item in the collection that matches the specified title.
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -313,6 +313,16 @@ def test_library_Collection_items(collection):
     assert len(items) == 1
 
 
+def test_library_Collection_thumbUrl(collection):
+    assert utils.SERVER_BASEURL in collection.thumbUrl
+    assert "/library/collections/" in collection.thumbUrl
+    assert "/composite/" in collection.thumbUrl
+
+
+def test_library_Collection_artUrl(collection):
+    assert collection.artUrl is None  # Collections don't have default art
+
+
 def test_search_with_weird_a(plex):
     ep_title = "Coup de Grâce"
     result_root = plex.search(ep_title)


### PR DESCRIPTION
## Description

* Add `Collections.thumbUrl` and `Collections.artUrl` properties to retrieve the server URL to the collection poster and artwork.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
