### PR TITLE
Allow relative dates for search filters

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -872,8 +872,8 @@ class LibrarySection(PlexObject):
         """
         if isinstance(value, datetime):
             return int(value.timestamp())
-        elif re.match(r'^-\d+(mon|[smhdwy])$', value):
-            return value
+        elif re.match(r'^-?\d+(mon|[smhdwy])$', value):
+            return '-' + value.lstrip('-')
         else:
             return int(utils.toDatetime(value, '%Y-%m-%d').timestamp())
 
@@ -975,11 +975,11 @@ class LibrarySection(PlexObject):
             * **writer** (:class:`~plexapi.media.MediaTag`): Search for the name of a writer.
             * **year** (*int*): Search for a specific year.
 
-            Tag type filter values can be a :class:`~plexapi.media.MediaTag` object, the exact name :attr:`MediaTag.tag`
-            (*str*), or the exact id :attr:`MediaTag.id` (*int*).
+            Tag type filter values can be a :class:`~plexapi.media.MediaTag` object, the exact name
+            :attr:`MediaTag.tag` (*str*), or the exact id :attr:`MediaTag.id` (*int*).
             
-            Date type filter values can be a ``datetime`` object, a relative date using a ``-`` prefix and one of the
-            available date suffixes (e.g. ``-30d``) (*str*), or a date in ``YYYY-MM-DD`` (*str*) format.
+            Date type filter values can be a ``datetime`` object, a relative date using a one of the
+            available date suffixes (e.g. ``30d``) (*str*), or a date in ``YYYY-MM-DD`` (*str*) format.
 
             Relative date suffixes:
 
@@ -1092,7 +1092,7 @@ class LibrarySection(PlexObject):
                     library.search(**{"title<": "Marvel", "addedAt<<": "2021-01-01"})
 
                     # Added in the last 30 days using relative dates
-                    library.search(**{"addedAt>>": "-30d"})
+                    library.search(**{"addedAt>>": "30d"})
 
                     # Collection is James Bond and user rating is greater than 8
                     library.search(**{"collection": "James Bond", "userRating>>": 8})

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -947,10 +947,7 @@ class LibrarySection(PlexObject):
             * See :func:`~plexapi.library.LibrarySection.listFilterChoices` to get a list of all available filter values.
 
             The following filter fields are just some examples of the possible filters. The list is not exaustive,
-            and not all filters apply to all library types. For tag type filters, a :class:`~plexapi.media.MediaTag`
-            object, the exact name :attr:`MediaTag.tag` (*str*), or the exact id :attr:`MediaTag.id` (*int*) can be
-            provided. For date type filters, either a ``datetime`` object or a date in ``YYYY-MM-DD`` (*str*) format
-            can be provided. Multiple values can be ``OR`` together by providing a list of values.
+            and not all filters apply to all library types.
 
             * **actor** (:class:`~plexapi.media.MediaTag`): Search for the name of an actor.
             * **addedAt** (*datetime*): Search for items added before or after a date. See operators below.
@@ -977,6 +974,24 @@ class LibrarySection(PlexObject):
             * **userRating** (*int*): Search for items with a specific user rating.
             * **writer** (:class:`~plexapi.media.MediaTag`): Search for the name of a writer.
             * **year** (*int*): Search for a specific year.
+
+            Tag type filter values can be a :class:`~plexapi.media.MediaTag` object, the exact name :attr:`MediaTag.tag`
+            (*str*), or the exact id :attr:`MediaTag.id` (*int*).
+            
+            Date type filter values can be a ``datetime`` object, a relative date using a ``-`` prefix and one of the
+            available date suffixes (e.g. ``-30d``) (*str*), or a date in ``YYYY-MM-DD`` (*str*) format.
+
+            Relative date suffixes:
+
+            * ``s``: ``seconds``
+            * ``m``: ``minutes``
+            * ``h``: ``hours``
+            * ``d``: ``days``
+            * ``w``: ``weeks``
+            * ``mon``: ``months``
+            * ``y``: ``years``
+            
+            Multiple values can be ``OR`` together by providing a list of values.
 
             Examples:
 
@@ -1075,6 +1090,9 @@ class LibrarySection(PlexObject):
 
                     # Title starts with Marvel and added before 2021-01-01
                     library.search(**{"title<": "Marvel", "addedAt<<": "2021-01-01"})
+
+                    # Added in the last 30 days using relative dates
+                    library.search(**{"addedAt>>": "-30d"})
 
                     # Collection is James Bond and user rating is greater than 8
                     library.search(**{"collection": "James Bond", "userRating>>": 8})

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -482,7 +482,7 @@ def _test_library_search(library, obj):
             elif field.type == "date":
                 searchValue = searchValue.strftime("%Y-%m-%d")
                 _do_test_library_search(library, obj, field, operator, searchValue)
-                searchValue = "-1s"
+                searchValue = "1s"
                 _do_test_library_search(library, obj, field, operator, searchValue)
 
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -490,7 +490,7 @@ def _do_test_library_search(library, obj, field, operator, searchValue):
     searchFilter = {field.key + operator.key[:-1]: searchValue}
     results = library.search(libtype=obj.type, **searchFilter)
 
-    if operator.key.startswith("!") or operator.key.startswith(">>") and (searchValue == 0 or searchValue == '-1s'):
+    if operator.key.startswith("!") or operator.key.startswith(">>") and (searchValue == 0 or searchValue == '1s'):
         assert obj not in results
     else:
         assert obj in results

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -469,28 +469,28 @@ def _test_library_search(library, obj):
                 searchValue = value - timedelta(days=1)
             else:
                 searchValue = value
-            
-            searchFilter = {field.key + operator.key[:-1]: searchValue}
-            results = library.search(libtype=obj.type, **searchFilter)
 
-            if operator.key.startswith("!") or operator.key.startswith(">>") and searchValue == 0:
-                assert obj not in results
-            else:
-                assert obj in results
+            _do_test_library_search(library, obj, field, operator, searchValue)
 
             # Test search again using string tag and date
-            if field.type in {"tag", "date"}:
-                if field.type == "tag" and fieldAttr != 'contentRating':
-                    if not isinstance(searchValue, list):
-                        searchValue = [searchValue]
-                    searchValue = [v.tag for v in searchValue]
-                elif field.type == "date":
-                    searchValue = searchValue.strftime("%Y-%m-%d")
+            if field.type == "tag" and fieldAttr != "contentRating":
+                if not isinstance(searchValue, list):
+                    searchValue = [searchValue]
+                searchValue = [v.tag for v in searchValue]
+                _do_test_library_search(library, obj, field, operator, searchValue)
 
-                searchFilter = {field.key + operator.key[:-1]: searchValue}
-                results = library.search(libtype=obj.type, **searchFilter)
+            elif field.type == "date":
+                searchValue = searchValue.strftime("%Y-%m-%d")
+                _do_test_library_search(library, obj, field, operator, searchValue)
+                searchValue = "-1s"
+                _do_test_library_search(library, obj, field, operator, searchValue)
 
-                if operator.key.startswith("!") or operator.key.startswith(">>") and searchValue == 0:
-                    assert obj not in results
-                else:
-                    assert obj in results
+
+def _do_test_library_search(library, obj, field, operator, searchValue):
+    searchFilter = {field.key + operator.key[:-1]: searchValue}
+    results = library.search(libtype=obj.type, **searchFilter)
+
+    if operator.key.startswith("!") or operator.key.startswith(">>") and searchValue == 0:
+        assert obj not in results
+    else:
+        assert obj in results

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -490,7 +490,7 @@ def _do_test_library_search(library, obj, field, operator, searchValue):
     searchFilter = {field.key + operator.key[:-1]: searchValue}
     results = library.search(libtype=obj.type, **searchFilter)
 
-    if operator.key.startswith("!") or operator.key.startswith(">>") and searchValue == 0:
+    if operator.key.startswith("!") or operator.key.startswith(">>") and (searchValue == 0 or searchValue == '-1s'):
         assert obj not in results
     else:
         assert obj in results


### PR DESCRIPTION
## Description

Adds support for using relative dates in the library search filters. This is the `in the last` and `in not the last` operators for date filters in Plex Web.

Example:
```python
# Added in the last 30 days using relative dates
library.search(**{"addedAt>>": "30d"})

# Added in not the last 30 days using relative dates
library.search(**{"addedAt<<": "30d"})
```

Fixes #716

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
