### PR TITLE
Change `MusicSection.stations()` to return `Playlist` objects

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -624,7 +624,7 @@ class LibrarySection(PlexObject):
     def hubs(self):
         """ Returns a list of available :class:`~plexapi.library.Hub` for this library section.
         """
-        key = '/hubs/sections/%s' % self.key
+        key = '/hubs/sections/%s?includeStations=1' % self.key
         return self.fetchItems(key)
 
     def agents(self):
@@ -1786,9 +1786,8 @@ class MusicSection(LibrarySection):
         return self.fetchItems(key)
 
     def stations(self):
-        """ Returns a list of :class:`~plexapi.audio.Album` objects in this section. """
-        key = '/hubs/sections/%s?includeStations=1' % self.key
-        return self.fetchItems(key, cls=Station)
+        """ Returns a list of :class:`~plexapi.playlist.Playlist` stations in this section. """
+        return next((hub.items for hub in self.hubs() if hub.context == 'hub.music.stations'), None)
 
     def searchArtists(self, **kwargs):
         """ Search for an artist. See :func:`~plexapi.library.LibrarySection.search` for usage. """
@@ -2002,6 +2001,7 @@ class Hub(PlexObject):
             context (str): The context of the hub.
             hubKey (str): API URL for these specific hub items.
             hubIdentifier (str): The identifier of the hub.
+            items (list): List of items in the hub.
             key (str): API URL for the hub.
             more (bool): True if there are more items to load (call reload() to fetch all items).
             size (int): The number of items in the hub.
@@ -2152,39 +2152,6 @@ class Place(HubMediaTag):
             TAGTYPE (int): 400
     """
     TAGTYPE = 400
-
-
-@utils.registerPlexObject
-class Station(PlexObject):
-    """ Represents the Station area in the MusicSection.
-
-        Attributes:
-            TITLE (str): 'Stations'
-            TYPE (str): 'station'
-            hubIdentifier (str): Unknown.
-            size (int): Number of items found.
-            title (str): Title of this Hub.
-            type (str): Type of items in the Hub.
-            more (str): Unknown.
-            style (str): Unknown
-            items (str): List of items in the Hub.
-    """
-    TITLE = 'Stations'
-    TYPE = 'station'
-
-    def _loadData(self, data):
-        """ Load attribute values from Plex XML response. """
-        self._data = data
-        self.hubIdentifier = data.attrib.get('hubIdentifier')
-        self.size = utils.cast(int, data.attrib.get('size'))
-        self.title = data.attrib.get('title')
-        self.type = data.attrib.get('type')
-        self.more = data.attrib.get('more')
-        self.style = data.attrib.get('style')
-        self.items = self.findItems(data)
-
-    def __len__(self):
-        return self.size
 
 
 class FilteringType(PlexObject):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -360,6 +360,10 @@ def test_library_MusicSection_albums(music):
     assert len(music.albums())
 
 
+def test_library_MusicSection_stations(music):
+    assert len(music.stations())
+
+
 def test_library_MusicSection_searchArtists(music):
     assert len(music.searchArtists(title="Broke for Free"))
 


### PR DESCRIPTION
## Description

Changes `MusicSection.stations()` to return a list of `Playlist` station objects to be consistent with #870.

Also removes the unnecessary `Station` object. The music station hub can be found through `MusicSection.hubs()`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
