### PR TITLE
Add support for collection "filtering based on user" advanced setting

### DIFF
--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -236,7 +236,7 @@ class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin
         }
         key = mode_dict.get(mode)
         if key is None:
-            raise BadRequest('Unknown collection mode : %s. Options %s' % (mode, list(mode_dict)))
+            raise BadRequest('Unknown collection mode: %s. Options %s' % (mode, list(mode_dict)))
         self.editAdvanced(collectionMode=key)
 
     def sortUpdate(self, sort=None):
@@ -254,6 +254,9 @@ class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin
 
                     collection.updateSort(mode="alpha")
         """
+        if self.smart:
+            raise BadRequest('Cannot change collection order for a smart collection.')
+
         sort_dict = {
             'release': 0,
             'alpha': 1,

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -186,6 +186,32 @@ class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin
         """ Alias to :func:`~plexapi.library.Collection.item`. """
         return self.item(title)
 
+    def filterUserUpdate(self, user=None):
+        """ Update the collection filtering user advanced setting.
+
+            Parameters:
+                user (str): One of the following values:
+                    "admin" (Always the server admin user),
+                    "user" (User currently viewing the content)
+
+            Example:
+
+                .. code-block:: python
+
+                    collection.updateMode(user="user")
+        """
+        if not self.smart:
+            raise BadRequest('Cannot change collection filtering user for a non-smart collection.')
+
+        user_dict = {
+            'admin': 0,
+            'user': 1
+        }
+        key = user_dict.get(user)
+        if key is None:
+            raise BadRequest('Unknown collection filtering user: %s. Options %s' % (user, list(user_dict)))
+        self.editAdvanced(collectionFilterBasedOnUser=key)
+
     def modeUpdate(self, mode=None):
         """ Update the collection mode advanced setting.
 

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -22,9 +22,10 @@ class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin
             art (str): URL to artwork image (/library/metadata/<ratingKey>/art/<artid>).
             artBlurHash (str): BlurHash string for artwork image.
             childCount (int): Number of items in the collection.
-            collectionMode (str): How the items in the collection are displayed.
+            collectionFilterBasedOnUser (int): Which user's activity is used for the collection filtering.
+            collectionMode (int): How the items in the collection are displayed.
             collectionPublished (bool): True if the collection is published to the Plex homepage.
-            collectionSort (str): How to sort the items in the collection.
+            collectionSort (int): How to sort the items in the collection.
             content (str): The filter URI string for smart collections.
             contentRating (str) Content rating (PG-13; NR; TV-G).
             fields (List<:class:`~plexapi.media.Field`>): List of field objects.
@@ -60,6 +61,7 @@ class Collection(PlexPartialObject, AdvancedSettingsMixin, ArtMixin, PosterMixin
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')
         self.childCount = utils.cast(int, data.attrib.get('childCount'))
+        self.collectionFilterBasedOnUser = utils.cast(int, data.attrib.get('collectionFilterBasedOnUser', '0'))
         self.collectionMode = utils.cast(int, data.attrib.get('collectionMode', '-1'))
         self.collectionPublished = utils.cast(bool, data.attrib.get('collectionPublished', '0'))
         self.collectionSort = utils.cast(int, data.attrib.get('collectionSort', '0'))

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -13,6 +13,7 @@ def test_Collection_attrs(collection):
     assert collection.art is None
     assert collection.artBlurHash is None
     assert collection.childCount == 1
+    assert collection.collectionFilterBasedOnUser == 0
     assert collection.collectionMode == -1
     assert collection.collectionPublished is False
     assert collection.collectionSort == 0
@@ -63,6 +64,27 @@ def test_Collection_item(collection):
 def test_Collection_items(collection):
     items = collection.items()
     assert len(items) == 1
+
+
+def test_Collection_filterUserUpdate(plex, movies):
+    title = "test_Collection_filterUserUpdate"
+    try:
+        collection = plex.createCollection(
+            title=title,
+            section=movies,
+            smart=True
+        )
+
+        mode_dict = {"admin": 0, "user": 1}
+        for key, value in mode_dict.items():
+            collection.filterUserUpdate(user=key)
+            collection.reload()
+            assert collection.collectionFilterBasedOnUser == value
+        with pytest.raises(BadRequest):
+            collection.filterUserUpdate(user="bad-user")
+        collection.filterUserUpdate("admin")
+    finally:
+        collection.delete()
 
 
 def test_Collection_modeUpdate(collection):
@@ -242,6 +264,8 @@ def test_Collection_exceptions(plex, movies, movie, artist):
             collection.updateFilters()
         with pytest.raises(BadRequest):
             collection.addItems(artist)
+        with pytest.raises(BadRequest):
+            collection.filterUserUpdate("user")
     finally:
         collection.delete()
 
@@ -258,6 +282,8 @@ def test_Collection_exceptions(plex, movies, movie, artist):
             collection.removeItems(movie)
         with pytest.raises(BadRequest):
             collection.moveItem(movie)
+        with pytest.raises(BadRequest):
+            collection.sortUpdate("custom")
     finally:
         collection.delete()
 


### PR DESCRIPTION
## Description

* Adds the `Collection.collectionFilterBasedOnUser` attribute for "Collection filtering based on" advanced setting for smart collections.

* Adds a `Collection.filterUserUpdate()` method to change the collection filtering user advanced setting.

* (Breaking change) Adds a check for smart collections for the `Collection.sortUpdate()` method and raises a `BadRequest` exception.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
