### PR TITLE
Use breadth-first search when using `rtag`

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -282,9 +282,9 @@ class PlexObject(object):
             kwargs['etag'] = cls.TAG
         if cls and cls.TYPE and 'type' not in kwargs:
             kwargs['type'] = cls.TYPE
-        # rtag to iter on a specific root tag
+        # rtag to iter on a specific root tag using breadth-first search
         if rtag:
-            data = next(data.iter(rtag), [])
+            data = next(utils.iterXMLBFS(data, rtag), [])
         # loop through all data elements to find matches
         items = []
         for elem in data:
@@ -304,9 +304,9 @@ class PlexObject(object):
     def listAttrs(self, data, attr, rtag=None, **kwargs):
         """ Return a list of values from matching attribute. """
         results = []
-        # rtag to iter on a specific root tag
+        # rtag to iter on a specific root tag using breadth-first search
         if rtag:
-            data = next(data.iter(rtag), [])
+            data = next(utils.iterXMLBFS(data, rtag), [])
         for elem in data:
             kwargs['%s__exists' % attr] = True
             if self._checkAttrs(elem, **kwargs):

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -9,6 +9,7 @@ import time
 import unicodedata
 import warnings
 import zipfile
+from collections import deque
 from datetime import datetime
 from getpass import getpass
 from threading import Event, Thread
@@ -472,3 +473,15 @@ def deprecated(message, stacklevel=2):
             return func(*args, **kwargs)
         return wrapper
     return decorator
+
+
+def iterXMLBFS(root, tag=None):
+    """ Iterate through an XML tree using a breadth-first search.
+        If tag is specified, only return nodes with that tag.
+    """
+    queue = deque([root])
+    while queue:
+        node = queue.popleft()
+        if tag is None or node.tag == tag:
+            yield node
+        queue.extend(list(node))


### PR DESCRIPTION
## Description

Fixes `findItems` and `listAttrs` to do a breadth-first search for `rtag` instead of the default of depth-first search.

This fixes things like `Season.extras()` which would return the wrong objects because there is an `<Extras>` tag earlier, but deeper, in the XML (e.g. nested inside `<OnDeck>`).

Example:
```xml
<MediaContainer>
  <Directory>
    <OnDeck>
      <Video>
        <Extras></Extras>    <-- Depth-first finds this Extras tag
      </Video>
    </OnDeck>
    <Extras></Extras>   <-- Breadth-first finds this Extras tag
  </Directory>
</MediaContainer>
```


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
