### PR TITLE
add library labels endpoint

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2062,6 +2062,7 @@ class File(PlexObject):
         self.path = data.attrib.get('path')
         self.title = data.attrib.get('title')
 
+
 class Label(PlexObject):
     """ Represents a single Label object for a :class:`~plexapi.library.Label`.
 

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -467,6 +467,11 @@ class LibrarySection(PlexObject):
         libtype = libtype or self.TYPE
         return self.search(libtype=libtype, **kwargs)
 
+    def labels(self):
+        """ Returns a list of available :class:`~plexapi.library.Label` for this library section.
+        """
+        return self.fetchItems('/library/sections/%s/label' % self.key, Label)
+
     def folders(self):
         """ Returns a list of available :class:`~plexapi.library.Folder` for this library section.
         """
@@ -2055,4 +2060,22 @@ class File(PlexObject):
     def _loadData(self, data):
         self.key = data.attrib.get('key')
         self.path = data.attrib.get('path')
+        self.title = data.attrib.get('title')
+
+class Label(PlexObject):
+    """ Represents a single Label object for a :class:`~plexapi.library.Label`.
+
+        Attributes:
+            TAG (str): 'Directory'
+            fastKey (str): The URL key for the label field.
+            key (str): The key for the label field.
+            title (str): The title of the label field.
+    """
+    TAG = 'Directory'
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        self._data = data
+        self.fastKey = data.attrib.get('fastKey')
+        self.key = data.attrib.get('key')
         self.title = data.attrib.get('title')


### PR DESCRIPTION
## Description

I added the Labels endpoint (`/library/sections/<section_id>/label`) which returns the new Label object. This gets you every label in that library. I could use some guidance on writing proper tests or if my docstring is incorrect but when tested for me it works.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
