### PR TITLE
Fix gdm.GDM.find_by_content_type()

### DIFF
--- a/plexapi/gdm.py
+++ b/plexapi/gdm.py
@@ -38,7 +38,7 @@ class GDM:
         """Return a list of entries that match the content_type."""
         self.scan()
         return [entry for entry in self.entries
-                if value in entry['data']['Content_Type']]
+                if value in entry['data']['Content-Type']]
 
     def find_by_data(self, values):
         """Return a list of entries that match the search parameters."""

--- a/plexapi/gdm.py
+++ b/plexapi/gdm.py
@@ -13,7 +13,11 @@ import struct
 
 
 class GDM:
-    """Base class to discover GDM services."""
+    """Base class to discover GDM services.
+
+       Atrributes:
+           entries (List<dict>): List of server and/or client data discovered.
+    """
 
     def __init__(self):
         self.entries = []

--- a/plexapi/gdm.py
+++ b/plexapi/gdm.py
@@ -17,7 +17,6 @@ class GDM:
 
     def __init__(self):
         self.entries = []
-        self.last_scan = None
 
     def scan(self, scan_for_clients=False):
         """Scan the network."""


### PR DESCRIPTION
While trying to integrate `plexapi.gdm.GDM.find_by_content_type()` into my service I noticed that it always throws an error because it tries to extract `Content_Type` instead of `Content-Type` from the received data. The last commit of this PR fixes that.

I added two additional commits:
* the first commit removes the unused attribute `last_scan`
* the second commit adds missing documentation for the `entries` attribute