### PR TITLE
Improve PlexClient connections

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -24,6 +24,8 @@ class PlexClient(PlexObject):
             data (ElementTree): Response from PlexServer used to build this object (optional).
             initpath (str): Path used to generate data.
             baseurl (str): HTTP URL to connect dirrectly to this client.
+            identifier (str): The resource/machine identifier for the desired client.
+                May be necessary when connecting to a specific proxied client (optional).
             token (str): X-Plex-Token used for authenication (optional).
             session (:class:`~requests.Session`): requests.Session object if you want more control (optional).
             timeout (int): timeout in seconds on initial connect to client (default config.TIMEOUT).


### PR DESCRIPTION
## Description

Fixes an issue when connecting to a proxied client via `<PMS>/resources` and that client is no longer available. Previously an `IndexError` was thrown as the payload would be valid but empty.

Also adds the ability to choose a specific proxied client if several are available. Previously the first available client was always returned when connecting to the proxy client address.

This raises `NotFound` if the requested client cannot be found instead of the uncaught `IndexError`. Non-breaking as this exception was already raised for 404 errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable