### PR TITLE
fix for advanced settings that dont use ints

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -505,7 +505,10 @@ class LibrarySection(PlexObject):
         for settingID, value in kwargs.items():
             try:
                 enums = idEnums.get(settingID)
-                enumValues = [int(x) for x in enums]
+                try:
+                    enumValues = [int(x) for x in enums]
+                except ValueError:
+                    enumValues = [x for x in enums]
             except TypeError:
                 raise NotFound('%s not found in %s' % (value, list(idEnums.keys())))
             if value in enumValues:

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -504,14 +504,10 @@ class LibrarySection(PlexObject):
 
         for settingID, value in kwargs.items():
             try:
-                enums = idEnums.get(settingID)
-                try:
-                    enumValues = [int(x) for x in enums]
-                except ValueError:
-                    enumValues = [x for x in enums]
-            except TypeError:
+                enums = idEnums[settingID]
+            except KeyError:
                 raise NotFound('%s not found in %s' % (value, list(idEnums.keys())))
-            if value in enumValues:
+            if value in enums:
                 data[key % settingID] = value
             else:
                 raise NotFound('%s not found in %s' % (value, enums))

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -41,11 +41,14 @@ class AdvancedSettingsMixin(object):
         key = '%s/prefs?' % self.key
         preferences = {pref.id: list(pref.enumValues.keys()) for pref in self.preferences()}
         for settingID, value in kwargs.items():
-            enumValues = preferences.get(settingID)
-            if value in enumValues:
+            try:
+                enums = preferences[settingID]
+            except KeyError:
+                raise NotFound('%s not found in %s' % (value, list(preferences.keys())))
+            if value in enums:
                 data[settingID] = value
             else:
-                raise NotFound('%s not found in %s' % (value, enumValues))
+                raise NotFound('%s not found in %s' % (value, enums))
         url = key + urlencode(data)
         self._server.query(url, method=self._server._session.put)
 


### PR DESCRIPTION
## Description

I was trying to change the Ratings Source Advance Setting of a Library like so:

```python
ps = PlexServer("http://192.168.1.144:32400", "notmyactualtoken", timeout=600)
plex = next((s for s in ps.library.sections() if s.title == "New Movies"), None)
plex.editAdvanced(**{"ratingsSource": "themoviedb"})
```
 
and i would get this:

```cmd
Traceback (most recent call last):
  File "C:\Users\meisn\Documents\Python\Plex Meta Manager\test.py", line 184, in <module>
    plex.editAdvanced(**{"ratingsSource": "themoviedb"})
  File "C:\Users\meisn\Documents\Python\Plex Meta Manager\venv\lib\site-packages\plexapi\library.py", line 508, in editAdvanced
    enumValues = [int(x) for x in enums]
  File "C:\Users\meisn\Documents\Python\Plex Meta Manager\venv\lib\site-packages\plexapi\library.py", line 508, in <listcomp>
    enumValues = [int(x) for x in enums]
ValueError: invalid literal for int() with base 10: 'rottentomatoes'
```

From what i can tell this is happening because all the keys from the enumValues of each setting get cast to ints, which works for most settings except ratingSource and one or two others. I just caught the ValueError and then recreated the list without casting it to int and i was able to edit the advance setting. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
