### PR TITLE
Fix language in library tests

### DIFF
--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -133,7 +133,7 @@ def test_library_add_edit_delete(plex, movies, photos):
         type="movie",
         agent="com.plexapp.agents.none",
         scanner="Plex Video Files Scanner",
-        language="en",
+        language="xn",
         location=[movie_location, photo_location]
     )
     section = plex.library.section(section_name)
@@ -146,7 +146,7 @@ def test_library_add_edit_delete(plex, movies, photos):
             type="movie",
             agent="com.plexapp.agents.none",
             scanner="Plex Video Files Scanner",
-            language="en",
+            language="xn",
             location=[movie_location, photo_location[:-1]]
         )
     # Create library with no path
@@ -156,7 +156,7 @@ def test_library_add_edit_delete(plex, movies, photos):
             type="movie",
             agent="com.plexapp.agents.none",
             scanner="Plex Video Files Scanner",
-            language="en",
+            language="xn",
         )
     with pytest.raises(NotFound):
         plex.library.section(error_section_name)

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -482,7 +482,8 @@ if __name__ == "__main__":
             "Server didnt appear in your account after %ss" % opts.bootstrap_timeout
         )
 
-    print("Plex container started after %ss, setting up content" % int(runtime))
+    print("Plex container started after %ss" % int(runtime))
+    print("Plex server version %s" % server.version)
 
     if opts.accept_eula:
         server.settings.get("acceptedEULA").set(True)


### PR DESCRIPTION
## Description

Fix language in `test_library.py::test_library_add_edit_delete`.

"Other Videos" library type uses `language="xn"`.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
