### PR TITLE
Improve getGuid method

### DIFF
--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -60,6 +60,8 @@ def test_library_section_get_movie(movies):
 def test_library_MovieSection_getGuid(movies, movie):
     result = movies.getGuid(guid=movie.guids[0].id)
     assert result == movie
+    with pytest.raises(NotFound):
+        movies.getGuid(guid='imdb://tt00000000')
 
 
 def test_library_section_movies_all(movies):


### PR DESCRIPTION
## Description

Improve the `LibrarySection.getGuid()` method so it doesn't need to iterate through the entire library to find a specific external guid.

This change "exploits" the "Fix Match" function in Plex which allows searching by external guids. We fetch a dummy object (the first media object in the library) and call the match function using the external guid. Then a library search is performed by using the Plex guid (`plex://`) from the match. Searching for a Plex guid is much faster since it is offloaded to the Plex server which supports filtering by the main guid.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
