### PR TITLE
Support python < 3

### DIFF
--- a/plexapi/__init__.py
+++ b/plexapi/__init__.py
@@ -21,7 +21,7 @@ TIMEOUT = CONFIG.get('plexapi.timeout', 30, int)
 X_PLEX_CONTAINER_SIZE = CONFIG.get('plexapi.container_size', 100, int)
 X_PLEX_ENABLE_FAST_CONNECT = CONFIG.get('plexapi.enable_fast_connect', False, bool)
 
-# Plex Header Configuation
+# Plex Header Configuration
 X_PLEX_PROVIDES = CONFIG.get('header.provides', 'controller')
 X_PLEX_PLATFORM = CONFIG.get('header.platform', CONFIG.get('header.platorm', uname()[0]))
 X_PLEX_PLATFORM_VERSION = CONFIG.get('header.platform_version', uname()[2])

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-from urllib.parse import quote_plus
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus  # python 2.7
 
 from plexapi import library, media, utils
 from plexapi.base import Playable, PlexPartialObject

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import re
 import weakref
-from urllib.parse import quote_plus, urlencode
+try:
+    from urllib.parse import quote_plus, urlencode
+except ImportError:
+    from urllib import quote_plus, urlencode  # python 2.7
 from xml.etree import ElementTree
 
 from plexapi import log, utils

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from urllib.parse import quote_plus
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus  # python 2.7
 
 from plexapi import media, utils
 from plexapi.base import PlexPartialObject

--- a/plexapi/config.py
+++ b/plexapi/config.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
 from collections import defaultdict
-from configparser import ConfigParser
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
 
 
 class PlexConfig(ConfigParser):

--- a/plexapi/const.py
+++ b/plexapi/const.py
@@ -5,5 +5,5 @@
 MAJOR_VERSION = 4
 MINOR_VERSION = 9
 PATCH_VERSION = 0
-__short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
-__version__ = f"{__short_version__}.{PATCH_VERSION}"
+__short_version__ = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
+__version__ = "%s.%s" % (__short_version__, PATCH_VERSION)

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import re
 from datetime import datetime
-from urllib.parse import quote, quote_plus, urlencode
+try:
+    from urllib.parse import quote_plus, unquote, urlencode
+except ImportError:
+    from urllib import quote_plus, unquote, urlencode  # python 2.7
 
 from plexapi import X_PLEX_CONTAINER_SIZE, log, media, utils
 from plexapi.base import OPERATORS, PlexObject

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -5,6 +5,7 @@ try:
     from urllib.parse import quote_plus, unquote, urlencode
 except ImportError:
     from urllib import quote_plus, unquote, urlencode  # python 2.7
+import sys
 
 from plexapi import X_PLEX_CONTAINER_SIZE, log, media, utils
 from plexapi.base import OPERATORS, PlexObject
@@ -67,7 +68,10 @@ class Library(PlexObject):
         try:
             return self._sectionsByTitle[title.lower()]
         except KeyError:
-            raise NotFound('Invalid library section: %s' % title) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Invalid library section: %s' % title)
+            else:
+                raise NotFound('Invalid library section: %s' % title) from None
 
     def sectionByID(self, sectionID):
         """ Returns the :class:`~plexapi.library.LibrarySection` that matches the specified sectionID.
@@ -83,7 +87,10 @@ class Library(PlexObject):
         try:
             return self._sectionsByID[sectionID]
         except KeyError:
-            raise NotFound('Invalid library sectionID: %s' % sectionID) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Invalid library sectionID: %s' % sectionID)
+            else:
+                raise NotFound('Invalid library sectionID: %s' % sectionID) from None
 
     def hubs(self, sectionID=None, identifier=None, **kwargs):
         """ Returns a list of :class:`~plexapi.library.Hub` across all library sections.
@@ -632,7 +639,10 @@ class LibrarySection(PlexObject):
             match = dummy.matches(agent=self.agent, title=guid.replace('://', '-'))
             return self.search(guid=match[0].guid)[0]
         except IndexError:
-            raise NotFound("Guid '%s' is not found in the library" % guid) from None
+            if sys.version_info.major < 3:
+                raise NotFound("Guid '%s' is not found in the library" % guid)
+            else:
+                raise NotFound("Guid '%s' is not found in the library" % guid) from None
 
     def all(self, libtype=None, **kwargs):
         """ Returns a list of all items from this library section.
@@ -836,9 +846,14 @@ class LibrarySection(PlexObject):
             return next(f for f in self.filterTypes() if f.type == libtype)
         except StopIteration:
             availableLibtypes = [f.type for f in self.filterTypes()]
-            raise NotFound('Unknown libtype "%s" for this library. '
-                           'Available libtypes: %s'
-                           % (libtype, availableLibtypes)) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unknown libtype "%s" for this library. '
+                               'Available libtypes: %s'
+                               % (libtype, availableLibtypes))
+            else:
+                raise NotFound('Unknown libtype "%s" for this library. '
+                               'Available libtypes: %s'
+                               % (libtype, availableLibtypes)) from None
 
     def fieldTypes(self):
         """ Returns a list of available :class:`~plexapi.library.FilteringFieldType` for this library section. """
@@ -860,9 +875,14 @@ class LibrarySection(PlexObject):
             return next(f for f in self.fieldTypes() if f.type == fieldType)
         except StopIteration:
             availableFieldTypes = [f.type for f in self.fieldTypes()]
-            raise NotFound('Unknown field type "%s" for this library. '
-                           'Available field types: %s'
-                           % (fieldType, availableFieldTypes)) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unknown field type "%s" for this library. '
+                               'Available field types: %s'
+                               % (fieldType, availableFieldTypes))
+            else:
+                raise NotFound('Unknown field type "%s" for this library. '
+                               'Available field types: %s'
+                               % (fieldType, availableFieldTypes)) from None
 
     def listFilters(self, libtype=None):
         """ Returns a list of available :class:`~plexapi.library.FilteringFilter` for a specified libtype.
@@ -977,9 +997,14 @@ class LibrarySection(PlexObject):
                 field = next(f for f in self.listFilters(libtype) if f.filter == field)
             except StopIteration:
                 availableFilters = [f.filter for f in self.listFilters(libtype)]
-                raise NotFound('Unknown filter field "%s" for libtype "%s". '
-                               'Available filters: %s'
-                               % (field, libtype, availableFilters)) from None
+                if sys.version_info.major < 3:
+                    raise NotFound('Unknown filter field "%s" for libtype "%s". '
+                                   'Available filters: %s'
+                                   % (field, libtype, availableFilters))
+                else:
+                    raise NotFound('Unknown filter field "%s" for libtype "%s". '
+                                   'Available filters: %s'
+                                   % (field, libtype, availableFilters)) from None
                 
         data = self._server.query(field.key)
         return self.findItems(data, FilterChoice)
@@ -1004,9 +1029,14 @@ class LibrarySection(PlexObject):
                         break
             else:
                 availableFields = [f.key for f in self.listFields(libtype)]
-                raise NotFound('Unknown filter field "%s" for libtype "%s". '
-                               'Available filter fields: %s'
-                               % (field, libtype, availableFields)) from None
+                if sys.version_info.major < 3:
+                    raise NotFound('Unknown filter field "%s" for libtype "%s". '
+                                   'Available filter fields: %s'
+                                   % (field, libtype, availableFields))
+                else:
+                    raise NotFound('Unknown filter field "%s" for libtype "%s". '
+                                   'Available filter fields: %s'
+                                   % (field, libtype, availableFields)) from None
 
         field = filterField.key
         operator = self._validateFieldOperator(filterField, operator)
@@ -1037,9 +1067,14 @@ class LibrarySection(PlexObject):
             next(o for o in fieldType.operators if o.key == operator)
         except StopIteration:
             availableOperators = [o.key for o in self.listOperators(filterField.type)]
-            raise NotFound('Unknown operator "%s" for filter field "%s". '
-                           'Available operators: %s'
-                           % (operator, filterField.key, availableOperators)) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unknown operator "%s" for filter field "%s". '
+                               'Available operators: %s'
+                               % (operator, filterField.key, availableOperators))
+            else:
+                raise NotFound('Unknown operator "%s" for filter field "%s". '
+                               'Available operators: %s'
+                               % (operator, filterField.key, availableOperators)) from None
 
         return '&=' if and_operator else operator
 
@@ -1067,8 +1102,12 @@ class LibrarySection(PlexObject):
                     value = self._validateFieldValueTag(value, filterField, libtype)
                 results.append(str(value))
         except (ValueError, AttributeError):
-            raise BadRequest('Invalid value "%s" for filter field "%s", value should be type %s'
-                             % (value, filterField.key, fieldType.type)) from None
+            if sys.version_info.major < 3:
+                raise BadRequest('Invalid value "%s" for filter field "%s", value should be type %s'
+                                 % (value, filterField.key, fieldType.type))
+            else:
+                raise BadRequest('Invalid value "%s" for filter field "%s", value should be type %s'
+                                 % (value, filterField.key, fieldType.type)) from None
     
         return results
 
@@ -1133,9 +1172,14 @@ class LibrarySection(PlexObject):
             filterSort = next(f for f in self.listSorts(libtype) if f.key == sortField)
         except StopIteration:
             availableSorts = [f.key for f in self.listSorts(libtype)]
-            raise NotFound('Unknown sort field "%s" for libtype "%s". '
-                           'Available sort fields: %s'
-                           % (sortField, libtype, availableSorts)) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unknown sort field "%s" for libtype "%s". '
+                               'Available sort fields: %s'
+                               % (sortField, libtype, availableSorts))
+            else:
+                raise NotFound('Unknown sort field "%s" for libtype "%s". '
+                               'Available sort fields: %s'
+                               % (sortField, libtype, availableSorts)) from None
 
         sortField = libtype + '.' + filterSort.key
 
@@ -1618,7 +1662,10 @@ class LibrarySection(PlexObject):
         try:
             return self.collections(title=title, title__iexact=title)[0]
         except IndexError:
-            raise NotFound('Unable to find collection with title "%s".' % title) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unable to find collection with title "%s".' % title)
+            else:
+                raise NotFound('Unable to find collection with title "%s".' % title) from None
 
     def collections(self, **kwargs):
         """ Returns a list of collections from this library section.
@@ -1647,7 +1694,10 @@ class LibrarySection(PlexObject):
         try:
             return self.playlists(title=title, title__iexact=title)[0]
         except IndexError:
-            raise NotFound('Unable to find playlist with title "%s".' % title) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unable to find playlist with title "%s".' % title)
+            else:
+                raise NotFound('Unable to find playlist with title "%s".' % title) from None
 
     def playlists(self, sort=None, **kwargs):
         """ Returns a list of playlists from this library section. """

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import xml
-from urllib.parse import quote_plus
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus  # python 2.7
 
 from plexapi import log, settings, utils
 from plexapi.base import PlexObject

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from urllib.parse import parse_qsl, quote_plus, unquote, urlencode, urlsplit
+try:
+    from urllib.parse import parse_qsl, quote_plus, unquote, urlencode, urlsplit
+except ImportError:
+    from urllib import quote_plus, unquote, urlencode  # python 2.7
+    from urlparse import parse_qsl, urlsplit  # python 2.7
 
 from plexapi import media, settings, utils
 from plexapi.exceptions import BadRequest, NotFound

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -4,6 +4,7 @@ try:
 except ImportError:
     from urllib import quote_plus, unquote, urlencode  # python 2.7
     from urlparse import parse_qsl, urlsplit  # python 2.7
+import sys
 
 from plexapi import media, settings, utils
 from plexapi.exceptions import BadRequest, NotFound
@@ -28,9 +29,14 @@ class AdvancedSettingsMixin(object):
             return next(p for p in prefs if p.id == pref)
         except StopIteration:
             availablePrefs = [p.id for p in prefs]
-            raise NotFound('Unknown preference "%s" for %s. '
-                           'Available preferences: %s'
-                           % (pref, self.TYPE, availablePrefs)) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unknown preference "%s" for %s. '
+                               'Available preferences: %s'
+                               % (pref, self.TYPE, availablePrefs))
+            else:
+                raise NotFound('Unknown preference "%s" for %s. '
+                               'Available preferences: %s'
+                               % (pref, self.TYPE, availablePrefs)) from None
 
     def editAdvanced(self, **kwargs):
         """ Edit a Plex object's advanced settings. """

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-from urllib.parse import quote_plus
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus  # python 2.7
 
 from plexapi import media, utils, video
 from plexapi.base import Playable, PlexPartialObject

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
-from urllib.parse import quote_plus, unquote
+try:
+    from urllib.parse import quote_plus, urlencode
+except ImportError:
+    from urllib import quote_plus, urlencode  # python 2.7
 
 from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -185,7 +185,7 @@ class PlayQueue(PlexObject):
         elif items.type == "playlist":
             args["type"] = items.playlistType
             if items.radio:
-                args["uri"] = f"server://{server.machineIdentifier}/{server.library.identifier}{items.key}"
+                args["uri"] = "server://%s/%s%s" % (server.machineIdentifier, server.library.identifier, items.key)
             else:
                 args["playlistID"] = items.ratingKey
         else:

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from urllib.parse import quote_plus
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus  # python 2.7
+import sys
 
 from plexapi import utils
 from plexapi.base import PlexObject
@@ -74,7 +78,11 @@ class PlayQueue(PlexObject):
         return self.playQueueTotalCount
 
     def __iter__(self):
-        yield from self.items
+        if sys.version_info.major < 3:
+            for x in self.items:
+                yield x
+        else:
+            yield from self.items
 
     def __contains__(self, media):
         """Returns True if the PlayQueue contains the provided media item."""

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -3,6 +3,7 @@ try:
     from urllib.parse import urlencode
 except ImportError:
     from urllib import urlencode  # python 2.7
+import sys
 from xml.etree import ElementTree
 
 import requests
@@ -294,7 +295,10 @@ class PlexServer(PlexObject):
         try:
             return next(account for account in self.systemAccounts() if account.id == accountID)
         except StopIteration:
-            raise NotFound('Unknown account with accountID=%s' % accountID) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unknown account with accountID=%s' % accountID)
+            else:
+                raise NotFound('Unknown account with accountID=%s' % accountID) from None
 
     def systemDevices(self):
         """ Returns a list of :class:`~plexapi.server.SystemDevice` objects this server contains. """
@@ -312,7 +316,10 @@ class PlexServer(PlexObject):
         try:
             return next(device for device in self.systemDevices() if device.id == deviceID)
         except StopIteration:
-            raise NotFound('Unknown device with deviceID=%s' % deviceID) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unknown device with deviceID=%s' % deviceID)
+            else:
+                raise NotFound('Unknown device with deviceID=%s' % deviceID) from None
 
     def myPlexAccount(self):
         """ Returns a :class:`~plexapi.myplex.MyPlexAccount` object using the same
@@ -629,7 +636,10 @@ class PlexServer(PlexObject):
         try:
             return self.playlists(title=title, title__iexact=title)[0]
         except IndexError:
-            raise NotFound('Unable to find playlist with title "%s".' % title) from None
+            if sys.version_info.major < 3:
+                raise NotFound('Unable to find playlist with title "%s".' % title)
+            else:
+                raise NotFound('Unable to find playlist with title "%s".' % title) from None
 
     def optimizedItems(self, removeAll=None):
         """ Returns list of all :class:`~plexapi.media.Optimized` objects connected to server. """

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from urllib.parse import urlencode
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode  # python 2.7
 from xml.etree import ElementTree
 
 import requests

--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
-from urllib.parse import quote
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus  # python 2.7
 
 from plexapi import log, utils
 from plexapi.base import PlexObject

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-from urllib.parse import quote_plus, urlencode
+try:
+    from urllib.parse import quote_plus, urlencode
+except ImportError:
+    from urllib import quote_plus, urlencode  # python 2.7
 
 from plexapi import library, media, utils
 from plexapi.base import Playable, PlexPartialObject


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.
- Add support for Python 2.7
  - The required changes to support Python < 3 are really quite minor.
  - This would allow plexapi to be used by Plex Metadata agents and any still maintained plug-ins.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
