### PR TITLE
Limit datetime attributes to max 32-bit integer timestamp

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -200,9 +200,8 @@ def toDatetime(value, format=None):
         else:
             # https://bugs.python.org/issue30684
             # And platform support for before epoch seems to be flaky.
-            # TODO check for others errors too.
-            if int(value) <= 0:
-                value = 86400
+            # Also limit to max 32-bit integer
+            value = min(max(int(value), 86400), 2**31 - 1)
             value = datetime.fromtimestamp(int(value))
     return value
 


### PR DESCRIPTION
## Description

Sometimes Plex messes up and has incorrect dates in the future. This limits `utils.toDatetime()` to a maximum 32-bit integer to prevent `OverflowError`. This will work until January, 2038 (`epoch=2^31-1`).

Fixes #675

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
