### PR TITLE
Add ability to retrieve a list of items and collection object from media tags

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1698,6 +1698,12 @@ class HubMediaTag(PlexObject):
         self.tagValue = utils.cast(int, data.attrib.get('tagValue'))
         self.thumb = data.attrib.get('thumb')
 
+    def items(self, *args, **kwargs):
+        """ Return the list of items within this tag. """
+        if not self.key:
+            raise BadRequest('Key is not defined for this tag: %s' % self.tag)
+        return self.fetchItems(self.key)
+
 
 @utils.registerPlexObject
 class Tag(HubMediaTag):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,11 +234,11 @@ def movie(movies):
 @pytest.fixture()
 def collection(movies):
     try:
-        return movies.collections(title="marvel")[0]
+        return movies.collections(title="Marvel")[0]
     except IndexError:
         movie = movies.get("Elephants Dream")
-        movie.addCollection("marvel")
-        return movies.collections(title="marvel")[0]
+        movie.addCollection("Marvel")
+        return movies.collections(title="Marvel")[0]
 
 
 @pytest.fixture()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import conftest as utils
-from . import test_mixins
+from . import test_media, test_mixins
 
 
 def test_audio_Artist_attr(artist):
@@ -87,6 +87,16 @@ def test_audio_Artist_mixins_tags(artist):
     test_mixins.edit_style(artist)
 
 
+def test_audio_Artist_media_tags(artist):
+    artist.reload()
+    test_media.tag_collection(artist)
+    test_media.tag_country(artist)
+    test_media.tag_genre(artist)
+    test_media.tag_mood(artist)
+    test_media.tag_similar(artist)
+    test_media.tag_style(artist)
+
+
 def test_audio_Album_attrs(album):
     assert utils.is_datetime(album.addedAt)
     if album.art:
@@ -163,6 +173,15 @@ def test_audio_Album_mixins_tags(album):
     test_mixins.edit_label(album)
     test_mixins.edit_mood(album)
     test_mixins.edit_style(album)
+
+
+def test_audio_Album_media_tags(album):
+    album.reload()
+    test_media.tag_collection(album)
+    test_media.tag_genre(album)
+    test_media.tag_label(album)
+    test_media.tag_mood(album)
+    test_media.tag_style(album)
 
 
 def test_audio_Track_attrs(album):
@@ -292,6 +311,12 @@ def test_audio_Track_mixins_images(track):
 def test_audio_Track_mixins_tags(track):
     test_mixins.edit_collection(track)
     test_mixins.edit_mood(track)
+
+
+def test_audio_Track_media_tags(track):
+    track.reload()
+    test_media.tag_collection(track)
+    test_media.tag_mood(track)
 
 
 def test_audio_Audio_section(artist, album, track):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -33,7 +33,7 @@ def test_Collection_attrs(collection):
     assert collection.summary == ""
     assert collection.thumb.startswith("/library/collections/%s/composite" % collection.ratingKey)
     assert collection.thumbBlurHash is None
-    assert collection.title == "marvel"
+    assert collection.title == "Marvel"
     assert collection.titleSort == collection.title
     assert collection.type == "collection"
     assert utils.is_datetime(collection.updatedAt)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+def _test_media_tag(obj, attr):
+    tags = getattr(obj, attr)
+    if tags:
+        assert obj in tags[0].items()
+
+
+def tag_collection(obj):
+    _test_media_tag(obj, "collections")
+
+
+def tag_country(obj):
+    _test_media_tag(obj, "countries")
+
+
+def tag_director(obj):
+    _test_media_tag(obj, "directors")
+
+
+def tag_genre(obj):
+    _test_media_tag(obj, "genres")
+
+
+def tag_label(obj):
+    _test_media_tag(obj, "labels")
+
+
+def tag_mood(obj):
+    _test_media_tag(obj, "moods")
+
+
+def tag_producer(obj):
+    _test_media_tag(obj, "producers")
+
+
+def tag_role(obj):
+    _test_media_tag(obj, "roles")
+
+
+def tag_similar(obj):
+    _test_media_tag(obj, "similar")
+
+
+def tag_style(obj):
+    _test_media_tag(obj, "styles")
+
+
+def tag_tag(obj):
+    _test_media_tag(obj, "tags")
+
+
+def tag_writer(obj):
+    _test_media_tag(obj, "writers")

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from . import test_mixins
+from . import test_media, test_mixins
 
 
 def test_photo_Photoalbum(photoalbum):
@@ -20,3 +20,8 @@ def test_photo_Photoalbum_mixins_images(photoalbum):
 
 def test_photo_Photo_mixins_tags(photo):
     test_mixins.edit_tag(photo)
+
+
+def test_photo_Photo_media_tags(photo):
+    photo.reload()
+    test_media.tag_tag(photo)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -135,6 +135,7 @@ def test_server_search(plex, movie):
     assert hub_tag.tagType == 1
     assert hub_tag.tagValue is None
     assert hub_tag.thumb is None
+    assert movie in hub_tag.items()
     # Test director search
     director = movie.directors[0]
     assert plex.search(director.tag, mediatype="director")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -8,7 +8,7 @@ import pytest
 from plexapi.exceptions import BadRequest, NotFound
 
 from . import conftest as utils
-from . import test_mixins
+from . import test_media, test_mixins
 
 
 def test_video_Movie(movies, movie):
@@ -57,6 +57,30 @@ def test_video_Movie_mixins_tags(movie):
     test_mixins.edit_label(movie)
     test_mixins.edit_producer(movie)
     test_mixins.edit_writer(movie)
+
+
+def test_video_Movie_media_tags(movie):
+    movie.reload()
+    test_media.tag_collection(movie)
+    test_media.tag_country(movie)
+    test_media.tag_director(movie)
+    test_media.tag_genre(movie)
+    test_media.tag_label(movie)
+    test_media.tag_producer(movie)
+    test_media.tag_role(movie)
+    test_media.tag_similar(movie)
+    test_media.tag_writer(movie)
+
+
+def test_video_Movie_media_tags_Exception(movie):
+    with pytest.raises(BadRequest):
+        movie.genres[0].items()
+
+
+def test_video_Movie_media_tags_collection(movie, collection):
+    movie.reload()
+    collection_tag = next(c for c in movie.collections if c.tag == "Marvel")
+    assert collection == collection_tag.collection()
 
 
 def test_video_Movie_getStreamURL(movie, account):
@@ -741,6 +765,15 @@ def test_video_Show_mixins_tags(show):
     test_mixins.edit_label(show)
 
 
+def test_video_Show_media_tags(show):
+    show.reload()
+    test_media.tag_collection(show)
+    test_media.tag_genre(show)
+    test_media.tag_label(show)
+    test_media.tag_role(show)
+    test_media.tag_similar(show)
+
+
 def test_video_Episode(show):
     episode = show.episode("Winter Is Coming")
     assert episode == show.episode(season=1, episode=1)
@@ -900,6 +933,13 @@ def test_video_Episode_mixins_tags(episode):
     test_mixins.edit_writer(episode)
 
 
+def test_video_Episode_media_tags(episode):
+    episode.reload()
+    test_media.tag_collection(episode)
+    test_media.tag_director(episode)
+    test_media.tag_writer(episode)
+
+
 def test_video_Season(show):
     seasons = show.seasons()
     assert len(seasons) == 2
@@ -996,6 +1036,12 @@ def test_video_Season_mixins_images(show):
 def test_video_Season_mixins_tags(show):
     season = show.season(season=1)
     test_mixins.edit_collection(season)
+
+
+def test_video_Season_media_tags(show):
+    season = show.season(season=1)
+    season.reload()
+    test_media.tag_collection(season)
 
 
 def test_that_reload_return_the_same_object(plex):


### PR DESCRIPTION
## Description

* Add ability to retrieve a list of items from media tags.

```python
>>> show = plex.library.section("TV Shows").get("Game of Thrones")
>>> show.reload()
>>> show.genres[0].items()  # Return all items in the library with the same genre
```

* Add ability to retrieve the full `plexapi.collection.Collection` object from a `plexapi.media.Collection` tag object.

```python
>>> show = plex.library.section("TV Shows").get("Game of Thrones")
>>> collection_tag = show.collections[0]  # MediaTag collection object
>>> collection = collection_tag.collection()  # Full Collection object
```


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
