### PR TITLE
Automatically retrieve external guids from libraries using includeGuids

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -457,7 +457,7 @@ class LibrarySection(PlexObject):
             Parameters:
                 title (str): Title of the item to return.
         """
-        key = '/library/sections/%s/all?title=%s' % (self.key, quote(title, safe=''))
+        key = '/library/sections/%s/all?includeGuids=1&title=%s' % (self.key, quote(title, safe=''))
         return self.fetchItem(key, title__iexact=title)
 
     def all(self, libtype=None, **kwargs):
@@ -979,6 +979,8 @@ class LibrarySection(PlexObject):
         """
         args = {}
         filter_args = []
+
+        args['includeGuids'] = int(bool(kwargs.pop('includeGuids', True)))
         for field, values in list(kwargs.items()):
             if field.split('__')[-1] not in OPERATORS:
                 filter_args.append(self._validateFilterField(field, values, libtype))

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -465,7 +465,9 @@ class LibrarySection(PlexObject):
 
     def getGuid(self, guid):
         """ Returns the media item with the specified external IMDB, TMDB, or TVDB ID.
-            Note: This search uses a PlexAPI operator so performance may be slow.
+            Note: This search uses a PlexAPI operator so performance may be slow. All items from the
+            entire Plex library need to be retrieved for each guid search. It is recommended to create
+            your own lookup dictionary if you are searching for a lot of external guids.
 
             Parameters:
                 guid (str): The external guid of the item to return.
@@ -473,6 +475,22 @@ class LibrarySection(PlexObject):
 
             Raises:
                 :exc:`~plexapi.exceptions.NotFound`: The guid is not found in the library.
+
+            Example:
+
+                .. code-block:: python
+
+                    # This will retrieve all items in the entire library 3 times
+                    result1 = library.getGuid('imdb://tt0944947')
+                    result2 = library.getGuid('tmdb://1399')
+                    result3 = library.getGuid('tvdb://121361')
+
+                    # This will only retrieve all items in the library once to create a lookup dictionary
+                    guidLookup = {guid.id: item for item in library.all() for guid in item.guids}
+                    result1 = guidLookup['imdb://tt0944947']
+                    result2 = guidLookup['tmdb://1399']
+                    result3 = guidLookup['tvdb://121361']
+
         """
         key = '/library/sections/%s/all?includeGuids=1' % self.key
         return self.fetchItem(key, Guid__id__iexact=guid)

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -456,6 +456,9 @@ class LibrarySection(PlexObject):
 
             Parameters:
                 title (str): Title of the item to return.
+
+            Raises:
+                :exc:`~plexapi.exceptions.NotFound`: The title is not found in the library.
         """
         key = '/library/sections/%s/all?includeGuids=1&title=%s' % (self.key, quote(title, safe=''))
         return self.fetchItem(key, title__iexact=title)
@@ -467,6 +470,9 @@ class LibrarySection(PlexObject):
             Parameters:
                 guid (str): The external guid of the item to return.
                     Examples: IMDB ``imdb://tt0944947``, TMDB ``tmdb://1399``, TVDB ``tvdb://121361``.
+
+            Raises:
+                :exc:`~plexapi.exceptions.NotFound`: The guid is not found in the library.
         """
         key = '/library/sections/%s/all?includeGuids=1' % self.key
         return self.fetchItem(key, Guid__id__iexact=guid)

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -460,6 +460,17 @@ class LibrarySection(PlexObject):
         key = '/library/sections/%s/all?includeGuids=1&title=%s' % (self.key, quote(title, safe=''))
         return self.fetchItem(key, title__iexact=title)
 
+    def getGuid(self, guid):
+        """ Returns the media item with the specified external IMDB, TMDB, or TVDB ID.
+            Note: This search uses a PlexAPI operator so performance may be slow.
+
+            Parameters:
+                guid (str): The external guid of the item to return.
+                    Examples: IMDB ``imdb://tt0944947``, TMDB ``tmdb://1399``, TVDB ``tvdb://121361``.
+        """
+        key = '/library/sections/%s/all?includeGuids=1' % self.key
+        return self.fetchItem(key, Guid__id__iexact=guid)
+
     def all(self, libtype=None, **kwargs):
         """ Returns a list of all items from this library section.
             See description of :func:`~plexapi.library.LibrarySection.search()` for details about filtering / sorting.

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -601,7 +601,9 @@ class SmartFilterMixin(object):
                 key += '='
                 value = value[1:]
 
-            if key == 'type':
+            if key == 'includeGuids':
+                filters['includeGuids'] = int(value)
+            elif key == 'type':
                 filters['libtype'] = utils.reverseSearchType(value)
             elif key == 'sort':
                 filters['sort'] = value.split(',')

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -2,6 +2,7 @@
 from collections import namedtuple
 from datetime import datetime, timedelta
 import pytest
+import plexapi.base
 from plexapi.exceptions import BadRequest, NotFound
 
 from . import conftest as utils
@@ -56,6 +57,19 @@ def test_library_section_movies_all(movies):
     # size should always be none unless pagenation is being used.
     assert movies.totalSize == 4
     assert len(movies.all(container_start=0, container_size=1, maxresults=1)) == 1
+
+
+def test_library_section_movies_all_guids(movies):
+    plexapi.base.USER_DONT_RELOAD_FOR_KEYS.add('guids')
+    try:
+        results = movies.all(includeGuids=False)
+        assert results[0].guids == []
+        results = movies.all()
+        assert results[0].guids
+        movie = movies.get("Sita Sings the Blues")
+        assert movie.guids
+    finally:
+        plexapi.base.USER_DONT_RELOAD_FOR_KEYS.remove('guids')
 
 
 def test_library_section_totalViewSize(tvshows):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -53,6 +53,11 @@ def test_library_section_get_movie(movies):
     assert movies.get("Sita Sings the Blues")
 
 
+def test_library_MovieSection_getGuid(movies, movie):
+    result = movies.getGuid(guid=movie.guids[0].id)
+    assert result == movie
+
+
 def test_library_section_movies_all(movies):
     # size should always be none unless pagenation is being used.
     assert movies.totalSize == 4


### PR DESCRIPTION
## Description

Adds the `includeGuids` parameter added in Plex Media Server 1.24.3.5033.   For older versions of PMS, accessing `guids` for a `PlexPartialObject` will still automatically reload the object.

https://forums.plex.tv/t/plex-media-server/30447/462

By default, external guids are automatically retrieved when using `LibrarySection.all()`, `LibrarySection.search()`, or `LibrarySection.get()`. Optionally, the external guids can also be skipped by adding the parameter `includeGuids=False` for `all()` or `search()` only.

Fixes #808

---

Adds new `LibrarySection.getGuid(guid)` method to return and item by external guid.

Closes #557

---

~~Note: The test is failing because `includeGuids` is not on the public PMS release yet.~~  PMS 1.24.3.5033 has been publicly released.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
