### PR TITLE
Add totalViewSize method to LibrarySection and search bug fixes

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -62,7 +62,7 @@ class Library(PlexObject):
         """ Returns the :class:`~plexapi.library.LibrarySection` that matches the specified sectionID.
 
             Parameters:
-                sectionID (str): ID of the section to return.
+                sectionID (int): ID of the section to return.
         """
         if not self._sectionsByID or sectionID not in self._sectionsByID:
             self.sections()

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1097,7 +1097,7 @@ class LibrarySection(PlexObject):
                 filter_args.append(self._validateFilterField(field, values, libtype))
                 del kwargs[field]
         if title is not None:
-            args['title'] = title
+            filter_args.append(self._validateFilterField('title', title, libtype))
         if sort is not None:
             args['sort'] = self._validateSortField(sort, libtype)
         if libtype is not None:

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1097,7 +1097,10 @@ class LibrarySection(PlexObject):
                 filter_args.append(self._validateFilterField(field, values, libtype))
                 del kwargs[field]
         if title is not None:
-            filter_args.append(self._validateFilterField('title', title, libtype))
+            if isinstance(title, (list, tuple)):
+                filter_args.append(self._validateFilterField('title', title, libtype))
+            else:
+                args['title'] = title
         if sort is not None:
             args['sort'] = self._validateSortField(sort, libtype)
         if libtype is not None:

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -394,13 +394,34 @@ class LibrarySection(PlexObject):
 
     @property
     def totalSize(self):
-        """ Returns the total number of items in the library. """
+        """ Returns the total number of items in the library for the default library type. """
         if self._totalSize is None:
             part = '/library/sections/%s/all?X-Plex-Container-Start=0&X-Plex-Container-Size=0' % self.key
             data = self._server.query(part)
             self._totalSize = int(data.attrib.get("totalSize"))
 
         return self._totalSize
+
+    def totalViewSize(self, libtype=None, includeCollections=True):
+        """ Returns the total number of items in the library for a specified libtype.
+            (e.g. The total number of episodes or albums.)
+
+            Parameters:
+                libtype (str, optional): The type of items to return the total number for (movie, show, season, episode,
+                    artist, album, track, photoalbum). Default is the main library type.
+                includeCollections (bool, optional): True or False to include collections in the total number.
+                    Default is True.
+        """
+        args = {
+            'includeCollections': int(includeCollections),
+            'X-Plex-Container-Start': 0,
+            'X-Plex-Container-Size': 0
+        }
+        if libtype is not None:
+            args['type'] = utils.searchType(libtype)
+        part = '/library/sections/%s/all%s' % (self.key, utils.joinArgs(args))
+        data = self._server.query(part)
+        return int(data.attrib.get("totalSize"))
 
     def delete(self):
         """ Delete a library section. """

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -398,7 +398,9 @@ class LibrarySection(PlexObject):
 
     def totalViewSize(self, libtype=None, includeCollections=True):
         """ Returns the total number of items in the library for a specified libtype.
-            (e.g. The total number of episodes or albums.)
+            The number of items for the default library type will be returned if no libtype is specified.
+            (e.g. Specify ``libtype='episode'`` for the total number of episodes
+            or ``libtype='albums'`` for the total number of albums.)
 
             Parameters:
                 libtype (str, optional): The type of items to return the total number for (movie, show, season, episode,
@@ -407,7 +409,7 @@ class LibrarySection(PlexObject):
                     Default is True.
         """
         args = {
-            'includeCollections': int(includeCollections),
+            'includeCollections': int(bool(includeCollections)),
             'X-Plex-Container-Start': 0,
             'X-Plex-Container-Size': 0
         }
@@ -415,7 +417,7 @@ class LibrarySection(PlexObject):
             args['type'] = utils.searchType(libtype)
         part = '/library/sections/%s/all%s' % (self.key, utils.joinArgs(args))
         data = self._server.query(part)
-        return int(data.attrib.get("totalSize"))
+        return utils.cast(int, data.attrib.get("totalSize"))
 
     def delete(self):
         """ Delete a library section. """

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -355,7 +355,6 @@ class LibrarySection(PlexObject):
         # Private attrs as we dont want a reload.
         self._filterTypes = None
         self._fieldTypes = None
-        self._totalSize = None
         self._totalViewSize = None
 
     def fetchItems(self, ekey, cls=None, container_start=None, container_size=None, **kwargs):
@@ -395,12 +394,7 @@ class LibrarySection(PlexObject):
     @property
     def totalSize(self):
         """ Returns the total number of items in the library for the default library type. """
-        if self._totalSize is None:
-            part = '/library/sections/%s/all?X-Plex-Container-Start=0&X-Plex-Container-Size=0' % self.key
-            data = self._server.query(part)
-            self._totalSize = int(data.attrib.get("totalSize"))
-
-        return self._totalSize
+        return self.totalViewSize(libtype=self.TYPE, includeCollections=False)
 
     def totalViewSize(self, libtype=None, includeCollections=True):
         """ Returns the total number of items in the library for a specified libtype.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -802,28 +802,28 @@ class MyPlexUser(PlexObject):
 
 class Section(PlexObject):
     """ This refers to a shared section. The raw xml for the data presented here
-        can be found at: https://plex.tv/api/servers/{machineId}/shared_servers/{serverId}
+        can be found at: https://plex.tv/api/servers/{machineId}/shared_servers
 
         Attributes:
             TAG (str): section
-            id (int): shared section id
-            sectionKey (str): what key we use for this section
-            title (str): Title of the section
-            sectionId (str): shared section id
-            type (str): movie, tvshow, artist
+            id (int): The shared section ID
+            key (int): The shared library section key
             shared (bool): If this section is shared with the user
+            title (str): Title of the section
+            type (str): movie, tvshow, artist
 
     """
     TAG = 'Section'
 
     def _loadData(self, data):
         self._data = data
-        # self.id = utils.cast(int, data.attrib.get('id'))  # Havnt decided if this should be changed.
-        self.sectionKey = data.attrib.get('key')
+        self.id = utils.cast(int, data.attrib.get('id'))
+        self.key = utils.cast(int, data.attrib.get('key'))
+        self.shared = utils.cast(bool, data.attrib.get('shared', '0'))
         self.title = data.attrib.get('title')
-        self.sectionId = data.attrib.get('id')
         self.type = data.attrib.get('type')
-        self.shared = utils.cast(bool, data.attrib.get('shared'))
+        self.sectionId = self.id  # For backwards compatibility
+        self.sectionKey = self.key  # For backwards compatibility
 
     def history(self, maxresults=9999999, mindate=None):
         """ Get all Play History for a user for this section in this shared server.

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -58,6 +58,18 @@ def test_library_section_movies_all(movies):
     assert len(movies.all(container_start=0, container_size=1, maxresults=1)) == 1
 
 
+def test_library_section_totalViewSize(tvshows):
+    assert tvshows.totalViewSize() == 2
+    assert tvshows.totalViewSize(libtype="show") == 2
+    assert tvshows.totalViewSize(libtype="season") == 4
+    assert tvshows.totalViewSize(libtype="episode") == 51
+    show = tvshows.get("The 100")
+    show.addCollection("test_view_size")
+    assert tvshows.totalViewSize() == 3
+    assert tvshows.totalViewSize(includeCollections=False) == 2
+    show.removeCollection("test_view_size", locked=False)
+
+
 def test_library_section_delete(movies, patched_http_call):
     movies.delete()
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -62,7 +62,7 @@ def test_library_section_totalViewSize(tvshows):
     assert tvshows.totalViewSize() == 2
     assert tvshows.totalViewSize(libtype="show") == 2
     assert tvshows.totalViewSize(libtype="season") == 4
-    assert tvshows.totalViewSize(libtype="episode") == 51
+    assert tvshows.totalViewSize(libtype="episode") == 49
     show = tvshows.get("The 100")
     show.addCollection("test_view_size")
     assert tvshows.totalViewSize() == 3


### PR DESCRIPTION
## Description

* Adds a `LibrarySection.totalViewSize()` method to returns the total number of items in the library for a specified `libtype`.
* Minor fix for an additional library section ID cast to int from #693.
* Fix `title` search argument not being applied as a `**kwarg` filter from #693 .

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
