### PR TITLE
Get album track by track number without keyword argument

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -313,10 +313,14 @@ class Album(
                 :exc:`~plexapi.exceptions.BadRequest`: If title or track parameter is missing.
         """
         key = '/library/metadata/%s/children' % self.ratingKey
-        if title is not None:
+        if title is not None and not isinstance(title, int):
             return self.fetchItem(key, Track, title__iexact=title)
-        elif track is not None:
-            return self.fetchItem(key, Track, parentTitle__iexact=self.title, index=track)
+        elif track is not None or isinstance(title, int):
+            if isinstance(title, int):
+                index = title
+            else:
+                index = track
+            return self.fetchItem(key, Track, parentTitle__iexact=self.title, index=index)
         raise BadRequest('Missing argument: title or track is required')
 
     def tracks(self, **kwargs):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -188,19 +188,20 @@ def test_audio_Album_tracks(album):
     assert len(tracks) == 1
 
 
-def test_audio_Album_track(album, track=None):
-    # this is not reloaded. its not that much info missing.
-    track = track or album.track("As Colourful As Ever")
-    track2 = album.track(track=1)
-    assert track == track2
+def test_audio_Album_track(album):
+    track = album.track("As Colourful as Ever")
+    assert track.title == "As Colourful as Ever"
+    track = album.track(track=1)
+    assert track.index == 1
+    track = album.track(1)
+    assert track.index == 1
     with pytest.raises(BadRequest):
         album.track()
 
 
 def test_audio_Album_get(album):
-    # alias for album.track()
-    track = album.get("As Colourful As Ever")
-    test_audio_Album_track(album, track=track)
+    track = album.get("As Colourful as Ever")
+    assert track.title == "As Colourful as Ever"
 
 
 def test_audio_Album_artist(album):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -744,6 +744,15 @@ def test_video_Show_attrs(show):
     assert show.url(None) is None
 
 
+def test_video_Show_episode(show):
+    episode = show.episode("Winter Is Coming")
+    assert episode == show.episode(season=1, episode=1)
+    with pytest.raises(BadRequest):
+        show.episode()
+    with pytest.raises(NotFound):
+        show.episode(season=1337, episode=1337)
+
+
 def test_video_Show_history(show):
     show.markWatched()
     history = show.history()
@@ -985,13 +994,15 @@ def test_video_Season_get(show):
 
 
 def test_video_Season_episode(show):
-    episode = show.season("Season 1").get("Winter Is Coming")
+    season = show.season("Season 1")
+    episode = season.get("Winter Is Coming")
     assert episode.title == "Winter Is Coming"
-
-
-def test_video_Season_episode_by_index(show):
-    episode = show.season(season=1).episode(episode=1)
+    episode = season.episode(episode=1)
     assert episode.index == 1
+    episode = season.episode(1)
+    assert episode.index == 1
+    with pytest.raises(BadRequest):
+        season.episode()
 
 
 def test_video_Season_episodes(show):
@@ -1055,15 +1066,6 @@ def test_video_Episode_stop(episode, mocker, patched_http_call):
         episode, "session", return_value=list(mocker.MagicMock(id="hello"))
     )
     episode.stop(reason="It's past bedtime!")
-
-
-def test_video_Episode(show):
-    episode = show.episode("Winter Is Coming")
-    assert episode == show.episode(season=1, episode=1)
-    with pytest.raises(BadRequest):
-        show.episode()
-    with pytest.raises(NotFound):
-        show.episode(season=1337, episode=1337)
 
 
 def test_video_Episode_history(episode):


### PR DESCRIPTION
## Description

Changes `Album.track()` to retrieve a track by track number without specifying the `track` keyword argument.

e.g. Both `Album.track(1)` and `Album.track(track=1)` will work.

This mimics `Season.episode(1)` and `Season.episode(episode=1)`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
