### PR TITLE
Decouple resource address sorting from connection attempts

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -16,10 +16,6 @@ from plexapi.sonos import PlexSonosClient
 from plexapi.sync import SyncItem, SyncList
 from requests.status_codes import _codes as codes
 
-# Default order to prioritize available resource connections
-RESOURCE_LOCATION_ORDER = ['local', 'remote', 'relay']
-RESOURCE_SCHEME_ORDER = ['https', 'http']
-
 
 class MyPlexAccount(PlexObject):
     """ MyPlex account and profile information. This object represents the data found Account on
@@ -927,6 +923,10 @@ class MyPlexResource(PlexObject):
     TAG = 'Device'
     key = 'https://plex.tv/api/resources?includeHttps=1&includeRelay=1'
 
+    # Default order to prioritize available resource connections
+    DEFAULT_LOCATION_ORDER = ['local', 'remote', 'relay']
+    DEFAULT_SCHEME_ORDER = ['https', 'http']
+
     def _loadData(self, data):
         self._data = data
         self.name = data.attrib.get('name')
@@ -955,8 +955,8 @@ class MyPlexResource(PlexObject):
         self,
         ssl=None,
         timeout=None,
-        locations=RESOURCE_LOCATION_ORDER,
-        schemes=RESOURCE_SCHEME_ORDER,
+        locations=DEFAULT_LOCATION_ORDER,
+        schemes=DEFAULT_SCHEME_ORDER,
     ):
         """ Returns a sorted list of the available connection addresses for this resource.
             Often times there is more than one address specified for a server or client.
@@ -991,8 +991,8 @@ class MyPlexResource(PlexObject):
         self,
         ssl=None,
         timeout=None,
-        locations=RESOURCE_LOCATION_ORDER,
-        schemes=RESOURCE_SCHEME_ORDER,
+        locations=DEFAULT_LOCATION_ORDER,
+        schemes=DEFAULT_SCHEME_ORDER,
     ):
         """ Returns a new :class:`~plexapi.server.PlexServer` or :class:`~plexapi.client.PlexClient` object.
             Uses `MyPlexResource.preferred_connections()` to generate the priority order of connection addresses.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -951,7 +951,8 @@ class MyPlexResource(PlexObject):
         self.ownerid = utils.cast(int, data.attrib.get('ownerId', 0))
         self.sourceTitle = data.attrib.get('sourceTitle')  # owners plex username.
 
-    def preferred_connections(self,
+    def preferred_connections(
+        self,
         ssl=None,
         timeout=None,
         locations=RESOURCE_LOCATION_ORDER,
@@ -986,7 +987,8 @@ class MyPlexResource(PlexObject):
                 connections.extend(connections_dict[location][scheme])
         return connections
 
-    def connect(self,
+    def connect(
+        self,
         ssl=None,
         timeout=None,
         locations=RESOURCE_LOCATION_ORDER,

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -16,6 +16,10 @@ from plexapi.sonos import PlexSonosClient
 from plexapi.sync import SyncItem, SyncList
 from requests.status_codes import _codes as codes
 
+# Default order to prioritize available resource connections
+RESOURCE_LOCATION_ORDER = ['local', 'remote', 'relay']
+RESOURCE_SCHEME_ORDER = ['https', 'http']
+
 
 class MyPlexAccount(PlexObject):
     """ MyPlex account and profile information. This object represents the data found Account on
@@ -947,10 +951,49 @@ class MyPlexResource(PlexObject):
         self.ownerid = utils.cast(int, data.attrib.get('ownerId', 0))
         self.sourceTitle = data.attrib.get('sourceTitle')  # owners plex username.
 
-    def connect(self, ssl=None, timeout=None):
-        """ Returns a new :class:`~plexapi.server.PlexServer` or :class:`~plexapi.client.PlexClient` object.
+    def preferred_connections(self,
+        ssl=None,
+        timeout=None,
+        locations=RESOURCE_LOCATION_ORDER,
+        schemes=RESOURCE_SCHEME_ORDER,
+    ):
+        """ Returns a sorted list of the available connection addresses for this resource.
             Often times there is more than one address specified for a server or client.
-            This function will prioritize local connections before remote or relay and HTTPS before HTTP.
+            Default behavior will prioritize local connections before remote or relay and HTTPS before HTTP.
+
+            Parameters:
+                ssl (bool, optional): Set True to only connect to HTTPS connections. Set False to
+                    only connect to HTTP connections. Set None (default) to connect to any
+                    HTTP or HTTPS connection.
+                timeout (int, optional): The timeout in seconds to attempt each connection.
+        """
+        connections_dict = {location: {scheme: [] for scheme in schemes} for location in locations}
+        for connection in self.connections:
+            # Only check non-local connections unless we own the resource
+            if self.owned or (not self.owned and not connection.local):
+                location = 'relay' if connection.relay else ('local' if connection.local else 'remote')
+                if location not in locations:
+                    continue
+                if 'http' in schemes:
+                    connections_dict[location]['http'].append(connection.httpuri)
+                if 'https' in schemes:
+                    connections_dict[location]['https'].append(connection.uri)
+        if ssl is True: schemes.remove('http')
+        elif ssl is False: schemes.remove('https')
+        connections = []
+        for location in locations:
+            for scheme in schemes:
+                connections.extend(connections_dict[location][scheme])
+        return connections
+
+    def connect(self,
+        ssl=None,
+        timeout=None,
+        locations=RESOURCE_LOCATION_ORDER,
+        schemes=RESOURCE_SCHEME_ORDER,
+    ):
+        """ Returns a new :class:`~plexapi.server.PlexServer` or :class:`~plexapi.client.PlexClient` object.
+            Uses `MyPlexResource.preferred_connections()` to generate the priority order of connection addresses.
             After trying to connect to all available addresses for this resource and
             assuming at least one connection was successful, the PlexServer object is built and returned.
 
@@ -963,22 +1006,7 @@ class MyPlexResource(PlexObject):
             Raises:
                 :exc:`~plexapi.exceptions.NotFound`: When unable to connect to any addresses for this resource.
         """
-        # Keys in the order we want the connections to be sorted
-        locations = ['local', 'remote', 'relay']
-        schemes = ['https', 'http']
-        connections_dict = {location: {scheme: [] for scheme in schemes} for location in locations}
-        for connection in self.connections:
-            # Only check non-local connections unless we own the resource
-            if self.owned or (not self.owned and not connection.local):
-                location = 'relay' if connection.relay else ('local' if connection.local else 'remote')
-                connections_dict[location]['http'].append(connection.httpuri)
-                connections_dict[location]['https'].append(connection.uri)
-        if ssl is True: schemes.remove('http')
-        elif ssl is False: schemes.remove('https')
-        connections = []
-        for location in locations:
-            for scheme in schemes:
-                connections.extend(connections_dict[location][scheme])
+        connections = self.preferred_connections(ssl, timeout, locations, schemes)
         # Try connecting to all known resource connections in parellel, but
         # only return the first server (in order) that provides a response.
         cls = PlexServer if 'server' in self.provides else PlexClient


### PR DESCRIPTION
## Description

Previously the connection address priority order for resources was hardcoded to prefer local over remote and HTTPS over HTTP in the `MyPlexResource.connect()` method. This decouples the generation of the prioritized list which:

1. Gives users access to the generated list of ordered connections.
2. Allows modification of the priorities.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
