### PR TITLE
Add methods to retrieve the Plex Web URL

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -416,11 +416,6 @@ class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin,
         """ Returns str, default title for a new syncItem. """
         return '%s - %s - %s' % (self.grandparentTitle, self.parentTitle, self.title)
 
-    def getWebURL(self, base=None):
-        """ Returns the Plex Web URL for the track's album.
-
-            Parameters:
-                base (str): The base URL before the fragment (``#!``).
-                    Default is https://app.plex.tv/desktop.
-        """
-        return self._buildWebURL(base=base, key=self.parentKey)
+    def _getWebURL(self, base=None):
+        """ Get the Plex Web URL with the correct parameters. """
+        return self._server._buildWebURL(base=base, endpoint='details', key=self.parentKey)

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -415,3 +415,12 @@ class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin,
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """
         return '%s - %s - %s' % (self.grandparentTitle, self.parentTitle, self.title)
+
+    def getWebURL(self, base=None):
+        """ Returns the Plex Web URL for the track's album.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+        """
+        return self._buildWebURL(base=base, key=self.parentKey)

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -575,11 +575,44 @@ class PlexPartialObject(PlexObject):
 
     def history(self, maxresults=9999999, mindate=None):
         """ Get Play History for a media item.
+
             Parameters:
                 maxresults (int): Only return the specified number of results (optional).
                 mindate (datetime): Min datetime to return results from.
         """
         return self._server.history(maxresults=maxresults, mindate=mindate, ratingKey=self.ratingKey)
+
+    def _buildWebURL(self, base=None, endpoint='details', key='', legacy=False):
+        """ Build the Plex Web URL for the item.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+                endpoint (str): The Plex Web URL endpoint.
+                    'playlist' for playlists, 'details' for all other media types.
+                key (str): The Plex API URL for the item (/library/metadata/<ratingKey>).
+                legacy (bool): True or False to use the legacy URL.
+                    Photoalbum and Photo use the legacy URL.
+        """
+        if base is None:
+            base = 'https://app.plex.tv/desktop'
+
+        params = {'key': key or self.key}
+        if legacy:
+            params['legacy'] = 1
+
+        return '%s#!/server/%s/%s%s' % (
+            base, self._server.machineIdentifier, endpoint, utils.joinArgs(params)
+        )
+
+    def getWebURL(self, base=None):
+        """ Returns the Plex Web URL for the item.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+        """
+        return self._buildWebURL(base=base)
 
 
 class Playable(object):

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -582,37 +582,20 @@ class PlexPartialObject(PlexObject):
         """
         return self._server.history(maxresults=maxresults, mindate=mindate, ratingKey=self.ratingKey)
 
-    def _buildWebURL(self, base=None, endpoint='details', key='', legacy=False):
-        """ Build the Plex Web URL for the item.
-
-            Parameters:
-                base (str): The base URL before the fragment (``#!``).
-                    Default is https://app.plex.tv/desktop.
-                endpoint (str): The Plex Web URL endpoint.
-                    'playlist' for playlists, 'details' for all other media types.
-                key (str): The Plex API URL for the item (/library/metadata/<ratingKey>).
-                legacy (bool): True or False to use the legacy URL.
-                    Photoalbum and Photo use the legacy URL.
+    def _getWebURL(self, base=None):
+        """ Get the Plex Web URL with the correct parameters.
+            Private method to allow overriding parameters from subclasses.
         """
-        if base is None:
-            base = 'https://app.plex.tv/desktop/'
-
-        params = {'key': key or self.key}
-        if legacy:
-            params['legacy'] = 1
-
-        return '%s#!/server/%s/%s%s' % (
-            base, self._server.machineIdentifier, endpoint, utils.joinArgs(params)
-        )
+        return self._server._buildWebURL(base=base, endpoint='details', key=self.key)
 
     def getWebURL(self, base=None):
-        """ Returns the Plex Web URL for the item.
+        """ Returns the Plex Web URL for a media item.
 
             Parameters:
                 base (str): The base URL before the fragment (``#!``).
                     Default is https://app.plex.tv/desktop.
         """
-        return self._buildWebURL(base=base)
+        return self._getWebURL(base=base)
 
 
 class Playable(object):

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -595,7 +595,7 @@ class PlexPartialObject(PlexObject):
                     Photoalbum and Photo use the legacy URL.
         """
         if base is None:
-            base = 'https://app.plex.tv/desktop'
+            base = 'https://app.plex.tv/desktop/'
 
         params = {'key': key or self.key}
         if legacy:

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1456,6 +1456,29 @@ class LibrarySection(PlexObject):
     def listChoices(self, category, libtype=None, **kwargs):
         return self.listFilterChoices(field=category, libtype=libtype)
 
+    def getWebURL(self, base=None, tab=None, key=None):
+        """ Returns the Plex Web URL for the library.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+                tab (str): The library tab (recommended, library, collections, playlists, timeline).
+                key (str): A hub key.
+        """
+        if base is None:
+            base = 'https://app.plex.tv/desktop/'
+
+        params = {'source': self.key}
+        if tab is not None:
+            params['pivot'] = tab
+        if key is not None:
+            params['key'] = key
+            params['pageType'] = 'list'
+
+        return '%s#!/media/%s/com.plexapp.plugins.library%s' % (
+            base, self._server.machineIdentifier, utils.joinArgs(params)
+        )
+
 
 class MovieSection(LibrarySection):
     """ Represents a :class:`~plexapi.library.LibrarySection` section containing movies.
@@ -1857,6 +1880,7 @@ class Hub(PlexObject):
         self.style = data.attrib.get('style')
         self.title = data.attrib.get('title')
         self.type = data.attrib.get('type')
+        self._section = None  # cache for self.section
 
     def __len__(self):
         return self.size
@@ -1867,6 +1891,22 @@ class Hub(PlexObject):
             self.items = self.fetchItems(self.key)
             self.more = False
             self.size = len(self.items)
+
+    def section(self):
+        """ Returns the :class:`~plexapi.library.LibrarySection` this hub belongs to.
+        """
+        if self._section is None:
+            self._section = self._server.library.sectionByID(self.librarySectionID)
+        return self._section
+
+    def getWebURL(self, base=None):
+        """ Returns the Plex Web URL for the library.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+        """
+        return self.section().getWebURL(base=base, key=self.key)
 
 
 class HubMediaTag(PlexObject):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1465,19 +1465,13 @@ class LibrarySection(PlexObject):
                 tab (str): The library tab (recommended, library, collections, playlists, timeline).
                 key (str): A hub key.
         """
-        if base is None:
-            base = 'https://app.plex.tv/desktop/'
-
         params = {'source': self.key}
         if tab is not None:
             params['pivot'] = tab
         if key is not None:
             params['key'] = key
             params['pageType'] = 'list'
-
-        return '%s#!/media/%s/com.plexapp.plugins.library%s' % (
-            base, self._server.machineIdentifier, utils.joinArgs(params)
-        )
+        return self._server._buildWebURL(base=base, **params)
 
 
 class MovieSection(LibrarySection):
@@ -1898,15 +1892,6 @@ class Hub(PlexObject):
         if self._section is None:
             self._section = self._server.library.sectionByID(self.librarySectionID)
         return self._section
-
-    def getWebURL(self, base=None):
-        """ Returns the Plex Web URL for the library.
-
-            Parameters:
-                base (str): The base URL before the fragment (``#!``).
-                    Default is https://app.plex.tv/desktop.
-        """
-        return self.section().getWebURL(base=base, key=self.key)
 
 
 class HubMediaTag(PlexObject):

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -137,14 +137,9 @@ class Photoalbum(PlexPartialObject, ArtMixin, PosterMixin, RatingMixin):
                 filepaths.append(filepath)
         return filepaths
 
-    def getWebURL(self, base=None):
-        """ Returns the Plex Web URL for the photoalbum.
-
-            Parameters:
-                base (str): The base URL before the fragment (``#!``).
-                    Default is https://app.plex.tv/desktop.
-        """
-        return self._buildWebURL(base=base, legacy=True)
+    def _getWebURL(self, base=None):
+        """ Get the Plex Web URL with the correct parameters. """
+        return self._server._buildWebURL(base=base, endpoint='details', key=self.key, legacy=1)
 
 
 @utils.registerPlexObject
@@ -311,11 +306,6 @@ class Photo(PlexPartialObject, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixi
                 filepaths.append(filepath)
         return filepaths
 
-    def getWebURL(self, base=None):
-        """ Returns the Plex Web URL for the photo's photoalbum.
-
-            Parameters:
-                base (str): The base URL before the fragment (``#!``).
-                    Default is https://app.plex.tv/desktop.
-        """
-        return self._buildWebURL(base=base, key=self.parentKey, legacy=True)
+    def _getWebURL(self, base=None):
+        """ Get the Plex Web URL with the correct parameters. """
+        return self._server._buildWebURL(base=base, endpoint='details', key=self.parentKey, legacy=1)

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -137,6 +137,15 @@ class Photoalbum(PlexPartialObject, ArtMixin, PosterMixin, RatingMixin):
                 filepaths.append(filepath)
         return filepaths
 
+    def getWebURL(self, base=None):
+        """ Returns the Plex Web URL for the photoalbum.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+        """
+        return self._buildWebURL(base=base, legacy=True)
+
 
 @utils.registerPlexObject
 class Photo(PlexPartialObject, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin, TagMixin):
@@ -301,3 +310,12 @@ class Photo(PlexPartialObject, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixi
             if filepath:
                 filepaths.append(filepath)
         return filepaths
+
+    def getWebURL(self, base=None):
+        """ Returns the Plex Web URL for the photo's photoalbum.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+        """
+        return self._buildWebURL(base=base, key=self.parentKey, legacy=True)

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -460,11 +460,6 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin, SmartFilterMi
 
         return myplex.sync(sync_item, client=client, clientId=clientId)
 
-    def getWebURL(self, base=None):
-        """ Returns the Plex Web URL for the playlist.
-
-            Parameters:
-                base (str): The base URL before the fragment (``#!``).
-                    Default is https://app.plex.tv/desktop.
-        """
-        return self._buildWebURL(base=base, endpoint='playlist')
+    def _getWebURL(self, base=None):
+        """ Get the Plex Web URL with the correct parameters. """
+        return self._server._buildWebURL(base=base, endpoint='playlist', key=self.key)

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -459,3 +459,12 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin, SmartFilterMi
             raise Unsupported('Unsupported playlist content')
 
         return myplex.sync(sync_item, client=client, clientId=clientId)
+
+    def getWebURL(self, base=None):
+        """ Returns the Plex Web URL for the playlist.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+        """
+        return self._buildWebURL(base=base, endpoint='playlist')

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -890,6 +890,25 @@ class PlexServer(PlexObject):
         key = '/statistics/resources?timespan=6'
         return self.fetchItems(key, StatisticsResources)
 
+    def getPlaylistsWebURL(self, base=None, tab=None):
+        """ Returns the Plex Web URL for the server playlists page.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+                tab (str): The playlist tab (audio, video, photo).
+        """
+        if base is None:
+            base = 'https://app.plex.tv/desktop/'
+
+        params = {'source': 'playlists'}
+        if tab is not None:
+            params['pivot'] = 'playlists.%s' % tab
+
+        return '%s#!/media/%s/com.plexapp.plugins.library%s' % (
+            base, self._server.machineIdentifier, utils.joinArgs(params)
+        )
+
 
 class Account(PlexObject):
     """ Contains the locally cached MyPlex account information. The properties provided don't

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -890,24 +890,41 @@ class PlexServer(PlexObject):
         key = '/statistics/resources?timespan=6'
         return self.fetchItems(key, StatisticsResources)
 
-    def getPlaylistsWebURL(self, base=None, tab=None):
-        """ Returns the Plex Web URL for the server playlists page.
+    def _buildWebURL(self, base=None, endpoint=None, **kwargs):
+        """ Build the Plex Web URL for the object.
 
             Parameters:
                 base (str): The base URL before the fragment (``#!``).
                     Default is https://app.plex.tv/desktop.
-                tab (str): The playlist tab (audio, video, photo).
+                endpoint (str): The Plex Web URL endpoint.
+                    None for server, 'playlist' for playlists, 'details' for all other media types.
+                **kwargs (dict): Dictionary of URL parameters.
         """
         if base is None:
             base = 'https://app.plex.tv/desktop/'
 
-        params = {'source': 'playlists'}
-        if tab is not None:
-            params['pivot'] = 'playlists.%s' % tab
+        if endpoint:
+            return '%s#!/server/%s/%s%s' % (
+                base, self.machineIdentifier, endpoint, utils.joinArgs(kwargs)
+            )
+        else:
+            return '%s#!/media/%s/com.plexapp.plugins.library%s' % (
+                base, self.machineIdentifier, utils.joinArgs(kwargs)
+            )
 
-        return '%s#!/media/%s/com.plexapp.plugins.library%s' % (
-            base, self._server.machineIdentifier, utils.joinArgs(params)
-        )
+    def getWebURL(self, base=None, playlistTab=None):
+        """ Returns the Plex Web URL for the server.
+
+            Parameters:
+                base (str): The base URL before the fragment (``#!``).
+                    Default is https://app.plex.tv/desktop.
+                playlistTab (str): The playlist tab (audio, video, photo). Only used for the playlist URL.
+        """
+        if playlistTab is not None:
+            params = {'source': 'playlists', 'pivot': 'playlists.%s' % playlistTab}
+        else:
+            params = {'key': '/hubs', 'pageType': 'hub'}
+        return self._buildWebURL(base=base, **params)
 
 
 class Account(PlexObject):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from urllib.parse import quote_plus
+
 from . import conftest as utils
 from . import test_media, test_mixins
 
@@ -103,6 +105,14 @@ def test_audio_Artist_media_tags(artist):
     test_media.tag_style(artist)
 
 
+def test_video_Artist_PlexWebURL(plex, artist):
+    url = artist.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(artist.key) in url
+
+
 def test_audio_Album_attrs(album):
     assert utils.is_datetime(album.addedAt)
     if album.art:
@@ -194,6 +204,14 @@ def test_audio_Album_media_tags(album):
     test_media.tag_label(album)
     test_media.tag_mood(album)
     test_media.tag_style(album)
+
+
+def test_video_Album_PlexWebURL(plex, album):
+    url = album.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(album.key) in url
 
 
 def test_audio_Track_attrs(album):
@@ -335,6 +353,14 @@ def test_audio_Track_media_tags(track):
     track.reload()
     test_media.tag_collection(track)
     test_media.tag_mood(track)
+
+
+def test_video_Track_PlexWebURL(plex, track):
+    url = track.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(track.parentKey) in url
 
 
 def test_audio_Audio_section(artist, album, track):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from urllib.parse import quote_plus
+
 import pytest
 from plexapi.exceptions import BadRequest, NotFound
 
@@ -283,3 +285,11 @@ def test_Collection_mixins_rating(collection):
 
 def test_Collection_mixins_tags(collection):
     test_mixins.edit_label(collection)
+
+
+def test_Collection_PlexWebURL(plex, collection):
+    url = collection.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(collection.key) in url

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from collections import namedtuple
 from datetime import datetime, timedelta
+from urllib.parse import quote_plus
+
 import pytest
 from plexapi.exceptions import BadRequest, NotFound
 
@@ -210,6 +212,30 @@ def test_library_MovieSection_collections(movies, movie):
 def test_library_MovieSection_collection_exception(movies):
     with pytest.raises(NotFound):
         movies.collection("Does Not Exists")
+
+
+def test_library_MovieSection_PlexWebURL(plex, movies):
+    tab = 'library'
+    url = movies.getWebURL(tab=tab)
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'source=%s' % movies.key in url
+    assert 'pivot=%s' % tab in url
+    # Test a different base
+    base = 'https://doesnotexist.com/plex'
+    url = movies.getWebURL(base=base)
+    assert url.startswith(base)
+
+
+def test_library_MovieSection_PlexWebURL_hub(plex, movies):
+    hubs = movies.hubs()
+    hub = next(iter(hubs), None)
+    assert hub is not None
+    url = hub.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'source=%s' % movies.key in url
+    assert quote_plus(hub.key) in url
 
 
 def test_library_ShowSection_all(tvshows):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -231,7 +231,7 @@ def test_library_MovieSection_PlexWebURL_hub(plex, movies):
     hubs = movies.hubs()
     hub = next(iter(hubs), None)
     assert hub is not None
-    url = hub.getWebURL()
+    url = hub.section().getWebURL(key=hub.key)
     assert url.startswith('https://app.plex.tv/desktop')
     assert plex.machineIdentifier in url
     assert 'source=%s' % movies.key in url

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from urllib.parse import quote_plus
+
 from . import test_media, test_mixins
 
 
@@ -22,6 +24,15 @@ def test_photo_Photoalbum_mixins_rating(photoalbum):
     test_mixins.edit_rating(photoalbum)
 
 
+def test_video_Photoalbum_PlexWebURL(plex, photoalbum):
+    url = photoalbum.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(photoalbum.key) in url
+    assert 'legacy=1' in url
+
+
 def test_photo_Photo_mixins_rating(photo):
     test_mixins.edit_rating(photo)
 
@@ -33,3 +44,12 @@ def test_photo_Photo_mixins_tags(photo):
 def test_photo_Photo_media_tags(photo):
     photo.reload()
     test_media.tag_tag(photo)
+
+
+def test_video_Photo_PlexWebURL(plex, photo):
+    url = photo.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(photo.parentKey) in url
+    assert 'legacy=1' in url

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
+from urllib.parse import quote_plus
 
 import pytest
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
@@ -253,5 +254,19 @@ def test_Playlist_exceptions(plex, movies, movie, artist):
             playlist.removeItems(movie)
         with pytest.raises(BadRequest):
             playlist.moveItem(movie)
+    finally:
+        playlist.delete()
+
+
+def test_Playlist_PlexWebURL(plex, show):
+    title = 'test_playlist_plexweburl'
+    episodes = show.episodes()
+    playlist = plex.createPlaylist(title, items=episodes[:3])
+    try:
+        url = playlist.getWebURL()
+        assert url.startswith('https://app.plex.tv/desktop')
+        assert plex.machineIdentifier in url
+        assert 'playlist' in url
+        assert quote_plus(playlist.key) in url
     finally:
         playlist.delete()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import time
+from urllib.parse import quote_plus
 
 import pytest
 from datetime import datetime
@@ -514,14 +515,22 @@ def test_server_transcode_sessions(plex, requests_mock):
     assert utils.is_int(session.width, gte=852)
 
 
-def test_server_PlaylistsPlexWebURL(plex):
+def test_server_PlexWebURL(plex):
+    url = plex.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert quote_plus('/hubs') in url
+    assert 'pageType=hub' in url
+    # Test a different base
+    base = 'https://doesnotexist.com/plex'
+    url = plex.getWebURL(base=base)
+    assert url.startswith(base)
+
+
+def test_server_PlexWebURL_playlists(plex):
     tab = 'audio'
-    url = plex.getPlaylistsWebURL(tab=tab)
+    url = plex.getWebURL(playlistTab=tab)
     assert url.startswith('https://app.plex.tv/desktop')
     assert plex.machineIdentifier in url
     assert 'source=playlists' in url
     assert 'pivot=playlists.%s' % tab in url
-    # Test a different base
-    base = 'https://doesnotexist.com/plex'
-    url = plex.getPlaylistsWebURL(base=base)
-    assert url.startswith(base)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -512,3 +512,16 @@ def test_server_transcode_sessions(plex, requests_mock):
     assert session.videoCodec in utils.CODECS
     assert session.videoDecision == "transcode"
     assert utils.is_int(session.width, gte=852)
+
+
+def test_server_PlaylistsPlexWebURL(plex):
+    tab = 'audio'
+    url = plex.getPlaylistsWebURL(tab=tab)
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'source=playlists' in url
+    assert 'pivot=playlists.%s' % tab in url
+    # Test a different base
+    base = 'https://doesnotexist.com/plex'
+    url = plex.getPlaylistsWebURL(base=base)
+    assert url.startswith(base)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -608,6 +608,17 @@ def test_video_Movie_extras(movies):
     assert extra.type == 'clip'
     assert extra.section() == movies
 
+def test_video_Movie_PlexWebURL(plex, movie):
+    url = movie.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(movie.key) in url
+    # Test a different base
+    base = 'https://doesnotexist.com/plex'
+    url = movie.getWebURL(base=base)
+    assert url.startswith(base)
+
 
 def test_video_Show_attrs(show):
     assert utils.is_datetime(show.addedAt)
@@ -801,6 +812,14 @@ def test_video_Show_media_tags(show):
     test_media.tag_similar(show)
 
 
+def test_video_Show_PlexWebURL(plex, show):
+    url = show.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(show.key) in url
+
+
 def test_video_Season(show):
     seasons = show.seasons()
     assert len(seasons) == 2
@@ -910,6 +929,14 @@ def test_video_Season_mixins_rating(show):
 def test_video_Season_mixins_tags(show):
     season = show.season(season=1)
     test_mixins.edit_collection(season)
+
+
+def test_video_Season_PlexWebURL(plex, season):
+    url = season.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(season.key) in url
 
 
 def test_video_Episode_updateProgress(episode, patched_http_call):
@@ -1117,6 +1144,14 @@ def test_video_Episode_media_tags(episode):
     test_media.tag_collection(episode)
     test_media.tag_director(episode)
     test_media.tag_writer(episode)
+
+
+def test_video_Episode_PlexWebURL(plex, episode):
+    url = episode.getWebURL()
+    assert url.startswith('https://app.plex.tv/desktop')
+    assert plex.machineIdentifier in url
+    assert 'details' in url
+    assert quote_plus(episode.key) in url
 
 
 def test_that_reload_return_the_same_object(plex):


### PR DESCRIPTION
## Description

Adds methods to retrieve the Plex Web URL for media, library, and playlist pages.

* `PlexServer.getWebURL()` for the main server homepage and the server playlist tabs.
* `LibrarySection.getWebURL()` for any library/hub related page/tabs. Use the `key` parameter for any hub or search page.
* `PlexPartialObject.getWebURL()` for any media details page.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
