### PR TITLE
Fix parsing episode parentRatingKey from parentThumb

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -832,7 +832,7 @@ class Episode(Video, Playable, ArtMixin, PosterMixin,
         # https://forums.plex.tv/t/parentratingkey-not-in-episode-xml-when-seasons-are-hidden/300553
         if self.skipParent and not self.parentRatingKey:
             # Parse the parentRatingKey from the parentThumb
-            if self.parentThumb.startswith('/library/metadata/'):
+            if self.parentThumb and self.parentThumb.startswith('/library/metadata/'):
                 self.parentRatingKey = utils.cast(int, self.parentThumb.split('/')[3])
             # Get the parentRatingKey from the season's ratingKey
             if not self.parentRatingKey and self.grandparentRatingKey:


### PR DESCRIPTION
## Description

I came across a situation where episodes do not have a `parentThumb` so it cannot parse the `parentRatingKey` from that thumb.

```
AttributeError: 'NoneType' object has no attribute 'startswith'
```


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods

