### PR TITLE
Return all albums with `Artist.albums()`

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -177,7 +177,7 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
 
     def albums(self, **kwargs):
         """ Returns a list of :class:`~plexapi.audio.Album` objects by the artist. """
-        key = '/library/metadata/%s/children' % self.ratingKey
+        key = f"/library/sections/{self.librarySectionID}/all?artist.id={self.ratingKey}&type=9"
         return self.fetchItems(key, Album, **kwargs)
 
     def track(self, title=None, album=None, track=None):


### PR DESCRIPTION
## Description

Some time ago, the `/library/metadata/<artist_rating_key>/children` endpoint started returning only "true" albums and moved special albums (e.g., EPs, live albums, compilations, etc) to the artist's hubs.

This updates the `Artist.albums()` method to return all albums associated with an artist.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
