### PR TITLE
Add originalTitle attribute to show

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -407,6 +407,7 @@ class Show(Video, SplitMergeMixin, UnmatchMatchMixin,
             leafCount (int): Number of items in the show view.
             locations (List<str>): List of folder paths where the show is found on disk.
             originallyAvailableAt (datetime): Datetime the show was released.
+            originalTitle (str): The original title of the show.
             rating (float): Show rating (7.9; 9.8; 8.1).
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
@@ -434,6 +435,7 @@ class Show(Video, SplitMergeMixin, UnmatchMatchMixin,
         self.leafCount = utils.cast(int, data.attrib.get('leafCount'))
         self.locations = self.listAttrs(data, 'path', etag='Location')
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
+        self.originalTitle = data.attrib.get('originalTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.roles = self.findItems(data, media.Role)
         self.similar = self.findItems(data, media.Similar)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -566,6 +566,7 @@ def test_video_Show_attrs(show):
     assert len(show.locations) == 1
     assert len(show.locations[0]) >= 10
     assert utils.is_datetime(show.originallyAvailableAt)
+    assert show.originalTitle == ""
     assert show.rating >= 8.0
     assert utils.is_int(show.ratingKey)
     assert sorted([i.tag for i in show.roles])[:4] == [

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -566,7 +566,7 @@ def test_video_Show_attrs(show):
     assert len(show.locations) == 1
     assert len(show.locations[0]) >= 10
     assert utils.is_datetime(show.originallyAvailableAt)
-    assert show.originalTitle == ""
+    assert show.originalTitle is None
     assert show.rating >= 8.0
     assert utils.is_int(show.ratingKey)
     assert sorted([i.tag for i in show.roles])[:4] == [


### PR DESCRIPTION
## Description

Adds the missing `Show.originalTitle` attribute.

![image](https://user-images.githubusercontent.com/9099342/107604196-21e05e80-6be4-11eb-8ba9-e1096ef0699f.png)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
