### PR TITLE
Fix `Artist.album()` to return special albums

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -174,7 +174,7 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
             Parameters:
                 title (str): Title of the album to return.
         """
-        key = '/library/metadata/%s/children' % self.ratingKey
+        key = f"/library/sections/{self.librarySectionID}/all?artist.id={self.ratingKey}&type=9"
         return self.fetchItem(key, Album, title__iexact=title)
 
     def albums(self, **kwargs):


### PR DESCRIPTION
## Description

Additional fix for #884. Update `Artist.album()` to also return different album types.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
