### PR TITLE
Fix LibrarySection totalViewSize for photo libraries

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -394,7 +394,7 @@ class LibrarySection(PlexObject):
     @property
     def totalSize(self):
         """ Returns the total number of items in the library for the default library type. """
-        return self.totalViewSize(libtype=self.TYPE, includeCollections=False)
+        return self.totalViewSize(includeCollections=False)
 
     def totalViewSize(self, libtype=None, includeCollections=True):
         """ Returns the total number of items in the library for a specified libtype.
@@ -414,7 +414,10 @@ class LibrarySection(PlexObject):
             'X-Plex-Container-Size': 0
         }
         if libtype is not None:
-            args['type'] = utils.searchType(libtype)
+            if libtype == 'photo':
+                args['clusterZoomLevel'] = 1
+            else:
+                args['type'] = utils.searchType(libtype)
         part = '/library/sections/%s/all%s' % (self.key, utils.joinArgs(args))
         data = self._server.query(part)
         return utils.cast(int, data.attrib.get("totalSize"))


### PR DESCRIPTION
## Description

Fix `LibrarySection.totalViewSize()` for photo libraries.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable (we don't have tests for photo libraries)
