### PR TITLE
Fix myplex share section ID cast to int

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -972,7 +972,7 @@ class LibrarySection(PlexObject):
             If you want to filter using episode view count then you must specify ``episode.viewCount`` explicitly.
             In addition, if the filter does not exist for the default library type it will fallback to the most
             specific ``libtype`` available. For example, ``show.unwatched`` does not exists so it will fallback to
-            ``episode.unwatched.`` The ``libtype`` prefix cannot be included directly in the function parameters so
+            ``episode.unwatched``. The ``libtype`` prefix cannot be included directly in the function parameters so
             the ``**kwargs`` must be provided as a dictionary.
 
             Examples:

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -499,15 +499,18 @@ class MyPlexAccount(PlexObject):
         url = self.PLEXSERVERS.replace('{machineId}', machineIdentifier)
         data = self.query(url, self._session.get)
         for elem in data[0]:
-            allSectionIds[elem.attrib.get('id', '').lower()] = elem.attrib.get('id')
-            allSectionIds[elem.attrib.get('title', '').lower()] = elem.attrib.get('id')
-            allSectionIds[elem.attrib.get('key', '').lower()] = elem.attrib.get('id')
+            _id = utils.cast(int, elem.attrib.get('id'))
+            _key = utils.cast(int, elem.attrib.get('key'))
+            _title = elem.attrib.get('title', '').lower()
+            allSectionIds[_id] = _id
+            allSectionIds[_key] = _id
+            allSectionIds[_title] = _id
         log.debug(allSectionIds)
         # Convert passed in section items to section ids from above lookup
         sectionIds = []
         for section in sections:
-            sectionKey = section.key if isinstance(section, LibrarySection) else section
-            sectionIds.append(allSectionIds[sectionKey.lower()])
+            sectionKey = section.key if isinstance(section, LibrarySection) else section.lower()
+            sectionIds.append(allSectionIds[sectionKey])
         return sectionIds
 
     def _filterDictToStr(self, filterDict):


### PR DESCRIPTION
## Description

Forgot one location where the library section IDs should be cast to int from #693.

Resolves the failed test: https://github.com/pkkid/python-plexapi/runs/2160511392

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
