### PR TITLE
Fix updateProgress and updateTimeline

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -699,9 +699,9 @@ class Playable(object):
     def updateProgress(self, time, state='stopped'):
         """ Set the watched progress for this video.
 
-        Note that setting the time to 0 will not work.
-        Use `markWatched` or `markUnwatched` to achieve
-        that goal.
+            Note that setting the time to 0 will not work.
+            Use `markWatched` or `markUnwatched` to achieve
+            that goal.
 
             Parameters:
                 time (int): Milliseconds watched. Minimum is 60001 ms (60 sec),

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -704,9 +704,15 @@ class Playable(object):
         that goal.
 
             Parameters:
-                time (int): milliseconds watched
-                state (string): state of the video, default 'stopped'
+                time (int): Milliseconds watched. Minimum is 60001 ms (60 sec),
+                    maximum is the duration of the video minus 1000 ms (1 sec remaining)
+                state (string): State of the video, default 'stopped'
+
+            Raises:
+                :exc:`~plexapi.exceptions.BadRequest`: time is not within minimum and maximum values
         """
+        if time <= 60000 or time > self.duration - 1000:
+            raise BadRequest('time must be between 60001 ms and %s (duration - 1000 ms)' % (self.duration - 1000))
         key = '/:/progress?key=%s&identifier=com.plexapp.plugins.library&time=%d&state=%s' % (self.ratingKey,
                                                                                               time, state)
         self._server.query(key)
@@ -716,10 +722,18 @@ class Playable(object):
         """ Set the timeline progress for this video.
 
             Parameters:
-                time (int): milliseconds watched
+                time (int): Milliseconds watched. Minimum is 60001 ms (60 sec),
+                    maximum is the duration of the video.
                 state (string): state of the video, default 'stopped'
                 duration (int): duration of the item
+
+            Raises:
+                :exc:`~plexapi.exceptions.Unsupported`: video duration is less than 60 sec
+                :exc:`~plexapi.exceptions.BadRequest`: time is not within minimum and maximum values
         """
+        if time <= 60000 or time > self.duration:
+            raise BadRequest('time must be between 60001 ms and %s (duration)' % self.duration)
+
         durationStr = '&duration='
         if duration is not None:
             durationStr = durationStr + str(duration)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -82,8 +82,8 @@ def test_library_fetchItem(plex, movie):
 
 
 def test_library_onDeck(plex, movie):
-    movie.updateProgress(movie.duration * 1000 / 10)  # set progress to 10%
-    assert len(list(plex.library.onDeck()))
+    movie.updateProgress(movie.duration // 4)  # set progress to 25%
+    assert movie in plex.library.onDeck()
     movie.markUnwatched()
 
 
@@ -174,11 +174,11 @@ def test_librarty_deleteMediaPreviews(movies):
 
 
 def test_library_MovieSection_onDeck(movie, movies, tvshows, episode):
-    movie.updateProgress(movie.duration * 1000 / 10)  # set progress to 10%
-    assert movies.onDeck()
+    movie.updateProgress(movie.duration // 4)  # set progress to 45%
+    assert movie in movies.onDeck()
     movie.markUnwatched()
-    episode.updateProgress(episode.duration * 1000 / 10)
-    assert tvshows.onDeck()
+    episode.updateProgress(episode.duration // 4)
+    assert episode in tvshows.onDeck()
     episode.markUnwatched()
 
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -913,13 +913,21 @@ def test_video_Season_mixins_tags(show):
 
 
 def test_video_Episode_updateProgress(episode, patched_http_call):
-    episode.updateProgress(10 * 60 * 1000)  # 10 minutes.
+    episode.updateProgress(2 * 60 * 1000)  # 2 minutes.
+    with pytest.raises(BadRequest):
+        episode.updateProgress(0)
+    with pytest.raises(BadRequest):
+        episode.updateProgress(episode.duration)
 
 
 def test_video_Episode_updateTimeline(episode, patched_http_call):
     episode.updateTimeline(
-        10 * 60 * 1000, state="playing", duration=episode.duration
-    )  # 10 minutes.
+        2 * 60 * 1000, state="playing", duration=episode.duration
+    )  # 2 minutes.
+    with pytest.raises(BadRequest):
+        episode.updateTimeline(0)
+    with pytest.raises(BadRequest):
+        episode.updateTimeline(episode.duration + 1000)
 
 
 def test_video_Episode_stop(episode, mocker, patched_http_call):


### PR DESCRIPTION
The bug has been identified due to XML corruption for movies that have been moved in a collection and have progress (`updateProgress`) or marked as played (`markWatched`). The bug has already been fixed by Plex in future versions of PMS so this PR is not necessary.

https://github.com/pkkid/python-plexapi/pull/783/commits/f1936c7387495fa352760a1be797504810541685

## Description

Using invalid `time` values for `updateProgress()` and `updateTimeline()` can corrupt the media item in the PMS database (see failed tests in #783). The corruption appears to be due to a database change in the latest PMS version. This change protects against this by raising `BadRequest` if the `time` is invalid.


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
