### PR TITLE
Fix media delete

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -79,13 +79,16 @@ class Media(PlexObject):
             self.make = data.attrib.get('make')
             self.model = data.attrib.get('model')
 
+        parent = self._parent()
+        self._parentKey = parent.key
+
     @property
     def isOptimizedVersion(self):
         """ Returns True if the media is a Plex optimized version. """
         return self.proxyType == utils.SEARCHTYPES['optimizedVersion']
 
     def delete(self):
-        part = self._initpath + '/media/%s' % self.id
+        part = '%s/media/%s' % (self._parentKey, self.id)
         try:
             return self._server.query(part, method=self._server._session.delete)
         except BadRequest:

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -129,13 +129,9 @@ def test_video_Movie_isPartialObject(movie):
     assert movie.isPartialObject()
 
 
-def test_video_Movie_delete_part(movie, mocker):
-    # we need to reload this as there is a bug in part.delete
-    # See https://github.com/pkkid/python-plexapi/issues/201
-    m = movie.reload()
-    for media in m.media:
-        with utils.callable_http_patch():
-            media.delete()
+def test_video_Movie_media_delete(movie, patched_http_call):
+    for media in movie.media:
+        media.delete()
 
 
 def test_video_Movie_iterParts(movie):


### PR DESCRIPTION
## Description

Fix deleting a `Media` object by leveraging `self._parent()` from #619.

Fixes #201

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
