### PR TITLE
Remove manual sorts/fields added to PMS

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2080,10 +2080,6 @@ class FilteringType(PlexObject):
                 ('rating', 'integer', 'Critic Rating'),
                 ('viewOffset', 'integer', 'View Offset')
             ])
-        elif self.type == 'artist':
-            additionalFields.extend([
-                ('lastViewedAt', 'date', 'Artist Last Played')
-            ])
         elif self.type == 'track':
             additionalFields.extend([
                 ('duration', 'integer', 'Duration'),

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2014,7 +2014,6 @@ class FilteringType(PlexObject):
             ('guid', 'asc', 'Guid'),
             ('id', 'asc', 'Rating Key'),
             ('index', 'asc', '%s Number' % self.type.capitalize()),
-            ('random', 'asc', 'Random'),
             ('summary', 'asc', 'Summary'),
             ('tagline', 'asc', 'Tagline'),
             ('updatedAt', 'asc', 'Date Updated')

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -461,9 +461,6 @@ def test_library_MovieSection_search_sort(movies):
     guid_asc = [r.guid for r in results_guid]
     assert guid_asc == sorted(guid_asc)
 
-    results_random = movies.search(sort="random")
-    assert len(results_random) == len(results)
-
     results_summary = movies.search(sort="summary")
     summary_asc = [r.summary for r in results_summary]
     assert summary_asc == sorted(summary_asc)


### PR DESCRIPTION
## Description

PMS 1.23.3.4692 exposes the following in the API / UI so we no longer need to add them manually:
* `random` sort
* Artist Last Played field (`artist.lastViewedAt`)

Note: Do not merge until PMS update is on the public channel.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
