### PR TITLE
Support global hubs

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -93,18 +93,15 @@ class Library(PlexObject):
                     Available on `Hub` instances as the `hubIdentifier` attribute.
                     Examples: 'home.continue' or 'home.ondeck'
         """
-        args = {}
         if sectionID:
             if not isinstance(sectionID, list):
                 sectionID = [sectionID]
-            args['contentDirectoryID'] = ",".join(map(str, sectionID))
+            kwargs['contentDirectoryID'] = ",".join(map(str, sectionID))
         if identifier:
             if not isinstance(identifier, list):
                 identifier = [identifier]
-            args['identifier'] = ",".join(identifier)
-        for attr, value in kwargs.items():
-            args[attr] = value
-        key = '/hubs%s' % utils.joinArgs(args)
+            kwargs['identifier'] = ",".join(identifier)
+        key = '/hubs%s' % utils.joinArgs(kwargs)
         return self.fetchItems(key)
 
     def all(self, **kwargs):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -82,6 +82,10 @@ class Library(PlexObject):
         except KeyError:
             raise NotFound('Invalid library sectionID: %s' % sectionID) from None
 
+    def hubs(self):
+        """ Returns a list of global :class:`~plexapi.library.Hub` library sections. """
+        return self.fetchItems('/hubs')
+
     def all(self, **kwargs):
         """ Returns a list of all media from all library sections.
             This may be a very large dataset to retrieve.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -82,9 +82,30 @@ class Library(PlexObject):
         except KeyError:
             raise NotFound('Invalid library sectionID: %s' % sectionID) from None
 
-    def hubs(self):
-        """ Returns a list of global :class:`~plexapi.library.Hub` library sections. """
-        return self.fetchItems('/hubs')
+    def hubs(self, sectionID=None, identifier=None, **kwargs):
+        """ Returns a list of :class:`~plexapi.library.Hub` across all library sections.
+
+            Parameters:
+                sectionID (int or str or list, optional):
+                    IDs of the sections to limit results or "playlists".
+                identifier (str or list, optional):
+                    Names of identifiers to limit results.
+                    Available on `Hub` instances as the `hubIdentifier` attribute.
+                    Examples: 'home.continue' or 'home.ondeck'
+        """
+        args = {}
+        if sectionID:
+            if not isinstance(sectionID, list):
+                sectionID = [sectionID]
+            args['contentDirectoryID'] = ",".join(map(str, sectionID))
+        if identifier:
+            if not isinstance(identifier, list):
+                identifier = [identifier]
+            args['identifier'] = ",".join(identifier)
+        for attr, value in kwargs.items():
+            args[attr] = value
+        key = '/hubs%s' % utils.joinArgs(args)
+        return self.fetchItems(key)
 
     def all(self, **kwargs):
         """ Returns a list of all media from all library sections.


### PR DESCRIPTION
## Description

Exposes global hubs in addition to the existing `LibrarySection`-level hubs.

The `sectionID` and `identifier` parameters can limit the results returned by the Plex server.

`sectionID` can be a `LibrarySection` ID, a list of those IDs, or the special "playlists" value.
_Examples_: `3`, `[1, 2, 8, "playlists"]`, `"playlists"`

`identifier` is a `Hub.hubIdentifier` or a list of them.
_Examples_: `'home.continue'`, `['home.movies.recent', 'home.ondeck']`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
