### PR TITLE
Add clientIdentifier attribute to SystemDevice

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -842,6 +842,7 @@ class SystemDevice(PlexObject):
 
         Attributes:
             TAG (str): 'Device'
+            clientIdentifier (str): The unique identifier for the device.
             createdAt (datatime): Datetime the device was created.
             id (int): The ID of the device (not the same as :class:`~plexapi.myplex.MyPlexDevice` ID).
             key (str): API URL (/devices/<id>)
@@ -852,6 +853,7 @@ class SystemDevice(PlexObject):
 
     def _loadData(self, data):
         self._data = data
+        self.clientIdentifier = data.attrib.get('clientIdentifier')
         self.createdAt = utils.toDatetime(data.attrib.get('createdAt'))
         self.id = cast(int, data.attrib.get('id'))
         self.key = '/devices/%s' % self.id

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -217,18 +217,40 @@ class PlexServer(PlexObject):
         return q.attrib.get('token')
 
     def systemAccounts(self):
-        """ Returns a list of :class:`~plexapi.server.SystemAccounts` objects this server contains. """
+        """ Returns a list of :class:`~plexapi.server.SystemAccount` objects this server contains. """
         if self._systemAccounts is None:
             key = '/accounts'
             self._systemAccounts = self.fetchItems(key, SystemAccount)
         return self._systemAccounts
 
+    def systemAccount(self, accountID):
+        """ Returns the :class:`~plexapi.server.SystemAccount` object for the specified account ID.
+
+            Parameters:
+                accountID (int): The :class:`~plexapi.server.SystemAccount` ID.
+        """
+        try:
+            return next(account for account in self.systemAccounts() if account.id == accountID)
+        except StopIteration:
+            raise NotFound('Unknown account with accountID=%s' % accountID) from None
+
     def systemDevices(self):
-        """ Returns a list of :class:`~plexapi.server.SystemDevices` objects this server contains. """
+        """ Returns a list of :class:`~plexapi.server.SystemDevice` objects this server contains. """
         if self._systemDevices is None:
             key = '/devices'
             self._systemDevices = self.fetchItems(key, SystemDevice)
         return self._systemDevices
+
+    def systemDevice(self, deviceID):
+        """ Returns the :class:`~plexapi.server.SystemDevice` object for the specified device ID.
+
+            Parameters:
+                deviceID (int): The :class:`~plexapi.server.SystemDevice` ID.
+        """
+        try:
+            return next(device for device in self.systemDevices() if device.id == deviceID)
+        except StopIteration:
+            raise NotFound('Unknown device with deviceID=%s' % deviceID) from None
 
     def myPlexAccount(self):
         """ Returns a :class:`~plexapi.myplex.MyPlexAccount` object using the same
@@ -896,19 +918,11 @@ class StatisticsBandwidth(PlexObject):
 
     def account(self):
         """ Returns the :class:`~plexapi.server.SystemAccount` associated with the bandwidth data. """
-        accounts = self._server.systemAccounts()
-        try:
-            return next(account for account in accounts if account.id == self.accountID)
-        except StopIteration:
-            raise NotFound('Unknown account for this bandwidth data: accountID=%s' % self.accountID)
+        return self._server.systemAccount(self.accountID)
 
     def device(self):
         """ Returns the :class:`~plexapi.server.SystemDevice` associated with the bandwidth data. """
-        devices = self._server.systemDevices()
-        try:
-            return next(device for device in devices if device.id == self.deviceID)
-        except StopIteration:
-            raise NotFound('Unknown device for this bandwidth data: deviceID=%s' % self.deviceID)
+        return self._server.systemDevice(self.deviceID)
 
 
 class StatisticsResources(PlexObject):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -388,18 +388,20 @@ def test_server_system_accounts(plex):
     assert account.thumb == ""
     assert account.accountID == account.id
     assert account.accountKey == account.key
+    assert plex.systemAccount(account.id) == account
 
 
 def test_server_system_devices(plex):
     devices = plex.systemDevices()
     assert len(devices)
     device = devices[-1]
-    assert len(device.clientIdentifier) or device.clientIdentifier is None
+    assert device.clientIdentifier or device.clientIdentifier is None
     assert utils.is_datetime(device.createdAt)
     assert utils.is_int(device.id)
     assert len(device.key)
     assert len(device.name) or device.name == ""
     assert len(device.platform) or device.platform == ""
+    assert plex.systemDevice(device.id) == device
     
 
 @pytest.mark.authenticated

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -394,6 +394,7 @@ def test_server_system_devices(plex):
     devices = plex.systemDevices()
     assert len(devices)
     device = devices[-1]
+    assert len(device.clientIdentifier) or device.clientIdentifier is None
     assert utils.is_datetime(device.createdAt)
     assert utils.is_int(device.id)
     assert len(device.key)


### PR DESCRIPTION
## Description

Add the `clientIdentifier` attribute to `SystemDevice` that was added in PMS 1.22.1.4200.

Added convenience methods `systemAccount(accountID)` and `systemDevice(deviceID)` to retrieve the account or device by ID.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
