### PR TITLE
Fix PMS timeline reporting on clients when using `playMedia`

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -511,7 +511,9 @@ class PlexClient(PlexObject):
 
         playqueue = media if isinstance(media, PlayQueue) else self._server.createPlayQueue(media)
         self.sendCommand('playback/playMedia', **dict({
+            'providerIdentifier': 'com.plexapp.plugins.library',
             'machineIdentifier': self._server.machineIdentifier,
+            'protocol': server_url[0],
             'address': server_url[1].strip('/'),
             'port': server_port,
             'offset': offset,


### PR DESCRIPTION
## Description

Add missing parameters to the player `playMedia` command.

This fixes an issue where some AndroidTV (e.g., Nvidia Shield and Fire TV), Samsung (Tizen), LG WebOS, and likely other clients do not report timeline updates to PMS when playback is started using `plexapi`. This would cause active playback sessions to not show up in the Plex Web dashboard (and `PlexServer.sessions()`), watched states to not update, etc.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
