### PR TITLE
Fix episode parentKey and parentRatingKey when seasons are hidden in Plex

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -47,6 +47,7 @@ class PlexObject(object):
         self._data = data
         self._initpath = initpath or self.key
         self._parent = weakref.ref(parent) if parent else None
+        self._details_key = None
         if data is not None:
             self._loadData(data)
         self._details_key = self._buildDetailsKey()

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -738,6 +738,7 @@ class Episode(Playable, Video):
             parentThumb (str): URL to season thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the season for the episode.
             rating (float): Episode rating (7.9; 9.8; 8.1).
+            skipParent (bool): True if the show's seasons are set to hidden.
             viewOffset (int): View offset in milliseconds.
             writers (List<:class:`~plexapi.media.Writer`>): List of writers objects.
             year (int): Year episode was released.
@@ -774,9 +775,22 @@ class Episode(Playable, Video):
         self.parentThumb = data.attrib.get('parentThumb')
         self.parentTitle = data.attrib.get('parentTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
+        self.skipParent = utils.cast(bool, data.attrib.get('skipParent', '0'))
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.writers = self.findItems(data, media.Writer)
         self.year = utils.cast(int, data.attrib.get('year'))
+
+        # If seasons are hidden, parentKey and parentRatingKey are missing from the XML response.
+        # https://forums.plex.tv/t/parentratingkey-not-in-episode-xml-when-seasons-are-hidden/300553
+        if self.skipParent and not self.parentRatingKey:
+            # Parse the parentRatingKey from the parentThumb
+            if self.parentThumb.startswith('/library/metadata/'):
+                self.parentRatingKey = utils.cast(int, self.parentThumb.split('/')[3])
+            # Get the parentRatingKey from the season's ratingKey
+            if not self.parentRatingKey and self.grandparentRatingKey:
+                self.parentRatingKey = self.show().season(season=self.parentIndex).ratingKey
+            if self.parentRatingKey:
+                self.parentKey = '/library/metadata/%s' % self.parentRatingKey
 
     def __repr__(self):
         return '<%s>' % ':'.join([p for p in [

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -739,6 +739,21 @@ def test_video_Episode_history(episode):
     episode.markUnwatched()
 
 
+def test_video_Episode_hidden_season(episode):
+    assert episode.skipParent is False
+    assert episode.parentRatingKey
+    assert episode.parentKey
+    assert episode.seasonNumber
+    show = episode.show()
+    show.editAdvanced(flattenSeasons=1)
+    episode.reload()
+    assert episode.skipParent is True
+    assert episode.parentRatingKey
+    assert episode.parentKey
+    assert episode.seasonNumber
+    show.defaultAdvanced()
+
+
 # Analyze seems to fail intermittently
 @pytest.mark.xfail
 def test_video_Episode_analyze(tvshows):
@@ -765,6 +780,7 @@ def test_video_Episode_attrs(episode):
     assert episode.rating >= 7.7
     assert utils.is_int(episode.ratingKey)
     assert episode._server._baseurl == utils.SERVER_BASEURL
+    assert episode.skipParent is False
     assert utils.is_string(episode.summary, gte=100)
     assert utils.is_metadata(episode.thumb, contains="/thumb/")
     assert episode.title == "Winter Is Coming"


### PR DESCRIPTION
## Description

If seasons are hidden in Plex, `parentKey` and `parentRatingKey` are missing from the episode XML response.
https://forums.plex.tv/t/parentratingkey-not-in-episode-xml-when-seasons-are-hidden/300553

This fix tries to parse the `parentRatingKey` from the `parentThumb` or falls back to retrieving the season's `ratingKey` by matching the `parentIndex`.

Also adds the `skipParent` attribute to episodes which indicates if seasons are hidden for the show.

Fixes #655

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
