### PR TITLE
Add ability to use FilterChoice and FilteringSort objects in library search

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -97,7 +97,7 @@ def _test_mixins_image(obj, attr):
             # Select a different image
             set_img_method(images[1])
             images = get_img_method()
-            assert utils.wait_until(_check_img_selected, get_img_method=get_img_method)
+            assert utils.wait_until(_check_img_selected, delay=0.25, timeout=5, get_img_method=get_img_method)
     else:
         default_image = None
     # Test upload image from file

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -93,11 +93,17 @@ def _test_mixins_image(obj, attr):
         assert len(image.ratingKey) >= 10
         assert utils.is_bool(image.selected)
         assert len(image.thumb) >= 10
+        print(images)
         if len(images) >= 2:
             # Select a different image
+            for i in images:
+                print(vars(i))
             set_img_method(images[1])
             images = get_img_method()
-            assert utils.wait_until(_check_img_selected, delay=0.25, timeout=5, get_img_method=get_img_method)
+            for i in images:
+                print(vars(i))
+            assert images[0].selected is False
+            assert images[1].selected is True
     else:
         default_image = None
     # Test upload image from file
@@ -111,11 +117,6 @@ def _test_mixins_image(obj, attr):
     # Reset to default image
     if default_image:
         set_img_method(default_image)
-
-
-def _check_img_selected(get_img_method):
-    images = get_img_method()
-    return images[0].selected is False and images[1].selected is True
 
 
 def edit_art(obj):

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -97,8 +97,7 @@ def _test_mixins_image(obj, attr):
             # Select a different image
             set_img_method(images[1])
             images = get_img_method()
-            assert images[0].selected is False
-            assert images[1].selected is True
+            assert utils.wait_until(_check_img_selected, get_img_method=get_img_method)
     else:
         default_image = None
     # Test upload image from file
@@ -112,6 +111,11 @@ def _test_mixins_image(obj, attr):
     # Reset to default image
     if default_image:
         set_img_method(default_image)
+
+
+def _check_img_selected(get_img_method):
+    images = get_img_method()
+    return images[0].selected is False and images[1].selected is True
 
 
 def edit_art(obj):

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -272,6 +272,8 @@ def create_section(server, section, opts):
     processed_media = 0
     expected_media_count = section.pop("expected_media_count", 0)
     expected_media_type = (section["type"],)
+    if section["type"] == "show":
+        expected_media_type = ("show", "season", "episode")
     if section["type"] == "artist":
         expected_media_type = ("artist", "album", "track")
     expected_media_type = tuple(SEARCHTYPES[t] for t in expected_media_type)


### PR DESCRIPTION
## Description

* Adds ability to use a `FilterChoice` object when searching a library using a tag.

```python
availableChoices = library.listFilterChoices('collection')  # List of FilterChoice objects
filters = {'collection': availableChoices[0]}  # Filter using a FilterChoice object instead of a collection name string
library.search(filters=filters)
```

* Adds ability to use a `FilteringSort` object when searching a library using a sort field. Using a `FilteringSort` object will sort in the `defaultDirection` of the field.

```python
availableSorts = library.listSorts()  # List of FilteringSort objects.
sort = availableSorts[0]  # Sort using a FilteringSort object instead of a field:dir string
library.search(sort=sort)
```


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
