### PR TITLE
Add method to claim and unclaim server

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -193,6 +193,26 @@ class PlexServer(PlexObject):
         data = self.query(Account.key)
         return Account(self, data)
 
+    def claim(self, account):
+        """ Claim the Plex server using a :class:`~plexapi.myplex.MyPlexAccount`.
+            This will only work with an unclaimed server on localhost or the same subnet.
+        
+            Parameters:
+                account (:class:`~plexapi.myplex.MyPlexAccount`): The account used to
+                    claim the server.
+        """
+        key = '/myplex/claim'
+        params = {'token': account.claimToken()}
+        data = self.query(key, method=self._session.post, params=params)
+        return Account(self, data)
+
+    def unclaim(self):
+        """ Unclaim the Plex server. This will remove the server from your
+            :class:`~plexapi.myplex.MyPlexAccount`.
+        """
+        data = self.query(Account.key, method=self._session.delete)
+        return Account(self, data)
+
     @property
     def activities(self):
         """Returns all current PMS activities."""
@@ -209,7 +229,7 @@ class PlexServer(PlexObject):
         return self.fetchItems(key)
 
     def createToken(self, type='delegation', scope='all'):
-        """Create a temp access token for the server."""
+        """ Create a temp access token for the server. """
         if not self._token:
             # Handle unclaimed servers
             return None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -308,6 +308,16 @@ def test_server_account(plex):
     assert re.match(utils.REGEX_EMAIL, account.username)
 
 
+@pytest.mark.authenticated
+def test_server_claim_unclaim(plex, account):
+    server_account = plex.account()
+    assert server_account.signInState == 'ok'
+    result = plex.unclaim()
+    assert result.signInState == 'none'
+    result = plex.claim(account)
+    assert result.signInState == 'ok'
+
+
 def test_server_downloadLogs(tmpdir, plex):
     plex.downloadLogs(savepath=str(tmpdir), unpack=True)
     assert len(tmpdir.listdir()) > 1


### PR DESCRIPTION
## Description

Adds a `claim()` and `unclaim()` methods to `PlexServer` to allow claiming and unclaiming the server. Note: claiming a Plex server only works on localhost or the same subnet.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
