### PR TITLE
Add totalDuration and totalStorage properties to LibrarySection

### DIFF
--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -61,7 +61,6 @@ def test_library_MovieSection_getGuid(movies, movie):
 
 
 def test_library_section_movies_all(movies):
-    # size should always be none unless pagenation is being used.
     assert movies.totalSize == 4
     assert len(movies.all(container_start=0, container_size=1, maxresults=1)) == 1
 
@@ -77,6 +76,14 @@ def test_library_section_movies_all_guids(movies):
         assert movie.guids
     finally:
         plexapi.base.USER_DONT_RELOAD_FOR_KEYS.remove('guids')
+
+
+def test_library_section_totalDuration(tvshows):
+    assert utils.is_int(tvshows.totalDuration)
+
+
+def test_library_section_totalStorage(tvshows):
+    assert utils.is_int(tvshows.totalStorage)
 
 
 def test_library_section_totalViewSize(tvshows):


### PR DESCRIPTION
## Description

* Add `LibrarySection.totalDuration` property to return the total duration (in milliseconds) of items in the library.
* Add `LibrarySection.totalStorage` property to return the total storage (in bytes) of items in the library.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
