### PR TITLE
Add method to return a list of all optimized items

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -558,6 +558,13 @@ class Optimized(PlexObject):
         self.target = data.attrib.get('target')
         self.targetTagID = data.attrib.get('targetTagID')
 
+    def items(self):
+        """ Returns a list of all :class:`~plexapi.media.Video` objects
+            in this optimized item.
+        """
+        key = '%s/%s/items' % (self._initpath, self.id)
+        return self.fetchItems(key)
+        
     def remove(self):
         """ Remove an Optimized item"""
         key = '%s/%s' % (self._initpath, self.id)

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -496,7 +496,7 @@ class PlexServer(PlexObject):
         """
 
         backgroundProcessing = self.fetchItem('/playlists?type=42')
-        return self.fetchItems('%s/items/%s/items' % (backgroundProcessing.key, optimizedID))
+        return self.fetchItem('%s/items/%s/items' % (backgroundProcessing.key, optimizedID))
 
     def conversions(self, pause=None):
         """ Returns list of all :class:`~plexapi.media.Conversion` objects connected to server. """

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -489,6 +489,7 @@ class PlexServer(PlexObject):
             backgroundProcessing = self.fetchItem('/playlists?type=42')
             return self.fetchItems('%s/items' % backgroundProcessing.key, cls=Optimized)
 
+    @deprecated('use "plexapi.media.Optimized.items()" instead')
     def optimizedItem(self, optimizedID):
         """ Returns single queued optimized item :class:`~plexapi.media.Video` object.
             Allows for using optimized item ID to connect back to source item.

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -495,7 +495,7 @@ class PlexServer(PlexObject):
         """
 
         backgroundProcessing = self.fetchItem('/playlists?type=42')
-        return self.fetchItem('%s/items/%s/items' % (backgroundProcessing.key, optimizedID))
+        return self.fetchItems('%s/items/%s/items' % (backgroundProcessing.key, optimizedID))
 
     def conversions(self, pause=None):
         """ Returns list of all :class:`~plexapi.media.Conversion` objects connected to server. """

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1102,7 +1102,7 @@ def test_video_optimize(movie, plex):
     assert len(plex.conversions()) == 0
     assert len(plex.optimizedItems()) == 1
     optimized = plex.optimizedItems()[0]
-    video = plex.optimizedItem(optimizedID=optimized.id)
-    assert movie.key == video.key
+    videos = optimized.items()
+    assert movie in videos
     plex.optimizedItems(removeAll=True)
     assert len(plex.optimizedItems()) == 0


### PR DESCRIPTION
## Description

There can be several videos in an optimization. In the current code we only loop on one.

* Deprecates `PlexServer.optimizedItem()`.
* Adds `Optimized.items()` method to return all videos that are part of the optimization.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
