### PR TITLE
Add attribute for Sonic Analysis

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -28,7 +28,7 @@ class Audio(PlexPartialObject):
             librarySectionTitle (str): :class:`~plexapi.library.LibrarySection` title.
             listType (str): Hardcoded as 'audio' (useful for search filters).
             moods (List<:class:`~plexapi.media.Mood`>): List of mood objects.
-            musicAnalysisVersion (int): Notes whether item has been Sonically Analyzed.
+            musicAnalysisVersion (int): The Plex music analysis version for the item.
             ratingKey (int): Unique key identifying the item.
             summary (str): Summary of the artist, album, or track.
             thumb (str): URL to thumbnail image (/library/metadata/<ratingKey>/thumb/<thumbid>).
@@ -79,6 +79,11 @@ class Audio(PlexPartialObject):
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """
         return self.title
+
+    @property
+    def hasSonicAnalysis(self):
+        """ Returns True if the audio has been sonically analyzed. """
+        return self.musicAnalysisVersion == 1
 
     def sync(self, bitrate, client=None, clientId=None, limit=None, title=None):
         """ Add current audio (artist, album or track) as sync item for specified device.

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -28,6 +28,7 @@ class Audio(PlexPartialObject):
             librarySectionTitle (str): :class:`~plexapi.library.LibrarySection` title.
             listType (str): Hardcoded as 'audio' (useful for search filters).
             moods (List<:class:`~plexapi.media.Mood`>): List of mood objects.
+            musicAnalysisVersion (int): Notes whether item has been Sonically Analyzed.
             ratingKey (int): Unique key identifying the item.
             summary (str): Summary of the artist, album, or track.
             thumb (str): URL to thumbnail image (/library/metadata/<ratingKey>/thumb/<thumbid>).
@@ -59,6 +60,7 @@ class Audio(PlexPartialObject):
         self.librarySectionTitle = data.attrib.get('librarySectionTitle')
         self.listType = 'audio'
         self.moods = self.findItems(data, media.Mood)
+        self.musicAnalysisVersion = utils.cast(int, data.attrib.get('musicAnalysisVersion'))
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
         self.summary = data.attrib.get('summary')
         self.thumb = data.attrib.get('thumb')


### PR DESCRIPTION
## Description

Adds attribute that denotes whether an Audio object has been Sonically Analyzed.

[Sonic Analysis](https://www.plex.tv/blog/super-sonic-get-closer-to-your-music-in-plexamp/) is a new feature from Plex. 

**Requirements**
 - Requires the latest Plex Media Server v1.24.0
 - Server OS: macOS, Windows, and Linux only
 - Server CPU: ARM CPUs are not supported

## Example

```python
plex = PlexServer(PLEX_URL, PLEX_TOKEN, session=sess)

albumAnalyzed = 0
music = plex.library.section("Music")
totalAlbums = len(music.albums())
for album in music.albums():
    if album.musicAnalysisVersion:
        albumAnalyzed += 1

print(f"Albums Total: {totalAlbums}"
      f"\nScanned: {albumAnalyzed}"
      f"\nLeft: {totalAlbums - albumAnalyzed}")

tracksAnalyzed = 0
totalTracks= len(music.searchTracks())
for track in music.searchTracks():
    if track.musicAnalysisVersion:
        tracksAnalyzed += 1

print(f"Tracks Total: {totalTracks}"
      f"\nScanned: {tracksAnalyzed}"
      f"\nLeft: {totalTracks - tracksAnalyzed}")
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
