### PR TITLE
Adds Movie and Artist advanced setting attributes

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -137,7 +137,7 @@ class Artist(Audio, ArtMixin, PosterMixin, SplitMergeMixin, UnmatchMatchMixin,
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
         Audio._loadData(self, data)
-        self.albumSort = utils.cast(int, self.data.attrib.get('albumSort', '-1'))
+        self.albumSort = utils.cast(int, data.attrib.get('albumSort', '-1'))
         self.collections = self.findItems(data, media.Collection)
         self.countries = self.findItems(data, media.Country)
         self.genres = self.findItems(data, media.Genre)

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -121,6 +121,8 @@ class Artist(Audio, ArtMixin, PosterMixin, SplitMergeMixin, UnmatchMatchMixin,
         Attributes:
             TAG (str): 'Directory'
             TYPE (str): 'artist'
+            albumSort (int): Setting that indicates how albums are sorted for the artist
+                (-1 = Library default, 0 = Newest first, 1 = Oldest first, 2 = By name).
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
             countries (List<:class:`~plexapi.media.Country`>): List country objects.
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
@@ -135,6 +137,7 @@ class Artist(Audio, ArtMixin, PosterMixin, SplitMergeMixin, UnmatchMatchMixin,
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
         Audio._loadData(self, data)
+        self.albumSort = utils.cast(int, self.data.attrib.get('albumSort', '-1'))
         self.collections = self.findItems(data, media.Collection)
         self.countries = self.findItems(data, media.Country)
         self.genres = self.findItems(data, media.Genre)

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -267,6 +267,8 @@ class Movie(Video, Playable, ArtMixin, PosterMixin, SplitMergeMixin, UnmatchMatc
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
             guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
+            languageOverride (str): Setting that indicates if a languge is used to override metadata
+                (eg. en-CA, None = Library default).
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             originallyAvailableAt (datetime): Datetime the movie was released.
             originalTitle (str): Original title, often the foreign title (転々; 엽기적인 그녀).
@@ -278,6 +280,8 @@ class Movie(Video, Playable, ArtMixin, PosterMixin, SplitMergeMixin, UnmatchMatc
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
+            useOriginalTitle (int): Setting that indicates if the original title is used for the movie
+                (-1 = Library default, 0 = No, 1 = Yes).
             userRating (float): User rating (2.0; 8.0).
             viewOffset (int): View offset in milliseconds.
             writers (List<:class:`~plexapi.media.Writer`>): List of writers objects.
@@ -303,6 +307,7 @@ class Movie(Video, Playable, ArtMixin, PosterMixin, SplitMergeMixin, UnmatchMatc
         self.genres = self.findItems(data, media.Genre)
         self.guids = self.findItems(data, media.Guid)
         self.labels = self.findItems(data, media.Label)
+        self.languageOverride = data.attrib.get('languageOverride')
         self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.originalTitle = data.attrib.get('originalTitle')
@@ -314,6 +319,7 @@ class Movie(Video, Playable, ArtMixin, PosterMixin, SplitMergeMixin, UnmatchMatc
         self.similar = self.findItems(data, media.Similar)
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
+        self.useOriginalTitle = utils.cast(int, data.attrib.get('useOriginalTitle', '-1'))
         self.userRating = utils.cast(float, data.attrib.get('userRating'))
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.writers = self.findItems(data, media.Writer)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -6,6 +6,7 @@ from . import test_mixins
 def test_audio_Artist_attr(artist):
     artist.reload()
     assert utils.is_datetime(artist.addedAt)
+    assert artist.albumSort == -1
     if artist.art:
         assert utils.is_art(artist.art)
     if artist.countries:

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -185,6 +185,7 @@ def test_video_Movie_attrs(movies):
     assert movie.guid == "plex://movie/5d776846880197001ec967c6"
     assert utils.is_metadata(movie._initpath)
     assert utils.is_metadata(movie.key)
+    assert movie.languageOverride is None
     assert utils.is_datetime(movie.lastViewedAt)
     assert int(movie.librarySectionID) >= 1
     assert movie.listType == "video"
@@ -206,6 +207,7 @@ def test_video_Movie_attrs(movies):
     assert not movie.transcodeSessions
     assert movie.type == "movie"
     assert movie.updatedAt > datetime(2017, 1, 1)
+    assert movie.useOriginalTitle == -1
     assert movie.userRating is None
     assert movie.viewCount == 0
     assert utils.is_int(movie.viewOffset, gte=0)


### PR DESCRIPTION
## Description

Adds the XML attributes for a `Movie` or `Artist` advanced settings.

Attributes for `Show` are already included in #679.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
