### PR TITLE
Fix checking object parent when the weakref is dead

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -119,7 +119,7 @@ class PlexObject(object):
                     See all possible `**kwargs*` in :func:`~plexapi.base.PlexObject.fetchItem`.
         """
         obj = self
-        while obj._parent is not None:
+        while obj._parent is not None and obj._parent() is not None:
             obj = obj._parent()
             if obj._checkAttrs(obj._data, **kwargs):
                 return True

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -119,9 +119,9 @@ class PlexObject(object):
                     See all possible `**kwargs*` in :func:`~plexapi.base.PlexObject.fetchItem`.
         """
         obj = self
-        while obj._parent is not None and obj._parent() is not None:
+        while obj and obj._parent is not None:
             obj = obj._parent()
-            if obj._checkAttrs(obj._data, **kwargs):
+            if obj and obj._checkAttrs(obj._data, **kwargs):
                 return True
         return False
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -739,6 +739,16 @@ def test_video_Episode_history(episode):
     episode.markUnwatched()
 
 
+def test_video_Episode_parent_weakref(show):
+    season = show.season(season=1)
+    episode = season.episode(episode=1)
+    assert episode._parent is not None
+    assert episode._parent() == season
+    episode = show.season(season=1).episode(episode=1)
+    assert episode._parent is not None
+    assert episode._parent() is None
+
+
 # Analyze seems to fail intermittently
 @pytest.mark.xfail
 def test_video_Episode_analyze(tvshows):


### PR DESCRIPTION
## Description

When an object is created through chaining, the `weakref` to the `episode._parent` object is dead because the season object is not saved. This fix ensures that the `weakref` is still alive when checking `_isChildOf`.

```python
>>> season = show.season(season=1)
>>> episode = season.episode(episode=1)
>>> episode._parent  # weakref is alive
<weakref at 0x0000013280F436D0; to 'Season' at 0x0000013280FC9C10>

>>> episode = show.season(season=1).episode(episode=1)
>>> episode._parent  # weakref is dead
<weakref at 0x0000013280F304A0; dead>
```

Fixes #654

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
