### PR TITLE
Fix sorting of resource connections

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -964,12 +964,12 @@ class MyPlexResource(PlexObject):
         locations = ['local', 'remote', 'relay']
         schemes = ['https', 'http']
         connections_dict = {location: {scheme: [] for scheme in schemes} for location in locations}
-        for c in self.connections:
+        for connection in self.connections:
             # Only check non-local connections unless we own the resource
-            if self.owned or (not self.owned and not c.local):
-                location = 'relay' if c.relay else ('local' if c.local else 'remote')
-                connections_dict[location]['http'].append(c.httpuri)
-                connections_dict[location]['https'].append(c.uri)
+            if self.owned or (not self.owned and not connection.local):
+                location = 'relay' if connection.relay else ('local' if connection.local else 'remote')
+                connections_dict[location]['http'].append(connection.httpuri)
+                connections_dict[location]['https'].append(connection.uri)
         if ssl is True: schemes.remove('http')
         elif ssl is False: schemes.remove('https')
         connections = []

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -947,15 +947,15 @@ class MyPlexResource(PlexObject):
     def connect(self, ssl=None, timeout=None):
         """ Returns a new :class:`~plexapi.server.PlexServer` or :class:`~plexapi.client.PlexClient` object.
             Often times there is more than one address specified for a server or client.
-            This function will prioritize local connections before remote and HTTPS before HTTP.
+            This function will prioritize local connections before remote or relay and HTTPS before HTTP.
             After trying to connect to all available addresses for this resource and
             assuming at least one connection was successful, the PlexServer object is built and returned.
 
             Parameters:
-                ssl (optional): Set True to only connect to HTTPS connections. Set False to
+                ssl (bool, optional): Set True to only connect to HTTPS connections. Set False to
                     only connect to HTTP connections. Set None (default) to connect to any
                     HTTP or HTTPS connection.
-                timeout (int): The timeout in seconds to attempt each connection.
+                timeout (int, optional): The timeout in seconds to attempt each connection.
 
             Raises:
                 :exc:`~plexapi.exceptions.NotFound`: When unable to connect to any addresses for this resource.


### PR DESCRIPTION
## Description

The `MyPlexResouce` connections were not sorted in the correct order for connection attempts. This corrects the connections to the following order:

* Local
  * HTTPS, HTTP
* Remote
  * HTTPS, HTTP
* Relay
  * HTTPS, HTTP


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
