### PR TITLE
Add tagline attribute to show

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -399,6 +399,7 @@ class Show(Video, ArtMixin, BannerMixin, PosterMixin, SplitMergeMixin, UnmatchMa
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             studio (str): Studio that created show (Di Bonaventura Pictures; 21 Laps Entertainment).
+            tagline (str): Show tag line.
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
             viewedLeafCount (int): Number of items marked as played in the show view.
             year (int): Year the show was released.
@@ -427,6 +428,7 @@ class Show(Video, ArtMixin, BannerMixin, PosterMixin, SplitMergeMixin, UnmatchMa
         self.roles = self.findItems(data, media.Role)
         self.similar = self.findItems(data, media.Similar)
         self.studio = data.attrib.get('studio')
+        self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -588,6 +588,7 @@ def test_video_Show_attrs(show):
     assert show._server._baseurl == utils.SERVER_BASEURL
     assert show.studio == "HBO"
     assert utils.is_string(show.summary, gte=100)
+    assert show.tagline is None
     assert utils.is_metadata(show.theme, contains="/theme/")
     if show.thumb:
         assert utils.is_thumb(show.thumb)


### PR DESCRIPTION
## Description

Adds the missing `Show.tagline` attribute.

Fixes #672

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
