### PR TITLE
Enable external media in responses, e.g. Tidal

### DIFF
--- a/plexapi/config.py
+++ b/plexapi/config.py
@@ -62,4 +62,5 @@ def reset_base_headers():
         'X-Plex-Device-Name': plexapi.X_PLEX_DEVICE_NAME,
         'X-Plex-Client-Identifier': plexapi.X_PLEX_IDENTIFIER,
         'X-Plex-Sync-Version': '2',
+        'X-Plex-Features': 'external-media',
     }


### PR DESCRIPTION
## Description

Adds the header `X-Plex-Features` which controls whether Tidal results are included in responses.

For example, running against my Plex server:

```python
# 61115 for track.source and album.source is for items from Tidal
len(music.searchAlbums(filters = {'album.source': '61115'}))
```

Results in `0` before this change and non-`0` after.

Refs #671.

The value that I see in the web frontend is `external-media,indirect-media` but the latter does not appear to change the results that I can tell; erring on the side of not adding it since it may cause another level of effects.

I don't know the Plex API well enough to know whether this may have additional side effects that I'm not considering. If that's the case, it may be worth making this opt-in instead.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
