### PR TITLE
Add library recently added methods for each libtype

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -537,13 +537,16 @@ class LibrarySection(PlexObject):
         key = '/library/sections/%s/onDeck' % self.key
         return self.fetchItems(key)
 
-    def recentlyAdded(self, maxresults=50):
+    def recentlyAdded(self, maxresults=50, libtype=None):
         """ Returns a list of media items recently added from this library section.
 
             Parameters:
                 maxresults (int): Max number of items to return (default 50).
+                libtype (str, optional): The library type to filter (movie, show, season, episode,
+                    artist, album, track, photoalbum, photo). Default is the main library type.
         """
-        return self.search(sort='addedAt:desc', maxresults=maxresults)
+        libtype = libtype or self.TYPE
+        return self.search(sort='addedAt:desc', maxresults=maxresults, libtype=libtype)
 
     def firstCharacter(self):
         key = '/library/sections/%s/firstCharacter' % self.key
@@ -1399,6 +1402,14 @@ class MovieSection(LibrarySection):
         """ Search for a movie. See :func:`~plexapi.library.LibrarySection.search` for usage. """
         return self.search(libtype='movie', **kwargs)
 
+    def recentlyAddedMovies(self, maxresults=50):
+        """ Returns a list of recently added movies from this library section.
+
+            Parameters:
+                maxresults (int): Max number of items to return (default 50).
+        """
+        return self.recentlyAdded(maxresults=maxresults, libtype='movie')
+
     def sync(self, videoQuality, limit=None, unwatched=False, **kwargs):
         """ Add current Movie library section as sync item for specified device.
             See description of :func:`~plexapi.library.LibrarySection.search` for details about filtering / sorting and
@@ -1460,13 +1471,29 @@ class ShowSection(LibrarySection):
         """ Search for an episode. See :func:`~plexapi.library.LibrarySection.search` for usage. """
         return self.search(libtype='episode', **kwargs)
 
-    def recentlyAdded(self, maxresults=50):
+    def recentlyAddedShows(self, maxresults=50):
+        """ Returns a list of recently added shows from this library section.
+
+            Parameters:
+                maxresults (int): Max number of items to return (default 50).
+        """
+        return self.recentlyAdded(maxresults=maxresults, libtype='show')
+
+    def recentlyAddedSeasons(self, maxresults=50):
+        """ Returns a list of recently added seasons from this library section.
+
+            Parameters:
+                maxresults (int): Max number of items to return (default 50).
+        """
+        return self.recentlyAdded(maxresults=maxresults, libtype='season')
+
+    def recentlyAddedEpisodes(self, maxresults=50):
         """ Returns a list of recently added episodes from this library section.
 
             Parameters:
                 maxresults (int): Max number of items to return (default 50).
         """
-        return self.search(sort='episode.addedAt:desc', maxresults=maxresults)
+        return self.recentlyAdded(maxresults=maxresults, libtype='episode')
 
     def sync(self, videoQuality, limit=None, unwatched=False, **kwargs):
         """ Add current Show library section as sync item for specified device.
@@ -1539,6 +1566,30 @@ class MusicSection(LibrarySection):
         """ Search for a track. See :func:`~plexapi.library.LibrarySection.search` for usage. """
         return self.search(libtype='track', **kwargs)
 
+    def recentlyAddedArtists(self, maxresults=50):
+        """ Returns a list of recently added artists from this library section.
+
+            Parameters:
+                maxresults (int): Max number of items to return (default 50).
+        """
+        return self.recentlyAdded(maxresults=maxresults, libtype='artist')
+
+    def recentlyAddedAlbums(self, maxresults=50):
+        """ Returns a list of recently added albums from this library section.
+
+            Parameters:
+                maxresults (int): Max number of items to return (default 50).
+        """
+        return self.recentlyAdded(maxresults=maxresults, libtype='album')
+
+    def recentlyAddedTracks(self, maxresults=50):
+        """ Returns a list of recently added tracks from this library section.
+
+            Parameters:
+                maxresults (int): Max number of items to return (default 50).
+        """
+        return self.recentlyAdded(maxresults=maxresults, libtype='track')
+
     def sync(self, bitrate, limit=None, **kwargs):
         """ Add current Music library section as sync item for specified device.
             See description of :func:`~plexapi.library.LibrarySection.search` for details about filtering / sorting and
@@ -1597,12 +1648,21 @@ class PhotoSection(LibrarySection):
         raise NotImplementedError('Collections are not available for a Photo library.')
 
     def searchAlbums(self, title, **kwargs):
-        """ Search for an album. See :func:`~plexapi.library.LibrarySection.search` for usage. """
+        """ Search for a photo album. See :func:`~plexapi.library.LibrarySection.search` for usage. """
         return self.search(libtype='photoalbum', title=title, **kwargs)
 
     def searchPhotos(self, title, **kwargs):
         """ Search for a photo. See :func:`~plexapi.library.LibrarySection.search` for usage. """
         return self.search(libtype='photo', title=title, **kwargs)
+
+    def recentlyAddedAlbums(self, maxresults=50):
+        """ Returns a list of recently added photo albums from this library section.
+
+            Parameters:
+                maxresults (int): Max number of items to return (default 50).
+        """
+        # Use search() instead of recentlyAdded() because libtype=None
+        return self.search(sort='addedAt:desc', maxresults=maxresults)
 
     def sync(self, resolution, limit=None, **kwargs):
         """ Add current Music library section as sync item for specified device.

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -186,8 +186,9 @@ def test_library_MovieSection_searchMovies(movies):
     assert movies.searchMovies(title="Elephants Dream")
 
 
-def test_library_MovieSection_recentlyAdded(movies):
-    assert len(movies.recentlyAdded())
+def test_library_MovieSection_recentlyAdded(movies, movie):
+    assert movie in movies.recentlyAdded()
+    assert movie in movies.recentlyAddedMovies()
 
 
 def test_library_MovieSection_analyze(movies):
@@ -214,8 +215,13 @@ def test_library_ShowSection_searchEpisodes(tvshows):
     assert tvshows.searchEpisodes(title="Winter Is Coming")
 
 
-def test_library_ShowSection_recentlyAdded(tvshows):
-    assert len(tvshows.recentlyAdded())
+def test_library_ShowSection_recentlyAdded(tvshows, show):
+    season = show.season(1)
+    episode = season.episode(1)
+    assert show in tvshows.recentlyAdded()
+    assert show in tvshows.recentlyAddedShows()
+    assert season in tvshows.recentlyAddedSeasons()
+    assert episode in tvshows.recentlyAddedEpisodes()
 
 
 def test_library_ShowSection_playlists(plex, tvshows, show):
@@ -239,6 +245,15 @@ def test_library_MusicSection_searchAlbums(music):
     assert len(music.searchAlbums(title="Layers"))
 
 
+def test_library_MusicSection_recentlyAdded(music, artist):
+    album = artist.albums()[0]
+    track = album.tracks()[0]
+    assert artist in music.recentlyAdded()
+    assert artist in music.recentlyAddedArtists()
+    assert album in music.recentlyAddedAlbums()
+    assert track in music.recentlyAddedTracks()
+
+
 def test_library_PhotoSection_searchAlbums(photos, photoalbum):
     title = photoalbum.title
     albums = photos.searchAlbums(title)
@@ -248,6 +263,10 @@ def test_library_PhotoSection_searchAlbums(photos, photoalbum):
 def test_library_PhotoSection_searchPhotos(photos, photoalbum):
     title = photoalbum.photos()[0].title
     assert len(photos.searchPhotos(title))
+
+
+def test_library_PhotoSection_recentlyAdded(photos, photoalbum):
+    assert photoalbum in photos.recentlyAddedAlbums()
 
 
 def test_library_and_section_search_for_movie(plex, movies):


### PR DESCRIPTION
## Description

Adds a recently added method of each libtype in a library section.
* `MovieSection.recentlyAddedMovies()`
* `ShowSection.recentlyAddedShows()`, `ShowSection.recentlyAddedSeasons()`, `ShowSection.recentlyAddedEpisodes()`
* `MusicSection.recentlyAddedArtists()`, `ShowSection.recentlyAddedAlbums()`, `ShowSection.recentlyAddedTracks()`
* `PhotoSection.recentlyAddedAlbums()`

Note: This PR depends on a search sorting fix in #750.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
