### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10.

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -194,7 +194,7 @@ def threaded(callback, listargs):
         args += [results, len(results)]
         results.append(None)
         threads.append(Thread(target=callback, args=args, kwargs=dict(job_is_done_event=job_is_done_event)))
-        threads[-1].setDaemon(True)
+        threads[-1].daemon = True
         threads[-1].start()
     while not job_is_done_event.is_set():
         if all(not t.is_alive() for t in threads):


### PR DESCRIPTION
## Description

The camelcase methods were deprecated in Python 3.10 in python/cpython#25174


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable