### PR TITLE
Add librarySectionID when calling fetchItem

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -169,9 +169,14 @@ class PlexObject(object):
             raise BadRequest('ekey was not provided')
         if isinstance(ekey, int):
             ekey = '/library/metadata/%s' % ekey
-        for elem in self._server.query(ekey):
+        data = self._server.query(ekey)
+        librarySectionID = utils.cast(int, data.attrib.get('librarySectionID'))
+        for elem in data:
             if self._checkAttrs(elem, **kwargs):
-                return self._buildItem(elem, cls, ekey)
+                item = self._buildItem(elem, cls, ekey)
+                if librarySectionID:
+                    item.librarySectionID = librarySectionID
+                return item
         clsname = cls.__name__ if cls else 'None'
         raise NotFound('Unable to find elem: cls=%s, attrs=%s' % (clsname, kwargs))
 


### PR DESCRIPTION
## Description

Adds the `librarySectionID` attribute when calling `fetchItem`. This mimics the behaviour of `fetchItems` and saves an extra reload when the `librarySectionID` is missing (i.e. when using `edit()`).


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
