### PR TITLE
Fix image mixins tests

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -85,6 +85,7 @@ def test_audio_Artist_mixins_edit_advanced_settings(artist):
     test_mixins.edit_advanced_settings(artist)
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_audio_Artist_mixins_images(artist):
     test_mixins.lock_art(artist)
     test_mixins.lock_poster(artist)
@@ -194,6 +195,7 @@ def test_audio_Album_artist(album):
     artist.title == "Broke For Free"
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_audio_Album_mixins_images(album):
     test_mixins.lock_art(album)
     test_mixins.lock_poster(album)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -272,6 +272,7 @@ def test_Collection_art(collection):
     assert not arts  # Collection has no default art
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_Collection_mixins_images(collection):
     test_mixins.lock_art(collection)
     test_mixins.lock_poster(collection)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -139,6 +139,9 @@ def _test_mixins_edit_image(obj, attr):
     # Reset to default image
     if default_image:
         set_img_method(default_image)
+    # Unlock the image
+    unlock_img_method = getattr(obj, "unlock" + cap_attr)
+    unlock_img_method()
 
 
 def edit_art(obj):

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from urllib.parse import quote_plus
 
+import pytest
+
 from . import test_media, test_mixins
 
 
@@ -13,6 +15,7 @@ def test_photo_Photoalbum(photoalbum):
     assert a_pic
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_photo_Photoalbum_mixins_images(photoalbum):
     # test_mixins.lock_art(photoalbum)  # Unlocking photoalbum artwork is broken in Plex
     # test_mixins.lock_poster(photoalbum)  # Unlocking photoalbum poster is broken in Plex

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -273,6 +273,7 @@ def test_Playlist_PlexWebURL(plex, show):
         playlist.delete()
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_Playlist_mixins_images(playlist):
     test_mixins.lock_art(playlist)
     test_mixins.lock_poster(playlist)

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -274,7 +274,7 @@ def test_Playlist_PlexWebURL(plex, show):
 
 
 def test_Playlist_mixins_images(playlist):
-    # test_mixins.lock_art(playlist)
+    test_mixins.lock_art(playlist)
     test_mixins.lock_poster(playlist)
-    # test_mixins.edit_art(playlist)
+    test_mixins.edit_art(playlist)
     test_mixins.edit_poster(playlist)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -44,6 +44,7 @@ def test_video_Movie_mixins_edit_advanced_settings(movie):
     test_mixins.edit_advanced_settings(movie)
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_video_Movie_mixins_images(movie):
     test_mixins.lock_art(movie)
     test_mixins.lock_poster(movie)
@@ -787,7 +788,7 @@ def test_video_Show_mixins_edit_advanced_settings(show):
     test_mixins.edit_advanced_settings(show)
 
 
-@pytest.mark.xfail(reason="Changing show art fails randomly")
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_video_Show_mixins_images(show):
     test_mixins.lock_art(show)
     test_mixins.lock_poster(show)
@@ -917,6 +918,7 @@ def test_video_Season_episodes(show):
     assert len(episodes) >= 1
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_video_Season_mixins_images(show):
     season = show.season(season=1)
     test_mixins.lock_art(season)
@@ -1128,6 +1130,7 @@ def test_video_Episode_unwatched(tvshows):
     episode.markUnwatched()
 
 
+@pytest.mark.xfail(reason="Changing images fails randomly")
 def test_video_Episode_mixins_images(episode):
     test_mixins.lock_art(episode)
     test_mixins.lock_poster(episode)


### PR DESCRIPTION
## Description

* Enable Playlist art mixins tests. [Editing Playlist art requires PMS >= 1.24.5](https://forums.plex.tv/t/plex-web/20528/371).
* Unlock images after edit image test to restore pre-test state.
* Mark all image mixins tests as xfail.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
