### PR TITLE
Fix bug preventing overwriting attrs with a blank list

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -58,8 +58,8 @@ class PlexObject(object):
         return '<%s>' % ':'.join([p for p in [self.__class__.__name__, uid, name] if p])
 
     def __setattr__(self, attr, value):
-        # Don't overwrite an attr with None or [] unless it's a private variable
-        if value not in [None, []] or attr.startswith('_') or attr not in self.__dict__:
+        # Don't overwrite an attr with None unless it's a private variable
+        if value is not None or attr.startswith('_') or attr not in self.__dict__:
             self.__dict__[attr] = value
 
     def _clean(self, value):
@@ -572,6 +572,13 @@ class Playable(object):
             playlistItemID (int): Playlist item ID (only populated for :class:`~plexapi.playlist.Playlist` items).
             playQueueItemID (int): PlayQueue item ID (only populated for :class:`~plexapi.playlist.PlayQueue` items).
     """
+
+    def __setattr__(self, attr, value):
+        # Don't overwrite session specific attr with []
+        session_attrs = ('usernames', 'players', 'transcodeSessions', 'session')
+        if attr in session_attrs and value == []:
+            value = getattr(self, attr, [])
+        PlexObject.__setattr__(self, attr, value)
 
     def _loadData(self, data):
         self.sessionKey = utils.cast(int, data.attrib.get('sessionKey'))            # session


### PR DESCRIPTION
## Description

Explicitly specify the `Playable` session attributes that should not be overwritten with a blank list.

Fixes #660

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
