### PR TITLE
Feature: Add label methods, properties to Episodes

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -710,7 +710,7 @@ class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin):
 
 @utils.registerPlexObject
 class Episode(Video, Playable, ArtMixin, PosterMixin, RatingMixin,
-        CollectionMixin, DirectorMixin, WriterMixin):
+        CollectionMixin, DirectorMixin, LabelMixin, WriterMixin):
     """ Represents a single Shows Episode.
 
         Attributes:
@@ -733,6 +733,7 @@ class Episode(Video, Playable, ArtMixin, PosterMixin, RatingMixin,
             grandparentTitle (str): Name of the show for the episode.
             guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             index (int): Episode number.
+            labels (List<:class:`~plexapi.media.Label`>): List of label objects.
             markers (List<:class:`~plexapi.media.Marker`>): List of marker objects.
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             originallyAvailableAt (datetime): Datetime the episode was released.
@@ -777,6 +778,7 @@ class Episode(Video, Playable, ArtMixin, PosterMixin, RatingMixin,
         self.grandparentTitle = data.attrib.get('grandparentTitle')
         self.guids = self.findItems(data, media.Guid)
         self.index = utils.cast(int, data.attrib.get('index'))
+        self.labels = self.findItems(data, media.Label)
         self.markers = self.findItems(data, media.Marker)
         self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1149,6 +1149,7 @@ def test_video_Episode_mixins_tags(episode):
     test_mixins.edit_collection(episode)
     test_mixins.edit_director(episode)
     test_mixins.edit_writer(episode)
+    test_mixins.edit_label(episode)
 
 
 def test_video_Episode_media_tags(episode):


### PR DESCRIPTION
## Description

Seems `LabelMixin` was added to `Album`, `Collection`, `Show`, and `Movie`, but left out of `Episode`.

My testing with `1.24.3.5033-757abe6b4` shows that Episodes can also have labels.

```py
>>> episode.addLabel(['skip-pts'])
>>> episode = (fetch episode again)
>>> print(episode.labels)
[<Label:/library/sections/2/:Skip-pts>]
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
