### PR TITLE
Fix season watched/unwatched

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -678,11 +678,11 @@ class Season(Video, ArtMixin, PosterMixin):
 
     def watched(self):
         """ Returns list of watched :class:`~plexapi.video.Episode` objects. """
-        return self.episodes(watched=True)
+        return self.episodes(viewCount__gt=0)
 
     def unwatched(self):
         """ Returns list of unwatched :class:`~plexapi.video.Episode` objects. """
-        return self.episodes(watched=False)
+        return self.episodes(viewCount=0)
 
     def download(self, savepath=None, keep_original_name=False, **kwargs):
         """ Download video files to specified directory.

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -611,17 +611,21 @@ def test_video_Show_history(show):
 
 def test_video_Show_watched(tvshows):
     show = tvshows.get("The 100")
-    show.episodes()[0].markWatched()
+    episode = show.episodes()[0]
+    episode.markWatched()
     watched = show.watched()
     assert len(watched) == 1 and watched[0].title == "Pilot"
+    episode.markUnwatched()
 
 
 def test_video_Show_unwatched(tvshows):
     show = tvshows.get("The 100")
     episodes = show.episodes()
-    episodes[0].markWatched()
+    episode = episodes[0]
+    episode.markWatched()
     unwatched = show.unwatched()
     assert len(unwatched) == len(episodes) - 1
+    episode.markUnwatched()
 
 
 def test_video_Show_settings(show):
@@ -883,6 +887,25 @@ def test_video_Season_history(show):
     history = season.history()
     assert len(history)
     season.markUnwatched()
+
+
+def test_video_Season_watched(tvshows):
+    season = tvshows.get("The 100").season(1)
+    episode = season.episode(1)
+    episode.markWatched()
+    watched = season.watched()
+    assert len(watched) == 1 and watched[0].title == "Pilot"
+    episode.markUnwatched()
+
+
+def test_video_Season_unwatched(tvshows):
+    season = tvshows.get("The 100").season(1)
+    episodes = season.episodes()
+    episode = episodes[0]
+    episode.markWatched()
+    unwatched = season.unwatched()
+    assert len(unwatched) == len(episodes) - 1
+    episode.markUnwatched()
 
 
 def test_video_Season_attrs(show):


### PR DESCRIPTION
## Description

Fixes the filter for `Season.watched()` and `Season.unwatched()` to use `viewCount` to return the correct list of episodes. Also added tests for those two methods.

Fixes #677

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
