### PR TITLE
Create PlayQueue from a radio station key

### DIFF
--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -204,12 +204,18 @@ class PlayQueue(PlexObject):
 
         Parameters:
             server (:class:`~plexapi.server.PlexServer`): Server you are connected to.
-            key (str): A station key as provided by `Library.hubs()` or `Artist.station()`
-                Examples:
-                    * From Artist.station().key:
-                        "/library/metadata/12855/station/8bd29616-abbb-479e-b8da-f42d0b1a0af4?type=10"
-                    * From music LibrarySection.hubs():
-                        "/library/sections/5/stations/1"
+            key (str): A station key as provided by :func:`~plexapi.library.LibrarySection.hubs()`
+                or :func:`~plexapi.audio.Artist.station()`
+
+        Example:
+            >>> from plexapi.playqueue import PlayQueue
+            >>> music = server.library.section("Music")
+            >>> artist = music.get("Artist Name")
+            >>> station = artist.station()
+            >>> key = station.key  # "/library/metadata/12855/station/8bd39616-dbdb-459e-b8da-f46d0b170af4?type=10"
+            >>> pq = PlayQueue.from_station_key(server, key)
+            >>> client = server.clients()[0]
+            >>> client.playMedia(pq)
         """
         args = {
             "type": "audio",

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -196,7 +196,7 @@ class PlayQueue(PlexObject):
         return c
 
     @classmethod
-    def from_station_key(cls, server, key):
+    def fromStationKey(cls, server, key):
         """Create and return a new :class:`~plexapi.playqueue.PlayQueue`.
 
         This is a convenience method to create a `PlayQueue` for
@@ -216,7 +216,7 @@ class PlayQueue(PlexObject):
                 artist = music.get("Artist Name")
                 station = artist.station()
                 key = station.key  # "/library/metadata/12855/station/8bd39616-dbdb-459e-b8da-f46d0b170af4?type=10"
-                pq = PlayQueue.from_station_key(server, key)
+                pq = PlayQueue.fromStationKey(server, key)
                 client = server.clients()[0]
                 client.playMedia(pq)
         """

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -208,14 +208,17 @@ class PlayQueue(PlexObject):
                 or :func:`~plexapi.audio.Artist.station()`
 
         Example:
-            >>> from plexapi.playqueue import PlayQueue
-            >>> music = server.library.section("Music")
-            >>> artist = music.get("Artist Name")
-            >>> station = artist.station()
-            >>> key = station.key  # "/library/metadata/12855/station/8bd39616-dbdb-459e-b8da-f46d0b170af4?type=10"
-            >>> pq = PlayQueue.from_station_key(server, key)
-            >>> client = server.clients()[0]
-            >>> client.playMedia(pq)
+
+            .. code-block:: python
+
+                from plexapi.playqueue import PlayQueue
+                music = server.library.section("Music")
+                artist = music.get("Artist Name")
+                station = artist.station()
+                key = station.key  # "/library/metadata/12855/station/8bd39616-dbdb-459e-b8da-f46d0b170af4?type=10"
+                pq = PlayQueue.from_station_key(server, key)
+                client = server.clients()[0]
+                client.playMedia(pq)
         """
         args = {
             "type": "audio",

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -195,6 +195,33 @@ class PlayQueue(PlexObject):
         c._server = server
         return c
 
+    @classmethod
+    def from_station_key(cls, server, key):
+        """Create and return a new :class:`~plexapi.playqueue.PlayQueue`.
+
+        This is a convenience method to create a `PlayQueue` for
+        radio stations when only the `key` string is available.
+
+        Parameters:
+            server (:class:`~plexapi.server.PlexServer`): Server you are connected to.
+            key (str): A station key as provided by `Library.hubs()` or `Artist.station()`
+                Examples:
+                    * From Artist.station().key:
+                        "/library/metadata/12855/station/8bd29616-abbb-479e-b8da-f42d0b1a0af4?type=10"
+                    * From music LibrarySection.hubs():
+                        "/library/sections/5/stations/1"
+        """
+        args = {
+            "type": "audio",
+            "uri": f"server://{server.machineIdentifier}/{server.library.identifier}{key}"
+        }
+        path = f"/playQueues{utils.joinArgs(args)}"
+        data = server.query(path, method=server._session.post)
+        c = cls(server, data, initpath=path)
+        c.playQueueType = args["type"]
+        c._server = server
+        return c
+
     def addItem(self, item, playNext=False, refresh=True):
         """
         Append the provided item to the "Up Next" section of the PlayQueue.


### PR DESCRIPTION
## Description

Radio stations do not have `ratingKey` identifiers and instead have `key` values such as:
* From Artist.station(): `/library/metadata/12855/station/8bd39616-dbdb-459e-b8da-f46d0b170af4?type=10`
* From LibrarySection.hubs(): `/library/sections/5/stations/2` (e.g., "Time Travel Radio")

In order to begin playback of these stations, you currently need the `Playlist` object obtained from one of the calls above. If only the item identifier (key) is available, there is not a straightfoward way to "look up" the object, but there is a simple way to create a `PlayQueue` instance to use for playback.

This PR allows you to create a `PlayQueue` instance using only the `key` string value, which can then be passed to `PlexClient.playMedia()` to begin playback of the station.

Example:
```python
from plexapi.playqueue import PlayQueue
music = server.library.section("Music")
artist = music.get("Stevie Wonder")
station = artist.station()
key = station.key  # "/library/metadata/12855/station/8bd39616-dbdb-459e-b8da-f46d0b170af4?type=10"
pq = PlayQueue.from_station_key(server, key)
client = server.clients()[0]
client.playMedia(pq)
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
