### PR TITLE
Fix photos sync test

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -375,7 +375,7 @@ def test_sync_entire_library_photos(clear_sync_device, photos):
         sync_item=new_item,
     )
     # It's not that easy, to just get all the photos within the library, so let`s query for photos with device!=0x0
-    section_content = photos.search(libtype="photo", **{"device!": "0x0"})
+    section_content = photos.search(libtype="photo", **{"addedAt>>": "2000-01-01"})
     media_list = utils.wait_until(
         get_media, delay=0.25, timeout=3, item=item, server=photos._server
     )


### PR DESCRIPTION
## Description

Update photos sync test with library search changes in #693. Searching photos by `device` won't work anymore with the automatic filter fields pulled from Plex. Change to use `addedAt` date instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
