### PR TITLE
Fix Agent object settings

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -562,7 +562,7 @@ class LibrarySection(PlexObject):
     def agents(self):
         """ Returns a list of available :class:`~plexapi.media.Agent` for this library section.
         """
-        return self._server.agents(utils.searchType(self.type))
+        return self._server.agents(self.type)
 
     def settings(self):
         """ Returns a list of all library settings. """

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -6,6 +6,7 @@ from urllib.parse import quote_plus
 from plexapi import log, settings, utils
 from plexapi.base import PlexObject
 from plexapi.exceptions import BadRequest
+from plexapi.utils import deprecated
 
 
 @utils.registerPlexObject
@@ -1074,10 +1075,14 @@ class Agent(PlexObject):
     def languageCode(self):
         return self.languageCodes
 
-    def _settings(self):
+    def settings(self):
         key = '/:/plugins/%s/prefs' % self.identifier
         data = self._server.query(key)
         return self.findItems(data, cls=settings.Setting)
+
+    @deprecated('use "settings" instead')
+    def _settings(self):
+        return self.settings()
 
 
 class AgentMediaType(Agent):

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1058,15 +1058,21 @@ class Agent(PlexObject):
         self.hasAttribution = data.attrib.get('hasAttribution')
         self.hasPrefs = data.attrib.get('hasPrefs')
         self.identifier = data.attrib.get('identifier')
+        self.name = data.attrib.get('name')
         self.primary = data.attrib.get('primary')
         self.shortIdentifier = self.identifier.rsplit('.', 1)[1]
+
         if 'mediaType' in self._initpath:
-            self.name = data.attrib.get('name')
-            self.languageCode = []
-            for code in data:
-                self.languageCode += [code.attrib.get('code')]
+            self.languageCodes = self.listAttrs(data, 'code', etag='Language')
+            self.mediaTypes = []
         else:
-            self.mediaTypes = [AgentMediaType(server=self._server, data=d) for d in data]
+            self.languageCodes = []
+            self.mediaTypes = self.findItems(data, cls=AgentMediaType)
+
+    @property
+    @deprecated('use "languageCodes" instead')
+    def languageCode(self):
+        return self.languageCodes
 
     def _settings(self):
         key = '/:/plugins/%s/prefs' % self.identifier
@@ -1075,14 +1081,23 @@ class Agent(PlexObject):
 
 
 class AgentMediaType(Agent):
+    """ Represents a single Agent MediaType.
+
+        Attributes:
+            TAG (str): 'MediaType'
+    """
+    TAG = 'MediaType'
 
     def __repr__(self):
         uid = self._clean(self.firstAttr('name'))
         return '<%s>' % ':'.join([p for p in [self.__class__.__name__, uid] if p])
 
     def _loadData(self, data):
+        self.languageCodes = self.listAttrs(data, 'code', etag='Language')
         self.mediaType = utils.cast(int, data.attrib.get('mediaType'))
         self.name = data.attrib.get('name')
-        self.languageCode = []
-        for code in data:
-            self.languageCode += [code.attrib.get('code')]
+
+    @property
+    @deprecated('use "languageCodes" instead')
+    def languageCode(self):
+        return self.languageCodes

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -228,10 +228,10 @@ class PlexServer(PlexObject):
         return activities
 
     def agents(self, mediaType=None):
-        """ Returns the :class:`~plexapi.media.Agent` objects this server has available. """
+        """ Returns a list of :class:`~plexapi.media.Agent` objects this server has available. """
         key = '/system/agents'
         if mediaType:
-            key += '?mediaType=%s' % mediaType
+            key += '?mediaType=%s' % utils.searchType(mediaType)
         return self.fetchItems(key)
 
     def createToken(self, type='delegation', scope='all'):

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -132,8 +132,8 @@ class Setting(PlexObject):
         return value
 
     def _getEnumValues(self, data):
-        """ Returns a list of dictionary of valis value for this setting. """
-        enumstr = data.attrib.get('enumValues')
+        """ Returns a list or dictionary of values for this setting. """
+        enumstr = data.attrib.get('enumValues') or data.attrib.get('values')
         if not enumstr:
             return None
         if ':' in enumstr:

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -113,17 +113,19 @@ class Setting(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self._setValue = None
+        self.type = data.attrib.get('type')
+        self.advanced = utils.cast(bool, data.attrib.get('advanced'))
+        self.default = self._cast(data.attrib.get('default'))
+        self.enumValues = self._getEnumValues(data)
+        self.group = data.attrib.get('group')
+        self.hidden = utils.cast(bool, data.attrib.get('hidden'))
         self.id = data.attrib.get('id')
         self.label = data.attrib.get('label')
+        self.option = data.attrib.get('option')
+        self.secure = utils.cast(bool, data.attrib.get('secure'))
         self.summary = data.attrib.get('summary')
-        self.type = data.attrib.get('type')
-        self.default = self._cast(data.attrib.get('default'))
         self.value = self._cast(data.attrib.get('value'))
-        self.hidden = utils.cast(bool, data.attrib.get('hidden'))
-        self.advanced = utils.cast(bool, data.attrib.get('advanced'))
-        self.group = data.attrib.get('group')
-        self.enumValues = self._getEnumValues(data)
+        self._setValue = None
 
     def _cast(self, value):
         """ Cast the specific value to the type of this setting. """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -571,3 +571,15 @@ def test_server_PlexWebURL_playlists(plex):
     assert plex.machineIdentifier in url
     assert 'source=playlists' in url
     assert 'pivot=playlists.%s' % tab in url
+
+
+def test_server_agents(plex):
+    agents = plex.agents()
+    assert agents
+    agent = next((a for a in agents if a.identifier == 'com.plexapp.agents.imdb'), None)
+    assert agent
+    settings = agent.settings()
+    assert settings
+    setting = next((s for s in settings if s.id == 'country'), None)
+    assert setting
+    assert setting.enumValues is not None


### PR DESCRIPTION
## Description

* Fix `mediaType` argument for `PlexServer.agents()` not converted to the `searchType` ID.
* Fix parsing `Agent` settings `enumValues`.
* Make `Agent.settings()` method public and add `DeprecationWarning` to `_settings()`

Fixes #863 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
