### PR TITLE
Add ability to parse the smart filters from collections and playlists

### DIFF
--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -6,13 +6,13 @@ from plexapi.base import PlexPartialObject
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection
 from plexapi.mixins import AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin
-from plexapi.mixins import LabelMixin
+from plexapi.mixins import LabelMixin, SmartFilterMixin
 from plexapi.playqueue import PlayQueue
 from plexapi.utils import deprecated
 
 
 @utils.registerPlexObject
-class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, LabelMixin):
+class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, LabelMixin, SmartFilterMixin):
     """ Represents a single Collection.
 
         Attributes:
@@ -90,6 +90,7 @@ class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin
         self.userRating = utils.cast(float, data.attrib.get('userRating'))
         self._items = None  # cache for self.items
         self._section = None  # cache for self.section
+        self._filters = None  # cache for self.filters
 
     def __len__(self):  # pragma: no cover
         return len(self.items())
@@ -140,6 +141,15 @@ class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin
     @deprecated('use "items" instead', stacklevel=3)
     def children(self):
         return self.items()
+
+    def filters(self):
+        """ Returns the search filter dict for smart collection.
+            The filter dict be passed back into :func:`~plexapi.library.LibrarySection.search`
+            to get the list of items.
+        """
+        if self.smart and self._filters is None:
+            self._filters = self._parseFilters(self.content)
+        return self._filters
 
     def section(self):
         """ Returns the :class:`~plexapi.library.LibrarySection` this collection belongs to.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -927,7 +927,7 @@ class LibrarySection(PlexObject):
                            'Available sort directions: %s'
                            % (sortDir, availableDirections))
 
-        return '%s:%s' % (sortField, sortDir)
+        return '%s:%s' % (sortField, sortDir) if sortDir else sortField
 
     def _validateAdvancedSearch(self, filters, libtype):
         """ Validates an advanced search filter dictionary.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -921,10 +921,7 @@ class LibrarySection(PlexObject):
 
         sortField = libtype + '.' + filterSort.key
 
-        if not sortDir:
-            sortDir = filterSort.defaultDirection
-
-        availableDirections = ['asc', 'desc', 'nullsLast']
+        availableDirections = ['', 'asc', 'desc', 'nullsLast']
         if sortDir not in availableDirections:
             raise NotFound('Unknown sort direction "%s". '
                            'Available sort directions: %s'

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2026,7 +2026,11 @@ class FilteringType(PlexObject):
             additionalSorts.extend([
                 ('absoluteIndex', 'asc', 'Absolute Index')
             ])
-        if self.type == 'collection':
+        elif self.type == 'photo':
+            additionalSorts.extend([
+                ('viewUpdatedAt', 'desc', 'View Updated At')
+            ])
+        elif self.type == 'collection':
             additionalSorts.extend([
                 ('addedAt', 'asc', 'Date Added')
             ])

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -6,13 +6,13 @@ from plexapi import utils
 from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection
-from plexapi.mixins import ArtMixin, PosterMixin
+from plexapi.mixins import ArtMixin, PosterMixin, SmartFilterMixin
 from plexapi.playqueue import PlayQueue
 from plexapi.utils import deprecated
 
 
 @utils.registerPlexObject
-class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin):
+class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin, SmartFilterMixin):
     """ Represents a single Playlist.
 
         Attributes:
@@ -61,6 +61,7 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin):
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self._items = None  # cache for self.items
         self._section = None  # cache for self.section
+        self._filters = None  # cache for self.filters
 
     def __len__(self):  # pragma: no cover
         return len(self.items())
@@ -106,6 +107,22 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin):
     def isPhoto(self):
         """ Returns True if this is a photo playlist. """
         return self.playlistType == 'photo'
+
+    def _getPlaylistItemID(self, item):
+        """ Match an item to a playlist item and return the item playlistItemID. """
+        for _item in self.items():
+            if _item.ratingKey == item.ratingKey:
+                return _item.playlistItemID
+        raise NotFound('Item with title "%s" not found in the playlist' % item.title)
+
+    def filters(self):
+        """ Returns the search filter dict for smart playlist.
+            The filter dict be passed back into :func:`~plexapi.library.LibrarySection.search`
+            to get the list of items.
+        """
+        if self.smart and self._filters is None:
+            self._filters = self._parseFilters(self.content)
+        return self._filters
 
     def section(self):
         """ Returns the :class:`~plexapi.library.LibrarySection` this smart playlist belongs to.
@@ -159,13 +176,6 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin):
     def get(self, title):
         """ Alias to :func:`~plexapi.playlist.Playlist.item`. """
         return self.item(title)
-
-    def _getPlaylistItemID(self, item):
-        """ Match an item to a playlist item and return the item playlistItemID. """
-        for _item in self.items():
-            if _item.ratingKey == item.ratingKey:
-                return _item.playlistItemID
-        raise NotFound('Item with title "%s" not found in the playlist' % item.title)
 
     def addItems(self, items):
         """ Add items to the playlist.

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -148,6 +148,7 @@ def searchType(libtype):
         Parameters:
             libtype (str): LibType to lookup (movie, show, season, episode, artist, album, track,
                                               collection)
+
         Raises:
             :exc:`~plexapi.exceptions.NotFound`: Unknown libtype
     """
@@ -156,6 +157,24 @@ def searchType(libtype):
         return libtype
     if SEARCHTYPES.get(libtype) is not None:
         return SEARCHTYPES[libtype]
+    raise NotFound('Unknown libtype: %s' % libtype)
+
+
+def reverseSearchType(libtype):
+    """ Returns the string value of the library type.
+
+        Parameters:
+            libtype (int): Integer value of the library type.
+
+        Raises:
+            :exc:`~plexapi.exceptions.NotFound`: Unknown libtype
+    """
+    if libtype in SEARCHTYPES:
+        return libtype
+    libtype = int(libtype)
+    for k, v in SEARCHTYPES.items():
+        if libtype == v:
+            return k
     raise NotFound('Unknown libtype: %s' % libtype)
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -184,6 +184,24 @@ def test_Collection_createSmart(plex, tvshows):
         collection.delete()
 
 
+def test_Collection_smartFilters(plex, tvshows):
+    title = "test_Collection_smartFilters"
+    try:
+        collection = plex.createCollection(
+            title=title,
+            section=tvshows,
+            smart=True,
+            limit=5,
+            libtype="episode",
+            sort=["season.index:nullsLast", "episode.index:nullsLast", "show.titleSort"],
+            filters={"or": [{"show.title": "game"}, {'show.title': "100"}]}
+        )
+        filters = collection.filters()
+        assert tvshows.search(**filters) == collection.items()
+    finally:
+        collection.delete()
+
+
 def test_Collection_exceptions(plex, movies, movie, artist):
     title = 'test_Collection_exceptions'
     try:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -184,20 +184,31 @@ def test_Collection_createSmart(plex, tvshows):
         collection.delete()
 
 
-def test_Collection_smartFilters(plex, tvshows):
+def test_Collection_smartFilters(plex, movies):
     title = "test_Collection_smartFilters"
+    advancedFilters = {
+        'and': [
+            {
+                'or': [
+                    {'title': 'elephant'},
+                    {'title=': 'Big Buck Bunny'}
+                ]
+            },
+            {'year>>': 1990},
+            {'unwatched': True}
+        ]
+    }
     try:
         collection = plex.createCollection(
             title=title,
-            section=tvshows,
+            section=movies,
             smart=True,
             limit=5,
-            libtype="episode",
-            sort=["season.index:nullsLast", "episode.index:nullsLast", "show.titleSort"],
-            filters={"or": [{"show.title": "game"}, {'show.title': "100"}]}
+            sort="year",
+            filters=advancedFilters
         )
         filters = collection.filters()
-        assert tvshows.search(**filters) == collection.items()
+        assert movies.search(**filters) == collection.items()
     finally:
         collection.delete()
 

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -182,6 +182,22 @@ def test_Playlist_createSmart(plex, movies, movie):
         playlist.delete()
 
 
+def test_Playlist_smartFilters(plex, tvshows):
+    try:
+        playlist = plex.createPlaylist(
+            title="smart_playlist_filters",
+            smart=True,
+            section=tvshows,
+            limit=5,
+            sort=["season.index:nullsLast", "episode.index:nullsLast", "show.titleSort"],
+            filters={"or": [{"show.title": "game"}, {'show.title': "100"}]}
+        )
+        filters = playlist.filters()
+        assert tvshows.search(**filters) == playlist.items()
+    finally:
+        playlist.delete()
+
+
 def test_Playlist_section(plex, movies, movie):
     title = 'test_playlist_section'
     try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,15 @@ def test_utils_searchType():
         utils.searchType("kekekekeke")
 
 
+def test_utils_reverseSearchType():
+    st = utils.reverseSearchType(1)
+    assert st == "movie"
+    movie = utils.reverseSearchType("movie")
+    assert movie == "movie"
+    with pytest.raises(NotFound):
+        utils.reverseSearchType(-1)
+
+
 def test_utils_joinArgs():
     test_dict = {"genre": "action", "type": 1337}
     assert utils.joinArgs(test_dict) == "?genre=action&type=1337"


### PR DESCRIPTION
## Description

Adds a `filters()` method to `Collection` and `Playlist` to parse out the smart filters originally used to create the collection or playlist. The filters returned from `filters()` can be passed directly into `LibrarySection.search()` as `kwargs` to return the list of items.

Note: Only supports parsing filters using the new advanced filters from Plex Web 4.56.3. Smart collections and playlists created before Plex Web 4.56.3 must be updated first.

Example:
```py
advancedFilters = {
    'and': [
        {
            'or': [
                {'title': 'elephant'},
                {'title': 'bunny'}
            ]
        },
        {'year>>': 1990},
        {'unwatched': True}
    ]
}

collection = movies.createCollection(
    title='Smart Filters',
    smart=True,
    limit=2,
    sort='year:asc',
    filters=advancedFilters
)
collectionSmartFilters = collection.filters()
assert collection.items() == movies.search(**collectionSmartFilters)
```


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
