### PR TITLE
Fix test track ratingCount attribute

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -298,7 +298,7 @@ def test_audio_Track_attrs(album):
     assert track.parentTitle == "Layers"
     assert track.playlistItemID is None
     assert track.primaryExtraKey is None
-    assert utils.is_int(track.ratingCount) or track.ratingCount is None
+    assert track.ratingCount is None or utils.is_int(track.ratingCount)
     assert utils.is_int(track.ratingKey)
     assert track._server._baseurl == utils.SERVER_BASEURL
     assert track.sessionKey is None


### PR DESCRIPTION
## Description

Fix transient issue with testing `track.ratingCount`. Check for `None` before `int`.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
