### PR TITLE
Rename server checkForUpdate

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -662,17 +662,3 @@ class Playable(object):
         key %= (self.ratingKey, self.key, time, state, durationStr)
         self._server.query(key)
         self.reload()
-
-
-@utils.registerPlexObject
-class Release(PlexObject):
-    TAG = 'Release'
-    key = '/updater/status'
-
-    def _loadData(self, data):
-        self.download_key = data.attrib.get('key')
-        self.version = data.attrib.get('version')
-        self.added = data.attrib.get('added')
-        self.fixed = data.attrib.get('fixed')
-        self.downloadURL = data.attrib.get('downloadURL')
-        self.state = data.attrib.get('state')

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -787,6 +787,20 @@ class Activity(PlexObject):
         self.uuid = data.attrib.get('uuid')
 
 
+@utils.registerPlexObject
+class Release(PlexObject):
+    TAG = 'Release'
+    key = '/updater/status'
+
+    def _loadData(self, data):
+        self.download_key = data.attrib.get('key')
+        self.version = data.attrib.get('version')
+        self.added = data.attrib.get('added')
+        self.fixed = data.attrib.get('fixed')
+        self.downloadURL = data.attrib.get('downloadURL')
+        self.state = data.attrib.get('state')
+
+
 class SystemAccount(PlexObject):
     """ Represents a single system account.
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -15,7 +15,7 @@ from plexapi.media import Conversion, Optimized
 from plexapi.playlist import Playlist
 from plexapi.playqueue import PlayQueue
 from plexapi.settings import Settings
-from plexapi.utils import cast
+from plexapi.utils import cast, deprecated
 from requests.status_codes import _codes as codes
 
 # Need these imports to populate utils.PLEXOBJECTS
@@ -374,7 +374,11 @@ class PlexServer(PlexObject):
         filepath = utils.download(url, self._token, None, savepath, self._session, unpack=unpack)
         return filepath
 
+    @deprecated('use "checkForUpdate" instead')
     def check_for_update(self, force=True, download=False):
+        return self.checkForUpdate()
+
+    def checkForUpdate(self, force=True, download=False):
         """ Returns a :class:`~plexapi.base.Release` object containing release info.
 
            Parameters:
@@ -390,7 +394,7 @@ class PlexServer(PlexObject):
 
     def isLatest(self):
         """ Check if the installed version of PMS is the latest. """
-        release = self.check_for_update(force=True)
+        release = self.checkForUpdate(force=True)
         return release is None
 
     def installUpdate(self):
@@ -398,7 +402,7 @@ class PlexServer(PlexObject):
         # We can add this but dunno how useful this is since it sometimes
         # requires user action using a gui.
         part = '/updater/apply'
-        release = self.check_for_update(force=True, download=True)
+        release = self.checkForUpdate(force=True, download=True)
         if release and release.version != self.version:
             # figure out what method this is..
             return self.query(part, method=self._session.put)


### PR DESCRIPTION
## Description

* Move `Release` to the server module.
* Rename `PlexServer.checkForUpdate()` to match camelCase and add depreaction warning to `PlexServer.check_for_update()`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
