### PR TITLE
Allow overwriting attributes with None when manually reloading

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -302,7 +302,7 @@ class PlexObject(object):
                 results.append(elem.attrib.get(attr))
         return results
 
-    def reload(self, key=None, _autoReload=False, **kwargs):
+    def reload(self, key=None, **kwargs):
         """ Reload the data for this object from self.key.
 
             Parameters:
@@ -333,6 +333,10 @@ class PlexObject(object):
                     movie.isFullObject()  # Returns True
 
         """
+        return self._reload(key=key, **kwargs)
+
+    def _reload(self, key=None, _autoReload=False, **kwargs):
+        """ Perform the actual reload. """
         details_key = self._buildDetailsKey(**kwargs) if kwargs else self._details_key
         key = key or details_key or self.key
         if not key:
@@ -459,7 +463,7 @@ class PlexPartialObject(PlexObject):
         objname = "%s '%s'" % (clsname, title) if title else clsname
         log.debug("Reloading %s for attr '%s'", objname, attr)
         # Reload and return the value
-        self.reload(_autoReload=True)
+        self._reload(_autoReload=True)
         return super(PlexPartialObject, self).__getattribute__(attr)
 
     def analyze(self):
@@ -701,7 +705,7 @@ class Playable(object):
         key = '/:/progress?key=%s&identifier=com.plexapp.plugins.library&time=%d&state=%s' % (self.ratingKey,
                                                                                               time, state)
         self._server.query(key)
-        self.reload(_autoReload=True)
+        self._reload(_autoReload=True)
 
     def updateTimeline(self, time, state='stopped', duration=None):
         """ Set the timeline progress for this video.
@@ -719,4 +723,4 @@ class Playable(object):
         key = '/:/timeline?ratingKey=%s&key=%s&identifier=com.plexapp.plugins.library&time=%d&state=%s%s'
         key %= (self.ratingKey, self.key, time, state, durationStr)
         self._server.query(key)
-        self.reload(_autoReload=True)
+        self._reload(_autoReload=True)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -135,9 +135,7 @@ def test_Collection_edit(collection, movies):
             "summary.locked": 0
         }
     )
-    # Cannot use collection.reload() since PlexObject.__setattr__()
-    # will not overwrite contentRating with None
-    collection = movies.collection("Test Collection")
+    collection.reload()
     assert collection.title == title
     assert collection.titleSort == titleSort
     assert collection.contentRating is None

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -185,9 +185,7 @@ def edit_rating(obj):
     assert utils.is_datetime(obj.lastRatedAt)
     assert obj.userRating == 10.0
     obj.rate()
-    # Cannot use obj.reload() since PlexObject.__setattr__()
-    # will not overwrite userRating with None
-    obj = obj.fetchItem(obj._details_key)
+    obj.reload()
     assert obj.userRating is None
     with pytest.raises(BadRequest):
         assert obj.rate('bad-rating')


### PR DESCRIPTION
## Description

The current reload behaviour prevents overwriting attributes with `None`. This change allows overwriting attributes with `None` when calling a manual `reload()`, but still prevents overwriting when we do the automatic internal reload when accessing a missing attribute.

Other changes:
* Changes `_DONT_RELOAD_FOR_KEYS` and `_DONT_OVERWRITE_SESSION_KEYS` to private variables.
* Adds `USER_DONT_RELOAD_FOR_KEYS` public variable for user configurable keys (Closes #713).

~~TODO: Tests can be updated after rebasing on #763 and #764 which ran into this reloading issue.~~
* ~~#763 - Erasing a collection's `contentRating` resets it back to `None`.~~
* ~~#764 - Resetting an items `userRating` resets it back to `None`.~~

Fixes #770


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
