### PR TITLE
Add method to manually run butler tasks

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -257,6 +257,16 @@ def test_server_sessions(plex):
     assert len(plex.sessions()) >= 0
 
 
+def test_server_butlerTasks(plex):
+    assert len(plex.butlerTasks())
+
+
+def test_server_runButlerTask(plex):
+    assert plex.runButlerTask("CleanOldBundles") is None
+    with pytest.raises(BadRequest):
+        plex.runButlerTask("<This-task-should-not-exist>")
+
+
 def test_server_isLatest(plex, mocker):
     from os import environ
 
@@ -271,12 +281,12 @@ def test_server_isLatest(plex, mocker):
 
 def test_server_installUpdate(plex, mocker):
     m = mocker.MagicMock(release="aa")
-    with utils.patch('plexapi.server.PlexServer.check_for_update', return_value=m):
+    with utils.patch('plexapi.server.PlexServer.checkForUpdate', return_value=m):
         with utils.callable_http_patch():
             plex.installUpdate()
 
 
-def test_server_check_for_update(plex, mocker):
+def test_server_checkForUpdate(plex, mocker):
     class R:
         def __init__(self, **kwargs):
             self.download_key = "plex.tv/release/1337"
@@ -286,8 +296,8 @@ def test_server_check_for_update(plex, mocker):
             self.downloadURL = "http://path-to-update"
             self.state = "downloaded"
 
-    with utils.patch('plexapi.server.PlexServer.check_for_update', return_value=R()):
-        rel = plex.check_for_update(force=False, download=True)
+    with utils.patch('plexapi.server.PlexServer.checkForUpdate', return_value=R()):
+        rel = plex.checkForUpdate(force=False, download=True)
         assert rel.download_key == "plex.tv/release/1337"
         assert rel.version == "1337"
         assert rel.added == "gpu transcode"


### PR DESCRIPTION
## Description

* Adds `PlexServer.butlerTasks()` to return a list of `ButlerTask` objects.
* Adds `PlexServer.runButlerTask(task)` to manually run a butler task immediately.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
