### PR TITLE
Add episodeNumber, trackNumber, and hasPreviewThumbnails helper properties

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -408,6 +408,11 @@ class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, CollectionMixin, MoodM
         """
         return [part.file for part in self.iterParts() if part]
 
+    @property
+    def trackNumber(self):
+        """ Returns the track number. """
+        return self.index
+
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """
         return '%s - %s - %s' % (self.grandparentTitle, self.parentTitle, self.title)

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -112,7 +112,7 @@ class MediaPart(PlexObject):
             has64bitOffsets (bool): True if the file has 64 bit offsets.
             hasThumbnail (bool): True if the file (track) has an embedded thumbnail.
             id (int): The unique ID for this media part on the server.
-            indexes (str, None): sd if the file has generated BIF thumbnails.
+            indexes (str, None): sd if the file has generated preview (BIF) thumbnails.
             key (str): API URL (ex: /library/parts/46618/1389985872/file.mkv).
             optimizedForStreaming (bool): True if the file is optimized for streaming.
             packetLength (int): The packet length of the file.
@@ -156,6 +156,11 @@ class MediaPart(PlexObject):
             items = self.findItems(data, cls, streamType=cls.STREAMTYPE)
             streams.extend(items)
         return streams
+
+    @property
+    def hasPreviewThumbnails(self):
+        """ Returns True if the media part has generated preview (BIF) thumbnails. """
+        return self.indexes == 'sd'
 
     def videoStreams(self):
         """ Returns a list of :class:`~plexapi.media.VideoStream` objects in this MediaPart. """

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -644,7 +644,7 @@ class Season(Video, ArtMixin, PosterMixin, CollectionMixin):
 
     @property
     def seasonNumber(self):
-        """ Returns season number. """
+        """ Returns the season number. """
         return self.index
 
     def episodes(self, **kwargs):
@@ -834,16 +834,21 @@ class Episode(Video, Playable, ArtMixin, PosterMixin, CollectionMixin, DirectorM
         return [part.file for part in self.iterParts() if part]
 
     @property
+    def episodeNumber(self):
+        """ Returns the episode number. """
+        return self.index
+
+    @property
     def seasonNumber(self):
-        """ Returns the episodes season number. """
+        """ Returns the episode's season number. """
         if self._seasonNumber is None:
             self._seasonNumber = self.parentIndex if self.parentIndex else self.season().seasonNumber
         return utils.cast(int, self._seasonNumber)
 
     @property
     def seasonEpisode(self):
-        """ Returns the s00e00 string containing the season and episode. """
-        return 's%se%s' % (str(self.seasonNumber).zfill(2), str(self.index).zfill(2))
+        """ Returns the s00e00 string containing the season and episode numbers. """
+        return 's%se%s' % (str(self.seasonNumber).zfill(2), str(self.episodeNumber).zfill(2))
 
     @property
     def hasIntroMarker(self):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -340,6 +340,11 @@ class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, Split
         """
         return [part.file for part in self.iterParts() if part]
 
+    @property
+    def hasPreviewThumbnails(self):
+        """ Returns True if any of the media parts has generated preview (BIF) thumbnails. """
+        return any(part.hasPreviewThumbnails for media in self.media for part in media.parts)
+
     def _prettyfilename(self):
         # This is just for compat.
         return self.title
@@ -856,6 +861,11 @@ class Episode(Video, Playable, ArtMixin, PosterMixin, CollectionMixin, DirectorM
         if not self.isFullObject():
             self.reload()
         return any(marker.type == 'intro' for marker in self.markers)
+
+    @property
+    def hasPreviewThumbnails(self):
+        """ Returns True if any of the media parts has generated preview (BIF) thumbnails. """
+        return any(part.hasPreviewThumbnails for media in self.media for part in media.parts)
 
     def season(self):
         """" Return the episode's :class:`~plexapi.video.Season`. """

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -180,7 +180,8 @@ def test_audio_Track_attrs(album):
         assert utils.is_thumb(track.grandparentThumb)
     assert track.grandparentTitle == "Broke For Free"
     assert track.guid.startswith("mbid://") or track.guid.startswith("plex://track/")
-    assert int(track.index) == 1
+    assert track.index == 1
+    assert track.trackNumber == track.index
     assert utils.is_metadata(track._initpath)
     assert utils.is_metadata(track.key)
     assert utils.is_datetime(track.lastViewedAt)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -187,6 +187,7 @@ def test_video_Movie_attrs(movies):
     assert "Animation" in [i.tag for i in movie.genres]
     assert "imdb://tt1172203" in [i.id for i in movie.guids]
     assert movie.guid == "plex://movie/5d776846880197001ec967c6"
+    assert movie.hasPreviewThumbnails is False
     assert utils.is_metadata(movie._initpath)
     assert utils.is_metadata(movie.key)
     assert movie.languageOverride is None
@@ -337,6 +338,7 @@ def test_video_Movie_attrs(movies):
     assert part.exists
     assert len(part.file) >= 10
     assert part.has64bitOffsets is False
+    assert part.hasPreviewThumbnails is False
     assert part.hasThumbnail is None
     assert utils.is_int(part.id)
     assert part.indexes is None
@@ -805,6 +807,7 @@ def test_video_Episode_attrs(episode):
         assert utils.is_thumb(episode.grandparentThumb)
     assert episode.grandparentTitle == "Game of Thrones"
     assert episode.guids == []  # TODO: Change when updating test to the Plex TV agent
+    assert episode.hasPreviewThumbnails is False
     assert episode.index == 1
     assert episode.episodeNumber == episode.index
     assert utils.is_metadata(episode._initpath)
@@ -862,6 +865,7 @@ def test_video_Episode_attrs(episode):
     assert part.container in utils.CONTAINERS
     assert utils.is_int(part.duration, gte=150000)
     assert len(part.file) >= 10
+    assert part.hasPreviewThumbnails is False
     assert utils.is_int(part.id)
     assert utils.is_metadata(part._initpath)
     assert len(part.key) >= 10

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -806,11 +806,13 @@ def test_video_Episode_attrs(episode):
     assert episode.grandparentTitle == "Game of Thrones"
     assert episode.guids == []  # TODO: Change when updating test to the Plex TV agent
     assert episode.index == 1
+    assert episode.episodeNumber == episode.index
     assert utils.is_metadata(episode._initpath)
     assert utils.is_metadata(episode.key)
     assert episode.listType == "video"
     assert utils.is_datetime(episode.originallyAvailableAt)
-    assert utils.is_int(episode.parentIndex)
+    assert episode.parentIndex == 1
+    assert episode.seasonNumber == episode.parentIndex
     assert utils.is_metadata(episode.parentKey)
     assert utils.is_int(episode.parentRatingKey)
     if episode.parentThumb:
@@ -836,6 +838,7 @@ def test_video_Episode_attrs(episode):
     assert episode.isWatched in [True, False]
     assert len(episode.locations) == 1
     assert len(episode.locations[0]) >= 10
+    assert episode.seasonEpisode == "s01e01"
     # Media
     media = episode.media[0]
     assert media.aspectRatio == 1.78


### PR DESCRIPTION
## Description

Adds the following helper properties:
* `Episode.episodeNumber` alias to `index`
* `Track.trackNumber` alias to `index`
* `MediaPart.hasPreviewThumbnails` helper for `MediaPart.indexes == "sd"`
* `Movie.hasPreviewThumbnails` and `Episode.hasPreviewThumbnails` helper if any `MediaPart.hasPreviewThumbnails` is `True`


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
