### PR TITLE
Exclude leaves from show seasons

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -518,7 +518,7 @@ class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, Spl
             Raises:
                 :exc:`~plexapi.exceptions.BadRequest`: If title or season parameter is missing.
         """
-        key = '/library/metadata/%s/children' % self.ratingKey
+        key = '/library/metadata/%s/children?excludeAllLeaves=1' % self.ratingKey
         if title is not None and not isinstance(title, int):
             return self.fetchItem(key, Season, title__iexact=title)
         elif season is not None or isinstance(title, int):


### PR DESCRIPTION
## Description

When using `show.season(0)` to try and get the Specials Season of a Show it currently does not return the specials and instead returns the allLeaves Season. Adding `?excludeAllLeaves=1` to the call allows it to return the proper season 0.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
