### PR TITLE
Add album formats and subformats

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -234,6 +234,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
             TAG (str): 'Directory'
             TYPE (str): 'album'
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
+            formats (List<:class:`~plexapi.media.Format`>): List of format objects.
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
             key (str): API URL (/library/metadata/<ratingkey>).
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
@@ -248,6 +249,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
             rating (float): Album rating (7.9; 9.8; 8.1).
             studio (str): Studio that released the album.
             styles (List<:class:`~plexapi.media.Style`>): List of style objects.
+            subformats (List<:class:`~plexapi.media.Subformat`>): List of subformat objects.
             viewedLeafCount (int): Number of items marked as played in the album view.
             year (int): Year the album was released.
     """
@@ -258,6 +260,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
         """ Load attribute values from Plex XML response. """
         Audio._loadData(self, data)
         self.collections = self.findItems(data, media.Collection)
+        self.formats = self.findItems(data, media.Format)
         self.genres = self.findItems(data, media.Genre)
         self.key = self.key.replace('/children', '')  # FIX_BUG_50
         self.labels = self.findItems(data, media.Label)
@@ -272,6 +275,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.studio = data.attrib.get('studio')
         self.styles = self.findItems(data, media.Style)
+        self.subformats = self.findItems(data, media.Subformat)
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
 

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -174,7 +174,7 @@ class MediaPart(PlexObject):
         return [stream for stream in self.streams if isinstance(stream, SubtitleStream)]
 
     def lyricStreams(self):
-        """ Returns a list of :class:`~plexapi.media.SubtitleStream` objects in this MediaPart. """
+        """ Returns a list of :class:`~plexapi.media.LyricStream` objects in this MediaPart. """
         return [stream for stream in self.streams if isinstance(stream, LyricStream)]
 
     def setDefaultAudioStream(self, stream):

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -732,6 +732,18 @@ class Director(MediaTag):
 
 
 @utils.registerPlexObject
+class Format(MediaTag):
+    """ Represents a single Format media tag.
+
+        Attributes:
+            TAG (str): 'Format'
+            FILTER (str): 'format'
+    """
+    TAG = 'Format'
+    FILTER = 'format'
+
+
+@utils.registerPlexObject
 class Genre(MediaTag):
     """ Represents a single Genre media tag.
 
@@ -813,6 +825,18 @@ class Style(MediaTag):
     """
     TAG = 'Style'
     FILTER = 'style'
+
+
+@utils.registerPlexObject
+class Subformat(MediaTag):
+    """ Represents a single Subformat media tag.
+
+        Attributes:
+            TAG (str): 'Subformat'
+            FILTER (str): 'subformat'
+    """
+    TAG = 'Subformat'
+    FILTER = 'subformat'
 
 
 @utils.registerPlexObject

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import pytest
+from plexapi.exceptions import BadRequest
+
 from . import conftest as utils
 from . import test_media, test_mixins
 
@@ -36,9 +39,9 @@ def test_audio_Artist_attr(artist):
     assert utils.is_int(artist.viewCount, gte=0)
 
 
-def test_audio_Artist_get(artist, music):
-    artist == music.searchArtists(**{"title": "Broke For Free"})[0]
-    artist.title == "Broke For Free"
+def test_audio_Artist_get(artist):
+    track = artist.get(album="Layers", title="As Colourful as Ever")
+    assert track.title == "As Colourful as Ever"
 
 
 def test_audio_Artist_history(artist):
@@ -52,6 +55,8 @@ def test_audio_Artist_track(artist):
     track = artist.track(album="Layers", track=1)
     assert track.parentTitle == "Layers"
     assert track.index == 1
+    with pytest.raises(BadRequest):
+        artist.track()
 
 
 def test_audio_Artist_tracks(artist):
@@ -67,6 +72,11 @@ def test_audio_Artist_album(artist):
 def test_audio_Artist_albums(artist):
     albums = artist.albums()
     assert len(albums) == 1 and albums[0].title == "Layers"
+
+
+def test_audio_Artist_hubs(artist):
+    hubs = artist.hubs()
+    assert isinstance(hubs, list)
 
 
 def test_audio_Artist_mixins_edit_advanced_settings(artist):
@@ -109,6 +119,7 @@ def test_audio_Album_attrs(album):
     assert utils.is_datetime(album.addedAt)
     if album.art:
         assert utils.is_art(album.art)
+    assert isinstance(album.formats, list)
     assert isinstance(album.genres, list)
     assert album.index == 1
     assert utils.is_metadata(album._initpath)
@@ -126,6 +137,7 @@ def test_audio_Album_attrs(album):
     assert album.ratingKey >= 1
     assert album._server._baseurl == utils.SERVER_BASEURL
     assert album.studio == "[no label]"
+    assert isinstance(album.subformats, list)
     assert album.summary == ""
     if album.thumb:
         assert utils.is_thumb(album.thumb)
@@ -157,6 +169,8 @@ def test_audio_Album_track(album, track=None):
     track = track or album.track("As Colourful As Ever")
     track2 = album.track(track=1)
     assert track == track2
+    with pytest.raises(BadRequest):
+        album.track()
 
 
 def test_audio_Album_get(album):
@@ -215,6 +229,7 @@ def test_audio_Track_attrs(album):
         assert utils.is_thumb(track.grandparentThumb)
     assert track.grandparentTitle == "Broke For Free"
     assert track.guid.startswith("mbid://") or track.guid.startswith("plex://track/")
+    assert track.hasSonicAnalysis is False
     assert track.index == 1
     assert track.trackNumber == track.index
     assert utils.is_metadata(track._initpath)
@@ -253,6 +268,7 @@ def test_audio_Track_attrs(album):
     assert track.viewOffset == 0
     assert track.viewedAt is None
     assert track.year is None
+    assert track.url(None) is None
     assert media.aspectRatio is None
     assert media.audioChannels == 2
     assert media.audioCodec == "mp3"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -261,12 +261,16 @@ def test_library_MusicSection_albums(music):
     assert len(music.albums())
 
 
-def test_library_MusicSection_searchTracks(music):
-    assert len(music.searchTracks(title="As Colourful As Ever"))
+def test_library_MusicSection_searchArtists(music):
+    assert len(music.searchArtists(title="Broke for Free"))
 
 
 def test_library_MusicSection_searchAlbums(music):
     assert len(music.searchAlbums(title="Layers"))
+
+
+def test_library_MusicSection_searchTracks(music):
+    assert len(music.searchTracks(title="As Colourful As Ever"))
 
 
 def test_library_MusicSection_recentlyAdded(music, artist):


### PR DESCRIPTION
## Description

Adds the `Album.formats` and `Album.subformats` attributes.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
