### PR TITLE
docs update: configuration "secrets = true" is always False

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,7 +34,7 @@ are optional. An example config.ini file may look like the following with all po
     level = INFO
     path = ~/.config/plexapi/plexapi.log
     rotate_bytes = 512000
-    secrets = false
+    show_secrets = false
     
 
 Environment Variables
@@ -167,7 +167,7 @@ Section [log] Options
 **rotate_bytes**
     Max size of the log file before rotating logs to a backup file (default: 512000 equals 0.5MB).
 
-**secrets**
+**show_secrets**
     By default Plex will hide all passwords and token values when logging. Set this to 'true' to enable
     logging these secrets. This should only be done on a private server and only enabled when needed
     (default: false).


### PR DESCRIPTION
## Description

PlexServer object parameter `_show_secrets` is always `False` when applying the configuration example in the documentation.
 
https://github.com/pkkid/python-plexapi/blob/bb4d0dbf1d628abba60eb86e896b8fd3ae5b69bb/docs/configuration.rst#L37
 
 Setting `secretes = true` does not load in `plexapi.__init__` or `plexapi.server.PlexServer()`
 
 https://github.com/pkkid/python-plexapi/blob/bb4d0dbf1d628abba60eb86e896b8fd3ae5b69bb/plexapi/__init__.py#L50-L52
 
https://github.com/pkkid/python-plexapi/blob/bb4d0dbf1d628abba60eb86e896b8fd3ae5b69bb/plexapi/server.py#L109

Setting `show_secrets = true` will load for both `plexapi.__init__` and `plexapi.server.PlexServer()` 

This will update the Documentation in two places: 

https://github.com/pkkid/python-plexapi/blob/bb4d0dbf1d628abba60eb86e896b8fd3ae5b69bb/docs/configuration.rst#L37

https://github.com/pkkid/python-plexapi/blob/bb4d0dbf1d628abba60eb86e896b8fd3ae5b69bb/docs/configuration.rst#L170


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [-] I have added tests when applicable
