### PR TITLE
Don't refresh metadata after editing tags

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -463,10 +463,9 @@ class PlexPartialObject(PlexObject):
         if not isinstance(items, list):
             items = [items]
         value = getattr(self, tag_plural(tag))
-        existing_cols = [t.tag for t in value if t and remove is False]
-        d = tag_helper(tag, existing_cols + items, locked, remove)
-        self.edit(**d)
-        self.refresh()
+        existing_tags = [t.tag for t in value if t and remove is False]
+        tag_edits = tag_helper(tag, existing_tags + items, locked, remove)
+        self.edit(**tag_edits)
 
     def refresh(self):
         """ Refreshing a Library or individual item causes the metadata for the item to be

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -452,13 +452,13 @@ class PlexPartialObject(PlexObject):
         self._server.query(part, method=self._server._session.put)
 
     def _edit_tags(self, tag, items, locked=True, remove=False):
-        """ Helper to edit and refresh a tags.
+        """ Helper to edit tags.
 
             Parameters:
-                tag (str): tag name
-                items (list): list of tags to add
-                locked (bool): lock this field.
-                remove (bool): If this is active remove the tags in items.
+                tag (str): Tag name.
+                items (list): List of tags to add.
+                locked (bool): True to lock the field.
+                remove (bool): True to remove the tags in items.
         """
         if not isinstance(items, list):
             items = [items]

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -708,10 +708,10 @@ class Collection(MediaTag):
 
 @utils.registerPlexObject
 class Label(MediaTag):
-    """ Represents a single label media tag.
+    """ Represents a single Label media tag.
 
         Attributes:
-            TAG (str): 'label'
+            TAG (str): 'Label'
             FILTER (str): 'label'
     """
     TAG = 'Label'
@@ -720,10 +720,10 @@ class Label(MediaTag):
 
 @utils.registerPlexObject
 class Tag(MediaTag):
-    """ Represents a single tag media tag.
+    """ Represents a single Tag media tag.
 
         Attributes:
-            TAG (str): 'tag'
+            TAG (str): 'Tag'
             FILTER (str): 'tag'
     """
     TAG = 'Tag'

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -4,218 +4,240 @@
 class CollectionMixin(object):
     """ Mixin for Plex objects that can have collections. """
 
-    def addCollection(self, collections):
+    def addCollection(self, collections, locked=True):
         """ Add a collection tag(s).
 
            Parameters:
                 collections (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('collection', collections)
+        self._edit_tags('collection', collections, locked=locked)
 
-    def removeCollection(self, collections):
+    def removeCollection(self, collections, locked=True):
         """ Remove a collection tag(s).
 
            Parameters:
                 collections (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('collection', collections, remove=True)
+        self._edit_tags('collection', collections, locked=locked, remove=True)
 
 
 class CountryMixin(object):
     """ Mixin for Plex objects that can have countries. """
 
-    def addCountry(self, countries):
+    def addCountry(self, countries, locked=True):
         """ Add a country tag(s).
 
            Parameters:
                 countries (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('country', countries)
+        self._edit_tags('country', countries, locked=locked)
 
-    def removeCountry(self, countries):
+    def removeCountry(self, countries, locked=True):
         """ Remove a country tag(s).
 
            Parameters:
                 countries (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('country', countries, remove=True)
+        self._edit_tags('country', countries, locked=locked, remove=True)
 
 
 class DirectorMixin(object):
     """ Mixin for Plex objects that can have directors. """
 
-    def addDirector(self, directors):
+    def addDirector(self, directors, locked=True):
         """ Add a director tag(s).
 
            Parameters:
                 directors (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('director', directors)
+        self._edit_tags('director', directors, locked=locked)
 
-    def removeDirector(self, directors):
+    def removeDirector(self, directors, locked=True):
         """ Remove a director tag(s).
 
            Parameters:
                 directors (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('director', directors, remove=True)
+        self._edit_tags('director', directors, locked=locked, remove=True)
 
 
 class GenreMixin(object):
     """ Mixin for Plex objects that can have genres. """
 
-    def addGenre(self, genres):
+    def addGenre(self, genres, locked=True):
         """ Add a genre tag(s).
 
            Parameters:
                 genres (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('genre', genres)
+        self._edit_tags('genre', genres, locked=locked)
 
-    def removeGenre(self, genres):
+    def removeGenre(self, genres, locked=True):
         """ Remove a genre tag(s).
 
            Parameters:
                 genres (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('genre', genres, remove=True)
+        self._edit_tags('genre', genres, locked=locked, remove=True)
 
 
 class LabelMixin(object):
     """ Mixin for Plex objects that can have labels. """
 
-    def addLabel(self, labels):
+    def addLabel(self, labels, locked=True):
         """ Add a label tag(s).
 
            Parameters:
                 labels (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('label', labels)
+        self._edit_tags('label', labels, locked=locked)
 
-    def removeLabel(self, labels):
+    def removeLabel(self, labels, locked=True):
         """ Remove a label tag(s).
 
            Parameters:
                 labels (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('label', labels, remove=True)
+        self._edit_tags('label', labels, locked=locked, remove=True)
 
 
 class MoodMixin(object):
     """ Mixin for Plex objects that can have moods. """
 
-    def addMood(self, moods):
+    def addMood(self, moods, locked=True):
         """ Add a mood tag(s).
 
            Parameters:
                 moods (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('mood', moods)
+        self._edit_tags('mood', moods, locked=locked)
 
-    def removeMood(self, moods):
+    def removeMood(self, moods, locked=True):
         """ Remove a mood tag(s).
 
            Parameters:
                 moods (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('mood', moods, remove=True)
+        self._edit_tags('mood', moods, locked=locked, remove=True)
 
 
 class ProducerMixin(object):
     """ Mixin for Plex objects that can have producers. """
 
-    def addProducer(self, producers):
+    def addProducer(self, producers, locked=True):
         """ Add a producer tag(s).
 
            Parameters:
                 producers (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('producer', producers)
+        self._edit_tags('producer', producers, locked=locked)
 
-    def removeProducer(self, producers):
+    def removeProducer(self, producers, locked=True):
         """ Remove a producer tag(s).
 
            Parameters:
                 producers (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('producer', producers, remove=True)
+        self._edit_tags('producer', producers, locked=locked, remove=True)
 
 
 class SimilarArtistMixin(object):
     """ Mixin for Plex objects that can have similar artists. """
 
-    def addSimilarArtist(self, artists):
+    def addSimilarArtist(self, artists, locked=True):
         """ Add a similar artist tag(s).
 
            Parameters:
                 artists (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('similar', artists)
+        self._edit_tags('similar', artists, locked=locked)
 
-    def removeSimilarArtist(self, artists):
+    def removeSimilarArtist(self, artists, locked=True):
         """ Remove a similar artist tag(s).
 
            Parameters:
                 artists (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('similar', artists, remove=True)
+        self._edit_tags('similar', artists, locked=locked, remove=True)
 
 
 class StyleMixin(object):
     """ Mixin for Plex objects that can have styles. """
 
-    def addStyle(self, styles):
+    def addStyle(self, styles, locked=True):
         """ Add a style tag(s).
 
            Parameters:
                 styles (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('style', styles)
+        self._edit_tags('style', styles, locked=locked)
 
-    def removeStyle(self, styles):
+    def removeStyle(self, styles, locked=True):
         """ Remove a style tag(s).
 
            Parameters:
                 styles (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('style', styles, remove=True)
+        self._edit_tags('style', styles, locked=locked, remove=True)
 
 
 class TagMixin(object):
     """ Mixin for Plex objects that can have tags. """
 
-    def addTag(self, tags):
+    def addTag(self, tags, locked=True):
         """ Add a tag(s).
 
            Parameters:
                 tags (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('tag', tags)
+        self._edit_tags('tag', tags, locked=locked)
 
-    def removeTag(self, tags):
+    def removeTag(self, tags, locked=True):
         """ Remove a tag(s).
 
            Parameters:
                 tags (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('tag', tags, remove=True)
+        self._edit_tags('tag', tags, locked=locked, remove=True)
 
 
 class EditWriter(object):
     """ Mixin for Plex objects that can have writers. """
 
-    def addWriter(self, writers):
+    def addWriter(self, writers, locked=True):
         """ Add a writer tag(s).
 
            Parameters:
                 writers (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('writer', writers)
+        self._edit_tags('writer', writers, locked=locked)
 
-    def removeWriter(self, writers):
+    def removeWriter(self, writers, locked=True):
         """ Remove a writer tag(s).
 
            Parameters:
                 writers (list): List of strings.
+                locked (bool): True (default) to lock the field, False to unlock the field.
         """
-        self._edit_tags('writer', writers, remove=True)
+        self._edit_tags('writer', writers, locked=locked, remove=True)

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -335,6 +335,15 @@ def download(url, token, filename=None, savepath=None, session=None, chunksize=4
     return fullpath
 
 
+def tag_singular(tag):
+    if tag == 'countries':
+        return 'country'
+    elif tag == 'similar':
+        return 'similar'
+    else:
+        return tag[:-1]
+
+
 def tag_plural(tag):
     if tag == 'country':
         return 'countries'

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -10,8 +10,7 @@ def _test_mixins_tag(obj, attr, tag_method):
     obj.reload()
     assert TEST_MIXIN_TAG in [tag.tag for tag in getattr(obj, attr)]
     remove_tag_method(TEST_MIXIN_TAG)
-    # obj.reload()
-    obj = obj._server.fetchItem(obj.ratingKey)  # Workaround for issue #660
+    obj.reload()
     assert TEST_MIXIN_TAG not in [tag.tag for tag in getattr(obj, attr)]
 
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -3,8 +3,8 @@ TEST_MIXIN_TAG = "Test Tag"
 
 
 def _test_mixins_tag(obj, attr, tag_method):
-    add_tag_method = getattr(obj, 'add' + tag_method)
-    remove_tag_method = getattr(obj, 'remove' + tag_method)
+    add_tag_method = getattr(obj, "add" + tag_method)
+    remove_tag_method = getattr(obj, "remove" + tag_method)
     assert TEST_MIXIN_TAG not in [tag.tag for tag in getattr(obj, attr)]
     add_tag_method(TEST_MIXIN_TAG)
     obj.reload()
@@ -15,44 +15,44 @@ def _test_mixins_tag(obj, attr, tag_method):
 
 
 def edit_collection(obj):
-    _test_mixins_tag(obj, 'collections', 'Collection')
+    _test_mixins_tag(obj, "collections", "Collection")
 
 
 def edit_country(obj):
-    _test_mixins_tag(obj, 'countries', 'Country')
+    _test_mixins_tag(obj, "countries", "Country")
 
 
 def edit_director(obj):
-    _test_mixins_tag(obj, 'directors', 'Director')
+    _test_mixins_tag(obj, "directors", "Director")
 
 
 def edit_genre(obj):
-    _test_mixins_tag(obj, 'genres', 'Genre')
+    _test_mixins_tag(obj, "genres", "Genre")
 
 
 def edit_label(obj):
-    _test_mixins_tag(obj, 'labels', 'Label')
+    _test_mixins_tag(obj, "labels", "Label")
 
 
 def edit_mood(obj):
-    _test_mixins_tag(obj, 'moods', 'Mood')
+    _test_mixins_tag(obj, "moods", "Mood")
 
 
 def edit_producer(obj):
-    _test_mixins_tag(obj, 'producers', 'Producer')
+    _test_mixins_tag(obj, "producers", "Producer")
 
 
 def edit_similar_artist(obj):
-    _test_mixins_tag(obj, 'similar', 'SimilarArtist')
+    _test_mixins_tag(obj, "similar", "SimilarArtist")
 
 
 def edit_style(obj):
-    _test_mixins_tag(obj, 'styles', 'Style')
+    _test_mixins_tag(obj, "styles", "Style")
 
 
 def edit_tag(obj):
-    _test_mixins_tag(obj, 'tags', 'Tag')
+    _test_mixins_tag(obj, "tags", "Tag")
 
 
 def edit_writer(obj):
-    _test_mixins_tag(obj, 'writers', 'Writer')
+    _test_mixins_tag(obj, "writers", "Writer")

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,17 +1,27 @@
 # -*- coding: utf-8 -*-
+from plexapi.utils import tag_singular
+
 TEST_MIXIN_TAG = "Test Tag"
 
 
 def _test_mixins_tag(obj, attr, tag_method):
     add_tag_method = getattr(obj, "add" + tag_method)
     remove_tag_method = getattr(obj, "remove" + tag_method)
+    field_name = tag_singular(attr)
+    # Check tag is not present to begin with
     assert TEST_MIXIN_TAG not in [tag.tag for tag in getattr(obj, attr)]
+    # Add tag and lock the field
     add_tag_method(TEST_MIXIN_TAG)
     obj.reload()
+    field = [f for f in obj.fields if f.name == field_name]
     assert TEST_MIXIN_TAG in [tag.tag for tag in getattr(obj, attr)]
-    remove_tag_method(TEST_MIXIN_TAG)
+    assert field and field[0].locked
+    # Remove tag and unlock to field to restore the clean state
+    remove_tag_method(TEST_MIXIN_TAG, locked=False)
     obj.reload()
+    field = [f for f in obj.fields if f.name == field_name]
     assert TEST_MIXIN_TAG not in [tag.tag for tag in getattr(obj, attr)]
+    assert not field
 
 
 def edit_collection(obj):

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -10,7 +10,8 @@ def _test_mixins_tag(obj, attr, tag_method):
     obj.reload()
     assert TEST_MIXIN_TAG in [tag.tag for tag in getattr(obj, attr)]
     remove_tag_method(TEST_MIXIN_TAG)
-    obj.reload()
+    # obj.reload()
+    obj = obj._server.fetchItem(obj.ratingKey)  # Workaround for issue #660
     assert TEST_MIXIN_TAG not in [tag.tag for tag in getattr(obj, attr)]
 
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -8,20 +8,25 @@ def _test_mixins_tag(obj, attr, tag_method):
     add_tag_method = getattr(obj, "add" + tag_method)
     remove_tag_method = getattr(obj, "remove" + tag_method)
     field_name = tag_singular(attr)
+    _tags = lambda: [t.tag for t in getattr(obj, attr)]
+    _fields = lambda: [f for f in obj.fields if f.name == field_name]
     # Check tag is not present to begin with
-    assert TEST_MIXIN_TAG not in [tag.tag for tag in getattr(obj, attr)]
+    tags = _tags()
+    assert TEST_MIXIN_TAG not in tags
     # Add tag and lock the field
     add_tag_method(TEST_MIXIN_TAG)
     obj.reload()
-    field = [f for f in obj.fields if f.name == field_name]
-    assert TEST_MIXIN_TAG in [tag.tag for tag in getattr(obj, attr)]
-    assert field and field[0].locked
+    tags = _tags()
+    fields = _fields()
+    assert TEST_MIXIN_TAG in tags
+    assert fields and fields[0].locked
     # Remove tag and unlock to field to restore the clean state
     remove_tag_method(TEST_MIXIN_TAG, locked=False)
     obj.reload()
-    field = [f for f in obj.fields if f.name == field_name]
-    assert TEST_MIXIN_TAG not in [tag.tag for tag in getattr(obj, attr)]
-    assert not field
+    tags = _tags()
+    fields = _fields()
+    assert TEST_MIXIN_TAG not in tags
+    assert not fields
 
 
 def edit_collection(obj):


### PR DESCRIPTION
Just two additional minor commits that should have been included in #649.

Also workaround #660 for reloading object in mixins tag test.