### PR TITLE
Add method to switch users for a PlexServer instance

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -470,6 +470,7 @@ class MyPlexAccount(PlexObject):
             Parameters:
                 username (str): Username, email or id of the user to return.
         """
+        username = str(username)
         for user in self.users():
             # Home users don't have email, username etc.
             if username.lower() == user.title.lower():

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -253,15 +253,13 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin):
         return cls(server, data, initpath=key)
 
     def copyToUser(self, user):
-        """ Copy playlist to another user account. """
-        from plexapi.server import PlexServer
-        myplex = self._server.myPlexAccount()
-        user = myplex.user(user)
-        # Get the token for your machine.
-        token = user.get_token(self._server.machineIdentifier)
-        # Login to your server using your friends credentials.
-        user_server = PlexServer(self._server._baseurl, token)
-        return self.create(user_server, self.title, self.items())
+        """ Copy playlist to another user account.
+        
+            Parameters:
+                user (str): Username, email or user id of the user to copy the playlist to.
+        """
+        userServer = self._server.switchUser(user)
+        return self.create(userServer, self.title, self.items())
 
     def sync(self, videoQuality=None, photoResolution=None, audioBitrate=None, client=None, clientId=None, limit=None,
              unwatched=False, title=None):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -105,12 +105,13 @@ class PlexServer(PlexObject):
         self._token = logfilter.add_secret(token or CONFIG.get('auth.server_token'))
         self._showSecrets = CONFIG.get('log.show_secrets', '').lower() == 'true'
         self._session = session or requests.Session()
+        self._timeout = timeout
         self._library = None   # cached library
         self._settings = None   # cached settings
         self._myPlexAccount = None   # cached myPlexAccount
         self._systemAccounts = None   # cached list of SystemAccount
         self._systemDevices = None   # cached list of SystemDevice
-        data = self.query(self.key, timeout=timeout)
+        data = self.query(self.key, timeout=self._timeout)
         super(PlexServer, self).__init__(self, data, self.key)
 
     def _loadData(self, data):
@@ -209,12 +210,34 @@ class PlexServer(PlexObject):
         return self.fetchItems(key)
 
     def createToken(self, type='delegation', scope='all'):
-        """Create a temp access token for the server."""
+        """ Create a temp access token for the server. """
         if not self._token:
             # Handle unclaimed servers
             return None
         q = self.query('/security/token?type=%s&scope=%s' % (type, scope))
         return q.attrib.get('token')
+
+    def switchUser(self, username):
+        """ Returns a new :class:`~plexapi.server.PlexServer` object logged in as the given username.
+            Note: Only the admin account can switch to other users.
+        
+            Parameters:
+                username (str): Username, email or user id of the user to log in to the server.
+
+            Example:
+
+                .. code-block:: python
+
+                    from plexapi.server import PlexServer
+                    # Login to the Plex server using the admin token
+                    plex = PlexServer('http://plexserver:32400', token='2ffLuB84dqLswk9skLos')
+                    # Login to the same Plex server using a different account
+                    userPlex = plex.switchUser("Username")
+
+        """
+        user = self.myPlexAccount().user(username)
+        userToken = user.get_token(self.machineIdentifier)
+        return PlexServer(self._baseurl, userToken, self._timeout)
 
     def systemAccounts(self):
         """ Returns a list of :class:`~plexapi.server.SystemAccount` objects this server contains. """

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -237,7 +237,7 @@ class PlexServer(PlexObject):
         """
         user = self.myPlexAccount().user(username)
         userToken = user.get_token(self.machineIdentifier)
-        return PlexServer(self._baseurl, userToken, self._timeout)
+        return PlexServer(self._baseurl, token=userToken, timeout=self._timeout)
 
     def systemAccounts(self):
         """ Returns a list of :class:`~plexapi.server.SystemAccount` objects this server contains. """


### PR DESCRIPTION
## Description

Add a method to switch to a different user on a `PlexServer`.

This saves the trouble of needing to get the `machineIdentifier` and `userToken`.

```python
adminAccount = plex.myPlexAccount()
userAccount = adminAccount.user("Username")
userToken = userAccount.get_token(plexServer.machineIdentifier)
userPlex = PlexServer(plex._baseurl, token=userToken)
```

Example from the doc string:
```python
from plexapi.server import PlexServer
# Login to the Plex server using the admin token
plex = PlexServer('http://plexserver:32400', token='2ffLuB84dqLswk9skLos')
# Login to the same Plex server using a different account
userPlex = plex.switchUser("Username")
```

No tests since we don't have another user to switch to on the test server.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
