### PR TITLE
Add extras and hubs mixins

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -2,11 +2,11 @@
 import os
 from urllib.parse import quote_plus
 
-from plexapi import library, media, utils
+from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import AdvancedSettingsMixin, ArtUrlMixin, ArtMixin, PosterUrlMixin, PosterMixin
-from plexapi.mixins import RatingMixin, SplitMergeMixin, UnmatchMatchMixin
+from plexapi.mixins import ExtrasMixin, HubsMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin
 from plexapi.mixins import CollectionMixin, CountryMixin, GenreMixin, LabelMixin, MoodMixin, SimilarArtistMixin, StyleMixin
 from plexapi.playlist import Playlist
 
@@ -125,7 +125,8 @@ class Audio(PlexPartialObject):
 
 
 @utils.registerPlexObject
-class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin,
+class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, ExtrasMixin, HubsMixin, RatingMixin,
+        SplitMergeMixin, UnmatchMatchMixin,
         CollectionMixin, CountryMixin, GenreMixin, MoodMixin, SimilarArtistMixin, StyleMixin):
     """ Represents a single Artist.
 
@@ -160,11 +161,6 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
     def __iter__(self):
         for album in self.albums():
             yield album
-
-    def hubs(self):
-        """ Returns a list of :class:`~plexapi.library.Hub` objects. """
-        data = self._server.query(self._details_key)
-        return self.findItems(data, library.Hub, rtag='Related')
 
     def album(self, title):
         """ Returns the :class:`~plexapi.audio.Album` that matches the specified title.
@@ -337,7 +333,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
 
 
 @utils.registerPlexObject
-class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin,
+class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, ExtrasMixin, RatingMixin,
         CollectionMixin, MoodMixin):
     """ Represents a single Track.
 

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -5,14 +5,15 @@ from plexapi import media, utils
 from plexapi.base import PlexPartialObject
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection
-from plexapi.mixins import AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin
+from plexapi.mixins import AdvancedSettingsMixin, ArtMixin, PosterMixin, HubsMixin, RatingMixin
 from plexapi.mixins import LabelMixin, SmartFilterMixin
 from plexapi.playqueue import PlayQueue
 from plexapi.utils import deprecated
 
 
 @utils.registerPlexObject
-class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, LabelMixin, SmartFilterMixin):
+class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin, HubsMixin, RatingMixin,
+        LabelMixin, SmartFilterMixin):
     """ Represents a single Collection.
 
         Attributes:

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -209,6 +209,26 @@ class PosterMixin(PosterUrlMixin):
         self._edit(**{'thumb.locked': 0})
 
 
+class ExtrasMixin(object):
+    """ Mixin for Plex objects that can have extras. """
+
+    def extras(self):
+        """ Returns a list of :class:`~plexapi.video.Extra` objects. """
+        from plexapi.video import Extra
+        data = self._server.query(self._details_key)
+        return self.findItems(data, Extra, rtag='Extras')
+
+
+class HubsMixin(object):
+    """ Mixin for Plex objects that can have related hubs. """
+
+    def hubs(self):
+        """ Returns a list of :class:`~plexapi.library.Hub` objects. """
+        from plexapi.library import Hub
+        data = self._server.query(self._details_key)
+        return self.findItems(data, Hub, rtag='Related')
+
+
 class RatingMixin(object):
     """ Mixin for Plex objects that can have user star ratings. """
 

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -2,11 +2,11 @@
 import os
 from urllib.parse import quote_plus, urlencode
 
-from plexapi import library, media, utils
+from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import AdvancedSettingsMixin, ArtUrlMixin, ArtMixin, BannerMixin, PosterUrlMixin, PosterMixin
-from plexapi.mixins import RatingMixin, SplitMergeMixin, UnmatchMatchMixin
+from plexapi.mixins import ExtrasMixin, HubsMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin
 from plexapi.mixins import CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin
 
 
@@ -261,7 +261,8 @@ class Video(PlexPartialObject):
 
 
 @utils.registerPlexObject
-class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin,
+class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, ExtrasMixin, HubsMixin, RatingMixin,
+        SplitMergeMixin, UnmatchMatchMixin,
         CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin):
     """ Represents a single Movie.
 
@@ -365,19 +366,10 @@ class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, Ratin
         data = self._server.query(self._details_key)
         return self.findItems(data, media.Review, rtag='Video')
 
-    def extras(self):
-        """ Returns a list of :class:`~plexapi.video.Extra` objects. """
-        data = self._server.query(self._details_key)
-        return self.findItems(data, Extra, rtag='Extras')
-
-    def hubs(self):
-        """ Returns a list of :class:`~plexapi.library.Hub` objects. """
-        data = self._server.query(self._details_key)
-        return self.findItems(data, library.Hub, rtag='Related')
-
 
 @utils.registerPlexObject
-class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin,
+class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, ExtrasMixin, HubsMixin, RatingMixin,
+        SplitMergeMixin, UnmatchMatchMixin,
         CollectionMixin, GenreMixin, LabelMixin):
     """ Represents a single Show (including all seasons and episodes).
 
@@ -483,11 +475,6 @@ class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, Rat
         """ Returns True if the show is fully watched. """
         return bool(self.viewedLeafCount == self.leafCount)
 
-    def hubs(self):
-        """ Returns a list of :class:`~plexapi.library.Hub` objects. """
-        data = self._server.query(self._details_key)
-        return self.findItems(data, library.Hub, rtag='Related')
-
     def onDeck(self):
         """ Returns show's On Deck :class:`~plexapi.video.Video` object or `None`.
             If show is unwatched, return will likely be the first episode.
@@ -574,7 +561,7 @@ class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, Rat
 
 
 @utils.registerPlexObject
-class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin):
+class Season(Video, ArtMixin, PosterMixin, ExtrasMixin, RatingMixin, CollectionMixin):
     """ Represents a single Show Season (including all episodes).
 
         Attributes:
@@ -709,7 +696,7 @@ class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin):
 
 
 @utils.registerPlexObject
-class Episode(Video, Playable, ArtMixin, PosterMixin, RatingMixin,
+class Episode(Video, Playable, ArtMixin, PosterMixin, ExtrasMixin, RatingMixin,
         CollectionMixin, DirectorMixin, WriterMixin):
     """ Represents a single Shows Episode.
 


### PR DESCRIPTION
## Description

Refactor `extras()` to an `ExtrasMixin` and `hubs()` to `HubsMixin`.

* Adds `ExtrasMixin` to `Artist`, `Track`, `Movie`, `Show`, `Season`, and `Episode` objects.
* Adds `HubsMixin` to `Artist`, `Movie`, `Show`, and `Collection` objects.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable (Tests already exist for extras and hubs)
