### PR TITLE
Support for `Artist` radio stations

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -8,6 +8,7 @@ from plexapi.exceptions import BadRequest
 from plexapi.mixins import AdvancedSettingsMixin, ArtUrlMixin, ArtMixin, PosterUrlMixin, PosterMixin
 from plexapi.mixins import RatingMixin, SplitMergeMixin, UnmatchMatchMixin
 from plexapi.mixins import CollectionMixin, CountryMixin, GenreMixin, LabelMixin, MoodMixin, SimilarArtistMixin, StyleMixin
+from plexapi.playlist import Playlist
 
 
 class Audio(PlexPartialObject):
@@ -221,6 +222,11 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
             _savepath = os.path.join(savepath, track.parentTitle) if subfolders else savepath
             filepaths += track.download(_savepath, keep_original_name, **kwargs)
         return filepaths
+
+    def stations(self):
+        """ Returns a list of :class:`~plexapi.audio.Playlist` radio stations for this artist. """
+        key = '%s?includeStations=1' % self.key
+        return self.fetchItems(key, cls=Playlist, rtag="Stations")
 
 
 @utils.registerPlexObject

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -223,7 +223,6 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
             filepaths += track.download(_savepath, keep_original_name, **kwargs)
         return filepaths
 
-    @property
     def station(self):
         """ Returns a :class:`~plexapi.playlist.Playlist` artist radio station or `None`. """
         key = '%s?includeStations=1' % self.key

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -223,6 +223,7 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
             filepaths += track.download(_savepath, keep_original_name, **kwargs)
         return filepaths
 
+    @property
     def station(self):
         """ Returns a :class:`~plexapi.playlist.Playlist` artist radio station or `None`. """
         key = '%s?includeStations=1' % self.key

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -223,10 +223,10 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
             filepaths += track.download(_savepath, keep_original_name, **kwargs)
         return filepaths
 
-    def stations(self):
-        """ Returns a list of :class:`~plexapi.playlist.Playlist` radio stations for this artist. """
+    def station(self):
+        """ Returns a :class:`~plexapi.playlist.Playlist` artist radio station or `None`. """
         key = '%s?includeStations=1' % self.key
-        return self.fetchItems(key, cls=Playlist, rtag="Stations")
+        return next(iter(self.fetchItems(key, cls=Playlist, rtag="Stations")), None)
 
 
 @utils.registerPlexObject

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -224,7 +224,7 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
         return filepaths
 
     def stations(self):
-        """ Returns a list of :class:`~plexapi.audio.Playlist` radio stations for this artist. """
+        """ Returns a list of :class:`~plexapi.playlist.Playlist` radio stations for this artist. """
         key = '%s?includeStations=1' % self.key
         return self.fetchItems(key, cls=Playlist, rtag="Stations")
 

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -29,7 +29,11 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin, SmartFilterMi
             icon (str): Icon URI string for smart playlists.
             key (str): API URL (/playlist/<ratingkey>).
             leafCount (int): Number of items in the playlist view.
+            librarySectionID (int): Library section identifier (radio only)
+            librarySectionKey (str): Library section key (radio only)
+            librarySectionTitle (str): Library section title (radio only)
             playlistType (str): 'audio', 'video', or 'photo'
+            radio (bool): If this playlist represents a radio station
             ratingKey (int): Unique key identifying the playlist.
             smart (bool): True if the playlist is a smart playlist.
             summary (str): Summary of the playlist.
@@ -54,7 +58,10 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin, SmartFilterMi
         self.icon = data.attrib.get('icon')
         self.key = data.attrib.get('key', '').replace('/items', '')  # FIX_BUG_50
         self.leafCount = utils.cast(int, data.attrib.get('leafCount'))
+        self.librarySectionKey = data.attrib.get('librarySectionKey')
+        self.librarySectionTitle = data.attrib.get('librarySectionTitle')
         self.playlistType = data.attrib.get('playlistType')
+        self.radio = utils.cast(bool, data.attrib.get('radio', 0))
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
         self.smart = utils.cast(bool, data.attrib.get('smart'))
         self.summary = data.attrib.get('summary')
@@ -169,6 +176,8 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin, SmartFilterMi
 
     def items(self):
         """ Returns a list of all items in the playlist. """
+        if self.radio:
+            return []
         if self._items is None:
             key = '%s/items' % self.key
             items = self.fetchItems(key)

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -58,6 +58,7 @@ class Playlist(PlexPartialObject, Playable, ArtMixin, PosterMixin, SmartFilterMi
         self.icon = data.attrib.get('icon')
         self.key = data.attrib.get('key', '').replace('/items', '')  # FIX_BUG_50
         self.leafCount = utils.cast(int, data.attrib.get('leafCount'))
+        self.librarySectionID = utils.cast(int, data.attrib.get('librarySectionID'))
         self.librarySectionKey = data.attrib.get('librarySectionKey')
         self.librarySectionTitle = data.attrib.get('librarySectionTitle')
         self.playlistType = data.attrib.get('playlistType')

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -175,8 +175,11 @@ class PlayQueue(PlexObject):
             args["uri"] = "library:///directory/{uri_args}".format(uri_args=uri_args)
             args["type"] = items[0].listType
         elif items.type == "playlist":
-            args["playlistID"] = items.ratingKey
             args["type"] = items.playlistType
+            if items.radio:
+                args["uri"] = f"server://{server.machineIdentifier}/{server.library.identifier}{items.key}"
+            else:
+                args["playlistID"] = items.ratingKey
         else:
             uuid = items.section().uuid
             args["type"] = items.listType


### PR DESCRIPTION
## Description

This adds support for artist radio stations. In Plex Web, this is represented by the "Play Radio" button on an artist page.

An artist radio station can be retrieved using `Artist.station()`, which returns a `Playlist` if it exists. To differentiate these radio stations from classic playlists, a new `radio` boolean attribute is exposed.

`PlayQueue` creation has been updated to handle these special radio `Playlist` instances, which allows `PlexClient.playMedia` to accept them as-is.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
