### PR TITLE
Fix retrieving Season.episode() by episode number

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -661,10 +661,14 @@ class Season(Video, ArtMixin, PosterMixin):
                 :exc:`~plexapi.exceptions.BadRequest`: If title or episode parameter is missing.
         """
         key = '/library/metadata/%s/children' % self.ratingKey
-        if title is not None:
+        if title is not None and not isinstance(title, int):
             return self.fetchItem(key, Episode, title__iexact=title)
-        elif episode is not None:
-            return self.fetchItem(key, Episode, parentIndex=self.index, index=episode)
+        elif episode is not None or isinstance(title, int):
+            if isinstance(title, int):
+                index = title
+            else:
+                index = episode
+            return self.fetchItem(key, Episode, parentIndex=self.index, index=index)
         raise BadRequest('Missing argument: title or episode is required')
 
     def get(self, title=None, episode=None):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -868,6 +868,25 @@ def test_video_Episode_attrs(episode):
     assert part.accessible
 
 
+def test_video_Episode_watched(tvshows):
+    season = tvshows.get("The 100").season(1)
+    episode = season.episode(1)
+    episode.markWatched()
+    watched = season.watched()
+    assert len(watched) == 1 and watched[0].title == "Pilot"
+    episode.markUnwatched()
+
+
+def test_video_Episode_unwatched(tvshows):
+    season = tvshows.get("The 100").season(1)
+    episodes = season.episodes()
+    episode = episodes[0]
+    episode.markWatched()
+    unwatched = season.unwatched()
+    assert len(unwatched) == len(episodes) - 1
+    episode.markUnwatched()
+
+
 def test_video_Episode_mixins_images(episode):
     #test_mixins.edit_art(episode)  # Uploading episode artwork is broken in Plex
     test_mixins.edit_poster(episode)
@@ -893,25 +912,6 @@ def test_video_Season_history(show):
     history = season.history()
     assert len(history)
     season.markUnwatched()
-
-
-def test_video_Season_watched(tvshows):
-    season = tvshows.get("The 100").season(1)
-    episode = season.episode(1)
-    episode.markWatched()
-    watched = season.watched()
-    assert len(watched) == 1 and watched[0].title == "Pilot"
-    episode.markUnwatched()
-
-
-def test_video_Season_unwatched(tvshows):
-    season = tvshows.get("The 100").season(1)
-    episodes = season.episodes()
-    episode = episodes[0]
-    episode.markWatched()
-    unwatched = season.unwatched()
-    assert len(unwatched) == len(episodes) - 1
-    episode.markUnwatched()
 
 
 def test_video_Season_attrs(show):


### PR DESCRIPTION
## Description

* Retrieving an episode using an episode number `Season.episode(<int>)` was not working. Change to mimic `Show.season(<int>)`.
* The two tests for episode watched/unwatched were incorrectly named as "Season" which also duplicated the name for the season watched/unwatched tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
