### PR TITLE
Add `Video.audioStreams()` convenience method

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -107,6 +107,15 @@ class Video(PlexPartialObject):
         """ Returns str, default title for a new syncItem. """
         return self.title
 
+    def audioStreams(self):
+        """ Returns a list of :class:`~plexapi.media.AudioStream` objects for all MediaParts. """
+        streams = []
+
+        parts = self.iterParts()
+        for part in parts:
+            streams += part.audioStreams()
+        return streams
+
     def subtitleStreams(self):
         """ Returns a list of :class:`~plexapi.media.SubtitleStream` objects for all MediaParts. """
         streams = []

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -150,11 +150,16 @@ def test_video_Movie_download(monkeydownload, tmpdir, movie):
     assert filename in with_resolution[0]
 
 
-def test_video_Movie_subtitlestreams(movie):
+def test_video_Movie_audioStreams(movie):
+    movie.reload()
+    assert movie.audioStreams()
+
+
+def test_video_Movie_subtitleStreams(movie):
     assert not movie.subtitleStreams()
 
 
-def test_video_Episode_subtitlestreams(episode):
+def test_video_Episode_subtitleStreams(episode):
     assert not episode.subtitleStreams()
 
 


### PR DESCRIPTION
## Description

Add `Video.audioStreams()` convenience method which mimics `Video.subtitleStreams()`.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
