### PR TITLE
Fix for accessing Account of non Plex Pass account

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -295,9 +295,12 @@ class PlexObject(object):
             if value is not None:
                 return value
 
-    def listAttrs(self, data, attr, **kwargs):
+    def listAttrs(self, data, attr, rtag=None, **kwargs):
         """ Return a list of values from matching attribute. """
         results = []
+        # rtag to iter on a specific root tag
+        if rtag:
+            data = next(data.iter(rtag), [])
         for elem in data:
             kwargs['%s__exists' % attr] = True
             if self._checkAttrs(elem, **kwargs):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -135,11 +135,9 @@ class MyPlexAccount(PlexObject):
         self.subscriptionPlan = subscription.attrib.get('plan')
         self.subscriptionFeatures = self.listAttrs(subscription, 'id', etag='feature')
 
-        roles = data.find('roles')
-        self.roles = self.listAttrs(roles, 'id', etag='role')
+        self.roles = self.listAttrs(data, 'id', rtag='roles', etag='role')
 
-        entitlements = data.find('entitlements')
-        self.entitlements = self.listAttrs(entitlements, 'id', etag='entitlement')
+        self.entitlements = self.listAttrs(data, 'id', rtag='entitlements', etag='entitlement')
 
         # TODO: Fetch missing MyPlexAccount attributes
         self.profile_settings = None


### PR DESCRIPTION
## Description

Fixes issue with accessing MyPlexAccount when account does not have a Plex Pass. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
