### PR TITLE
Ignore whitespace in library section lookup

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -43,7 +43,7 @@ class Library(PlexObject):
                 if elem.attrib.get('type') == cls.TYPE:
                     section = cls(self._server, elem, key)
                     self._sectionsByID[section.key] = section
-                    self._sectionsByTitle[section.title.lower()] = section
+                    self._sectionsByTitle[section.title.lower().strip()] = section
 
     def sections(self):
         """ Returns a list of all media sections in this library. Library sections may be any of
@@ -59,10 +59,11 @@ class Library(PlexObject):
             Parameters:
                 title (str): Title of the section to return.
         """
-        if not self._sectionsByTitle or title not in self._sectionsByTitle:
+        normalized_title = title.lower().strip()
+        if not self._sectionsByTitle or normalized_title not in self._sectionsByTitle:
             self._loadSections()
         try:
-            return self._sectionsByTitle[title.lower()]
+            return self._sectionsByTitle[normalized_title]
         except KeyError:
             raise NotFound('Invalid library section: %s' % title) from None
 


### PR DESCRIPTION
## Description

Ignores whitespace when looking up a library section using `Library.section()`.

This handles a workaround used by some users to reorder libraries by prepending spaces to the library section name.

Example: https://old.reddit.com/r/PleX/comments/9adjku/change_order_of_libraries/e4v5q5c/

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
