### PR TITLE
Fix return value when using USER_DONT_RELOAD_FOR_KEYS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ lib/
 pip-selfcheck.json
 pyvenv.cfg
 MANIFEST
-
+venv/
 
 # path for the test lib.
 tools/plex

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -455,7 +455,7 @@ class PlexPartialObject(PlexObject):
         # Check a few cases where we dont want to reload
         if attr in _DONT_RELOAD_FOR_KEYS: return value
         if attr in _DONT_OVERWRITE_SESSION_KEYS: return value
-        if attr in USER_DONT_RELOAD_FOR_KEYS: return
+        if attr in USER_DONT_RELOAD_FOR_KEYS: return value
         if attr.startswith('_'): return value
         if value not in (None, []): return value
         if self.isFullObject(): return value


### PR DESCRIPTION
## Description

Forgot to return the value when using `USER_DONT_RELOAD_FOR_KEYS`.

Fixes #765

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
