### PR TITLE
Add methods to lock and unlock a field for all items in a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ MANIFEST
 venv/
 
 # path for the test lib.
+plex/
 tools/plex

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -606,6 +606,36 @@ class LibrarySection(PlexObject):
 
         self.edit(**data)
 
+    def _lockUnlockAllField(self, field, libtype=None, locked=True):
+        """ Lock or unlock a field for all items in the library. """
+        libtype = libtype or self.TYPE
+        args = {
+            'type': utils.searchType(libtype),
+            '%s.locked' % field: int(locked)
+        }
+        key = '/library/sections/%s/all%s' % (self.key, utils.joinArgs(args))
+        self._server.query(key, method=self._server._session.put)
+
+    def lockAllField(self, field, libtype=None):
+        """ Lock a field for all items in the library.
+        
+            Parameters:
+                field (str): The field to lock (e.g. thumb, rating, collection).
+                libtype (str, optional): The library type to lock (movie, show, season, episode,
+                    artist, album, track, photoalbum, photo). Default is the main library type.
+        """
+        self._lockUnlockAllField(field, libtype=libtype, locked=True)
+
+    def unlockAllField(self, field, libtype=None):
+        """ Unlock a field for all items in the library.
+        
+            Parameters:
+                field (str): The field to unlock (e.g. thumb, rating, collection).
+                libtype (str, optional): The library type to lock (movie, show, season, episode,
+                    artist, album, track, photoalbum, photo). Default is the main library type.
+        """
+        self._lockUnlockAllField(field, libtype=libtype, locked=False)
+
     def timeline(self):
         """ Returns a timeline query for this library section. """
         key = '/library/sections/%s/timeline' % self.key

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -383,6 +383,19 @@ def test_library_editAdvanced_default(movies):
         assert str(setting.value) == str(setting.default)
 
 
+def test_library_lockUnlockAllFields(movies):
+    for movie in movies.all():
+        assert 'thumb' not in [f.name for f in movie.fields]
+
+    movies.lockAllField('thumb')
+    for movie in movies.all():
+        assert 'thumb' in [f.name for f in movie.fields]
+
+    movies.unlockAllField('thumb')
+    for movie in movies.all():
+        assert 'thumb' not in [f.name for f in movie.fields]
+
+
 def test_search_with_weird_a(plex, tvshows):
     ep_title = "Coup de Grâce"
     result_root = plex.search(ep_title)


### PR DESCRIPTION
## Description

Adds:
* `LibrarySection.lockAllField()` locks a field for all items in the library.
* `LibrarySection.unlockAllField()` locks a field for all items in the library.

Examples:
```python
# Lock all movie posters
plex.library.section("Movies").lockAllField('thumb')

# Lock all album art
plex.library.section("Music").lockAllField('thumb', libtype='album')

# Lock all episode collections
plex.library.section("TV Shows").lockAllField('collection', libtype='episode')

# Unlock all movie ratings
plex.library.section("Movies").unlockAllField('rating')
```


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
