### PR TITLE
Add support for watchlists and streaming services

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1112,3 +1112,41 @@ class AgentMediaType(Agent):
     @deprecated('use "languageCodes" instead')
     def languageCode(self):
         return self.languageCodes
+
+
+@utils.registerPlexObject
+class Availability(PlexObject):
+    """ Represents a single online streaming service Availability.
+
+        Attributes:
+            TAG (str): 'Availability'
+            country (str): The streaming service country.
+            offerType (str): Subscription, buy, or rent from the streaming service.
+            platform (str): The platform slug for the streaming service.
+            platformColorThumb (str): Thumbnail icon for the streaming service.
+            platformInfo (str): The streaming service platform info.
+            platformUrl (str): The URL to the media on the streaming service.
+            price (float): The price to buy or rent from the streaming service.
+            priceDescription (str): The display price to buy or rent from the streaming service.
+            quality (str): The video quality on the streaming service.
+            title (str): The title of the streaming service.
+            url (str): The Plex availability URL.
+    """
+    TAG = 'Availability'
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__}:{self.platform}:{self.offerType}>'
+
+    def _loadData(self, data):
+        self._data = data
+        self.country = data.attrib.get('country')
+        self.offerType = data.attrib.get('offerType')
+        self.platform = data.attrib.get('platform')
+        self.platformColorThumb = data.attrib.get('platformColorThumb')
+        self.platformInfo = data.attrib.get('platformInfo')
+        self.platformUrl = data.attrib.get('platformUrl')
+        self.price = utils.cast(float, data.attrib.get('price'))
+        self.priceDescription = data.attrib.get('priceDescription')
+        self.quality = data.attrib.get('quality')
+        self.title = data.attrib.get('title')
+        self.url = data.attrib.get('url')

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -984,3 +984,23 @@ class WriterMixin(EditTagsMixin):
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('writer', writers, locked=locked, remove=True)
+
+
+class WatchlistMixin(object):
+    """ Mixin for Plex objects that can be added to a user's watchlist. """
+
+    def addToWatchlist(self, account):
+        """ Add this item to the specified :class:`~plexapi.myplex.MyPlexAccount`'s watchlist.
+
+            Parameters:
+                account (:class:`~plexapi.myplex.MyPlexAccount`): Account to add item to the watchlist.
+        """
+        account.addToWatchlist(self)
+
+    def removeFromWatchlist(self, account):
+        """ Remove this item from the specified :class:`~plexapi.myplex.MyPlexAccount`'s watchlist.
+
+            Parameters:
+                account (:class:`~plexapi.myplex.MyPlexAccount`): Account to remove item from the watchlist.
+        """
+        account.removeFromWatchlist(self)

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -996,7 +996,10 @@ class WatchlistMixin(object):
                 account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to check item on the watchlist.
                    Note: This is required if you are not connected to a Plex server instance using the admin account.
         """
-        account = account or self._server.myPlexAccount()
+        try:
+            account = account or self._server.myPlexAccount()
+        except AttributeError:
+            account = self._server
         return account.onWatchlist(self)
 
     def addToWatchlist(self, account=None):
@@ -1006,7 +1009,10 @@ class WatchlistMixin(object):
                 account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to add item to the watchlist.
                    Note: This is required if you are not connected to a Plex server instance using the admin account.
         """
-        account = account or self._server.myPlexAccount()
+        try:
+            account = account or self._server.myPlexAccount()
+        except AttributeError:
+            account = self._server
         account.addToWatchlist(self)
 
     def removeFromWatchlist(self, account=None):
@@ -1016,7 +1022,10 @@ class WatchlistMixin(object):
                 account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to remove item from the watchlist.
                    Note: This is required if you are not connected to a Plex server instance using the admin account.
         """
-        account = account or self._server.myPlexAccount()
+        try:
+            account = account or self._server.myPlexAccount()
+        except AttributeError:
+            account = self._server
         account.removeFromWatchlist(self)
 
     def streamingServices(self, account=None):
@@ -1027,7 +1036,10 @@ class WatchlistMixin(object):
                 account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account used to retrieve availability.
                    Note: This is required if you are not connected to a Plex server instance using the admin account.
         """
-        account = account or self._server.myPlexAccount()
+        try:
+            account = account or self._server.myPlexAccount()
+        except AttributeError:
+            account = self._server
         ratingKey = self.guid.rsplit('/', 1)[-1]
         data = account.query(f"{account.METADATA}/library/metadata/{ratingKey}/availabilities")
         return self.findItems(data)

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -989,8 +989,16 @@ class WriterMixin(EditTagsMixin):
 class WatchlistMixin(object):
     """ Mixin for Plex objects that can be added to a user's watchlist. """
 
+    def onWatchlist(self, account):
+        """ Returns True if the item is on the user's watchlist.
+
+            Parameters:
+                account (:class:`~plexapi.myplex.MyPlexAccount`): Account to check item on the watchlist.
+        """
+        return account.onWatchlist(self)
+
     def addToWatchlist(self, account):
-        """ Add this item to the specified :class:`~plexapi.myplex.MyPlexAccount`'s watchlist.
+        """ Add this item to the specified user's watchlist.
 
             Parameters:
                 account (:class:`~plexapi.myplex.MyPlexAccount`): Account to add item to the watchlist.
@@ -998,7 +1006,7 @@ class WatchlistMixin(object):
         account.addToWatchlist(self)
 
     def removeFromWatchlist(self, account):
-        """ Remove this item from the specified :class:`~plexapi.myplex.MyPlexAccount`'s watchlist.
+        """ Remove this item from the specified user's watchlist.
 
             Parameters:
                 account (:class:`~plexapi.myplex.MyPlexAccount`): Account to remove item from the watchlist.

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -989,28 +989,34 @@ class WriterMixin(EditTagsMixin):
 class WatchlistMixin(object):
     """ Mixin for Plex objects that can be added to a user's watchlist. """
 
-    def onWatchlist(self, account):
+    def onWatchlist(self, account=None):
         """ Returns True if the item is on the user's watchlist.
 
             Parameters:
-                account (:class:`~plexapi.myplex.MyPlexAccount`): Account to check item on the watchlist.
+                account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to check item on the watchlist.
+                   Note: This is required if you are not connected to a Plex server instance using the admin account.
         """
+        account = account or self._server.myPlexAccount()
         return account.onWatchlist(self)
 
-    def addToWatchlist(self, account):
+    def addToWatchlist(self, account=None):
         """ Add this item to the specified user's watchlist.
 
             Parameters:
-                account (:class:`~plexapi.myplex.MyPlexAccount`): Account to add item to the watchlist.
+                account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to add item to the watchlist.
+                   Note: This is required if you are not connected to a Plex server instance using the admin account.
         """
+        account = account or self._server.myPlexAccount()
         account.addToWatchlist(self)
 
-    def removeFromWatchlist(self, account):
+    def removeFromWatchlist(self, account=None):
         """ Remove this item from the specified user's watchlist.
 
             Parameters:
-                account (:class:`~plexapi.myplex.MyPlexAccount`): Account to remove item from the watchlist.
+                account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to remove item from the watchlist.
+                   Note: This is required if you are not connected to a Plex server instance using the admin account.
         """
+        account = account or self._server.myPlexAccount()
         account.removeFromWatchlist(self)
 
     def streamingServices(self, account=None):

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -1004,3 +1004,16 @@ class WatchlistMixin(object):
                 account (:class:`~plexapi.myplex.MyPlexAccount`): Account to remove item from the watchlist.
         """
         account.removeFromWatchlist(self)
+
+    def streamingServices(self, account=None):
+        """ Return a list of :class:`~plexapi.media.Availability`
+            objects for the available streaming services for this item.
+
+            Parameters:
+                account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account used to retrieve availability.
+                   Note: This is required if you are not connected to a Plex server instance using the admin account.
+        """
+        account = account or self._server.myPlexAccount()
+        ratingKey = self.guid.rsplit('/', 1)[-1]
+        data = account.query(f"{account.METADATA}/library/metadata/{ratingKey}/availabilities")
+        return self.findItems(data)

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -991,6 +991,7 @@ class WatchlistMixin(object):
 
     def onWatchlist(self, account=None):
         """ Returns True if the item is on the user's watchlist.
+            Also see :func:`~plexapi.myplex.MyPlexAccount.onWatchlist`.
 
             Parameters:
                 account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to check item on the watchlist.
@@ -1004,6 +1005,7 @@ class WatchlistMixin(object):
 
     def addToWatchlist(self, account=None):
         """ Add this item to the specified user's watchlist.
+            Also see :func:`~plexapi.myplex.MyPlexAccount.addToWatchlist`.
 
             Parameters:
                 account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to add item to the watchlist.
@@ -1017,6 +1019,7 @@ class WatchlistMixin(object):
 
     def removeFromWatchlist(self, account=None):
         """ Remove this item from the specified user's watchlist.
+            Also see :func:`~plexapi.myplex.MyPlexAccount.removeFromWatchlist`.
 
             Parameters:
                 account (:class:`~plexapi.myplex.MyPlexAccount`, optional): Account to remove item from the watchlist.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -77,8 +77,6 @@ class MyPlexAccount(PlexObject):
     LINK = 'https://plex.tv/api/v2/pins/link'                                                   # put
     # Hub sections
     VOD = 'https://vod.provider.plex.tv'                                                        # get
-    WEBSHOWS = 'https://webshows.provider.plex.tv'                                              # get
-    PODCASTS = 'https://podcasts.provider.plex.tv'                                              # get
     MUSIC = 'https://music.provider.plex.tv'                                                    # get
     METADATA = 'https://metadata.provider.plex.tv'
     # Key may someday switch to the following url. For now the current value works.
@@ -724,18 +722,6 @@ class MyPlexAccount(PlexObject):
         """ Returns a list of VOD Hub items :class:`~plexapi.library.Hub`
         """
         data = self.query(f'{self.VOD}/hubs')
-        return self.findItems(data)
-
-    def webShows(self):
-        """ Returns a list of Webshow Hub items :class:`~plexapi.library.Hub`
-        """
-        data = self.query(f'{self.WEBSHOWS}/hubs')
-        return self.findItems(data)
-
-    def podcasts(self):
-        """ Returns a list of Podcasts Hub items :class:`~plexapi.library.Hub`
-        """
-        data = self.query(f'{self.PODCASTS}/hubs')
         return self.findItems(data)
 
     def tidal(self):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -798,6 +798,8 @@ class MyPlexAccount(PlexObject):
             items = [items]
         
         for item in items:
+            if self.onWatchlist(item):
+                raise BadRequest('"%s" is already on the watchlist' % item.title)
             ratingKey = item.guid.rsplit('/', 1)[-1]
             self.query(f'{self.METADATA}/actions/addToWatchlist?ratingKey={ratingKey}', method=self._session.put)
 
@@ -812,6 +814,8 @@ class MyPlexAccount(PlexObject):
             items = [items]
         
         for item in items:
+            if not self.onWatchlist(item):
+                raise BadRequest('"%s" is not on the watchlist' % item.title)
             ratingKey = item.guid.rsplit('/', 1)[-1]
             self.query(f'{self.METADATA}/actions/removeFromWatchlist?ratingKey={ratingKey}', method=self._session.put)
 

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -72,13 +72,13 @@ class MyPlexAccount(PlexObject):
     REMOVEHOMEUSER = 'https://plex.tv/api/home/users/{userId}'                                  # delete
     SIGNIN = 'https://plex.tv/users/sign_in.xml'                                                # get with auth
     WEBHOOKS = 'https://plex.tv/api/v2/user/webhooks'                                           # get, post with data
-    OPTOUTS = 'https://plex.tv/api/v2/user/%(userUUID)s/settings/opt_outs'                      # get
+    OPTOUTS = 'https://plex.tv/api/v2/user/{userUUID}/settings/opt_outs'                        # get
     LINK = 'https://plex.tv/api/v2/pins/link'                                                   # put
     # Hub sections
-    VOD = 'https://vod.provider.plex.tv/'                                                       # get
-    WEBSHOWS = 'https://webshows.provider.plex.tv/'                                             # get
-    PODCASTS = 'https://podcasts.provider.plex.tv/'                                             # get
-    MUSIC = 'https://music.provider.plex.tv/'                                                   # get
+    VOD = 'https://vod.provider.plex.tv'                                                        # get
+    WEBSHOWS = 'https://webshows.provider.plex.tv'                                              # get
+    PODCASTS = 'https://podcasts.provider.plex.tv'                                              # get
+    MUSIC = 'https://music.provider.plex.tv'                                                    # get
     # Key may someday switch to the following url. For now the current value works.
     # https://plex.tv/api/v2/user?X-Plex-Token={token}&X-Plex-Client-Identifier={clientId}
     key = 'https://plex.tv/users/account'
@@ -708,40 +708,36 @@ class MyPlexAccount(PlexObject):
             hist.extend(conn.history(maxresults=maxresults, mindate=mindate, accountID=1))
         return hist
 
+    def onlineMediaSources(self):
+        """ Returns a list of user account Online Media Sources settings :class:`~plexapi.myplex.AccountOptOut`
+        """
+        url = self.OPTOUTS.format(userUUID=self.uuid)
+        elem = self.query(url)
+        return self.findItems(elem, cls=AccountOptOut, etag='optOut')
+
     def videoOnDemand(self):
         """ Returns a list of VOD Hub items :class:`~plexapi.library.Hub`
         """
-        req = requests.get(self.VOD + 'hubs/', headers={'X-Plex-Token': self._token})
-        elem = ElementTree.fromstring(req.text)
-        return self.findItems(elem)
+        data = self.query(f'{self.VOD}/hubs')
+        return self.findItems(data)
 
     def webShows(self):
         """ Returns a list of Webshow Hub items :class:`~plexapi.library.Hub`
         """
-        req = requests.get(self.WEBSHOWS + 'hubs/', headers={'X-Plex-Token': self._token})
-        elem = ElementTree.fromstring(req.text)
-        return self.findItems(elem)
+        data = self.query(f'{self.WEBSHOWS}/hubs')
+        return self.findItems(data)
 
     def podcasts(self):
         """ Returns a list of Podcasts Hub items :class:`~plexapi.library.Hub`
         """
-        req = requests.get(self.PODCASTS + 'hubs/', headers={'X-Plex-Token': self._token})
-        elem = ElementTree.fromstring(req.text)
-        return self.findItems(elem)
+        data = self.query(f'{self.PODCASTS}/hubs')
+        return self.findItems(data)
 
     def tidal(self):
         """ Returns a list of tidal Hub items :class:`~plexapi.library.Hub`
         """
-        req = requests.get(self.MUSIC + 'hubs/', headers={'X-Plex-Token': self._token})
-        elem = ElementTree.fromstring(req.text)
-        return self.findItems(elem)
-
-    def onlineMediaSources(self):
-        """ Returns a list of user account Online Media Sources settings :class:`~plexapi.myplex.AccountOptOut`
-        """
-        url = self.OPTOUTS % {'userUUID': self.uuid}
-        elem = self.query(url)
-        return self.findItems(elem, cls=AccountOptOut, etag='optOut')
+        data = self.query(f'{self.MUSIC}/hubs')
+        return self.findItems(data)
 
     def link(self, pin):
         """ Link a device to the account using a pin code.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -741,10 +741,45 @@ class MyPlexAccount(PlexObject):
         data = self.query(f'{self.MUSIC}/hubs')
         return self.findItems(data)
 
-    def watchlist(self):
-        """ Returns a list of :class:`~plexapi.video.Movie` and :class:`~plexapi.video.Show` items in the user's watchlist
+    def watchlist(self, filter=None, sort=None, libtype=None):
+        """ Returns a list of :class:`~plexapi.video.Movie` and :class:`~plexapi.video.Show` items in the user's watchlist.
+            Note: The objects returned are from Plex's online metadata. To get the matching item on a Plex server,
+            search for the media using the guid.
+
+            Parameters:
+                filter (str, optional): 'available' or 'released' to only return items that are available or released,
+                    otherwise return all items.
+                sort (str, optional): In the format ``field:dir``. Available fields are ``watchlistedAt`` (Added At),
+                    ``titleSort`` (Title), ``originallyAvailableAt`` (Release Date), or ``rating`` (Critic Rating).
+                    ``dir`` can be ``asc`` or ``desc``.
+                libtype (str, optional): 'movie' or 'show' to only return movies or shows, otherwise return all items.
+
+
+            Example:
+
+                .. code-block:: python
+
+                    # Watchlist for released movies sorted by critic rating in descending order
+                    watchlist = account.watchlist(filter='released', sort='rating:desc', libtype='movie')
+                    item = watchlist[0]  # First item in the watchlist
+
+                    # Search for the item on a Plex server
+                    result = plex.library.search(guid=item.guid, libtype=item.type)
+
         """
-        data = self.query(f'{self.METADATA}/library/sections/watchlist/all?includeCollections=1&includeExternalMedia=1')
+        params = {
+            'includeCollections': 1,
+            'includeExternalMedia': 1
+        }
+
+        if not filter:
+            filter = 'all'
+        if sort:
+            params['sort'] = sort
+        if libtype:
+            params['type'] = utils.searchType(libtype)
+
+        data = self.query(f'{self.METADATA}/library/sections/watchlist/{filter}', params=params)
         return self.findItems(data)
 
     def addToWatchlist(self, items):

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -850,10 +850,7 @@ class MyPlexAccount(PlexObject):
         data = self.query(f'{self.METADATA}/library/search', headers=headers, params=params)
         searchResults = data['MediaContainer'].get('SearchResult', [])
 
-        if not searchResults:
-            return []
-
-        xml = ['<MediaContainer>']
+        results = []
         for result in searchResults:
             metadata = result['Metadata']
             type = metadata['type']
@@ -864,11 +861,10 @@ class MyPlexAccount(PlexObject):
             else:
                 continue
             attrs = ''.join(f'{k}="{html.escape(str(v))}" ' for k, v in metadata.items())
-            xml.append(f'<{tag} {attrs}/>')
+            xml = f'<{tag} {attrs}/>'
+            results.append(self._manuallyLoadXML(xml))
 
-        xml.append('</MediaContainer>')
-        data = ElementTree.fromstring(''.join(xml))
-        return self.findItems(data)
+        return results
 
     def link(self, pin):
         """ Link a device to the account using a pin code.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -792,7 +792,8 @@ class MyPlexAccount(PlexObject):
                     objects to be added to the watchlist.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: When trying to add invalid media to the watchlist.
+                :exc:`~plexapi.exceptions.BadRequest`: When trying to add invalid or existing
+                    media to the watchlist.
         """
         if not isinstance(items, list):
             items = [items]
@@ -809,6 +810,10 @@ class MyPlexAccount(PlexObject):
             Parameters:
                 items (List): List of :class:`~plexapi.video.Movie` or :class:`~plexapi.video.Show`
                     objects to be added to the watchlist.
+
+            Raises:
+                :exc:`~plexapi.exceptions.BadRequest`: When trying to remove invalid or non-existing
+                    media to the watchlist.
         """
         if not isinstance(items, list):
             items = [items]

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -782,6 +782,17 @@ class MyPlexAccount(PlexObject):
         data = self.query(f'{self.METADATA}/library/sections/watchlist/{filter}', params=params)
         return self.findItems(data)
 
+    def onWatchlist(self, item):
+        """ Returns True if the item is on the user's watchlist.
+
+            Parameters:
+                item (:class:`~plexapi.video.Movie` or :class:`~plexapi.video.Show`): Item to check
+                    if it is on the user's watchlist.
+        """
+        ratingKey = item.guid.rsplit('/', 1)[-1]
+        data = self.query(f"{self.METADATA}/library/metadata/{ratingKey}/userState")
+        return bool(data.find('UserState').attrib.get('watchlistedAt'))
+
     def addToWatchlist(self, items):
         """ Add media items to the user's watchlist
 

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -77,7 +77,6 @@ class MyPlexAccount(PlexObject):
     # Hub sections
     VOD = 'https://vod.provider.plex.tv/'                                                       # get
     WEBSHOWS = 'https://webshows.provider.plex.tv/'                                             # get
-    NEWS = 'https://news.provider.plex.tv/'                                                     # get
     PODCASTS = 'https://podcasts.provider.plex.tv/'                                             # get
     MUSIC = 'https://music.provider.plex.tv/'                                                   # get
     # Key may someday switch to the following url. For now the current value works.
@@ -720,13 +719,6 @@ class MyPlexAccount(PlexObject):
         """ Returns a list of Webshow Hub items :class:`~plexapi.library.Hub`
         """
         req = requests.get(self.WEBSHOWS + 'hubs/', headers={'X-Plex-Token': self._token})
-        elem = ElementTree.fromstring(req.text)
-        return self.findItems(elem)
-
-    def news(self):
-        """ Returns a list of News Hub items :class:`~plexapi.library.Hub`
-        """
-        req = requests.get(self.NEWS + 'hubs/sections/all', headers={'X-Plex-Token': self._token})
         elem = ElementTree.fromstring(req.text)
         return self.findItems(elem)
 

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -745,11 +745,7 @@ class MyPlexAccount(PlexObject):
         """ Returns a list of :class:`~plexapi.video.Movie` and :class:`~plexapi.video.Show` items in the user's watchlist
         """
         data = self.query(f'{self.METADATA}/library/sections/watchlist/all?includeCollections=1&includeExternalMedia=1')
-        items = self.findItems(data)
-        for item in items:
-            # ratingKey for metadata.provider.plex.tv is the guid hash
-            item.ratingKey = item.guid.rsplit('/', 1)[-1]
-        return items
+        return self.findItems(data)
 
     def addToWatchlist(self, items):
         """ Add media items to the user's watchlist
@@ -765,7 +761,7 @@ class MyPlexAccount(PlexObject):
             items = [items]
         
         for item in items:
-            ratingKey = item.ratingKey if isinstance(item.ratingKey, str) else item.guid.rsplit('/', 1)[-1]
+            ratingKey = item.guid.rsplit('/', 1)[-1]
             self.query(f'{self.METADATA}/actions/addToWatchlist?ratingKey={ratingKey}', method=self._session.put)
 
     def removeFromWatchlist(self, items):
@@ -779,7 +775,7 @@ class MyPlexAccount(PlexObject):
             items = [items]
         
         for item in items:
-            ratingKey = item.ratingKey if isinstance(item.ratingKey, str) else item.guid.rsplit('/', 1)[-1]
+            ratingKey = item.guid.rsplit('/', 1)[-1]
             self.query(f'{self.METADATA}/actions/removeFromWatchlist?ratingKey={ratingKey}', method=self._session.put)
 
     def link(self, pin):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -10,7 +10,8 @@ from plexapi.mixins import (
     ArtUrlMixin, ArtMixin, BannerMixin, PosterUrlMixin, PosterMixin, ThemeUrlMixin, ThemeMixin,
     ContentRatingMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
     SummaryMixin, TaglineMixin, TitleMixin,
-    CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin
+    CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin,
+    WatchlistMixin
 )
 
 
@@ -280,7 +281,8 @@ class Movie(
     ArtMixin, PosterMixin, ThemeMixin,
     ContentRatingMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
     SummaryMixin, TaglineMixin, TitleMixin,
-    CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin
+    CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin,
+    WatchlistMixin
 ):
     """ Represents a single Movie.
 
@@ -394,7 +396,8 @@ class Show(
     ArtMixin, BannerMixin, PosterMixin, ThemeMixin,
     ContentRatingMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
     SummaryMixin, TaglineMixin, TitleMixin,
-    CollectionMixin, GenreMixin, LabelMixin
+    CollectionMixin, GenreMixin, LabelMixin,
+    WatchlistMixin
 ):
     """ Represents a single Show (including all seasons and episodes).
 

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -259,3 +259,36 @@ def test_myplex_plexpass_attributes(account_plexpass):
 
 def test_myplex_claimToken(account):
     assert account.claimToken().startswith("claim-")
+
+
+def test_myplex_watchlist(account, movie, show, artist):
+    assert not account.watchlist()
+
+    # Add to watchlist from account
+    account.addToWatchlist(movie)
+    assert movie in account.watchlist()
+
+    # Add to watchlist from object
+    show.addToWatchlist(account)
+    assert show in account.watchlist()
+
+    # Remove from watchlist from account
+    account.removeFromWatchlist(show)
+    assert show not in account.watchlist()
+
+    # Remove from watchlist from object
+    movie.removeFromWatchlist(account)
+    assert movie not in account.watchlist()
+
+    # Add multiple items to watchlist
+    account.addToWatchlist([movie, show])
+    watchlist = account.watchlist()
+    assert movie in watchlist and show in watchlist
+
+    # Remove multiple items from watchlist
+    account.removeFromWatchlist([movie, show])
+    watchlist = account.watchlist()
+    assert movie not in watchlist and show not in watchlist
+
+    with pytest.raises(BadRequest):
+        account.addToWatchlist(artist)

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -262,33 +262,41 @@ def test_myplex_claimToken(account):
 
 
 def test_myplex_watchlist(account, movie, show, artist):
+    # Need to match using guid because ratingKey is different
+    watchlist_guids = lambda: [i.guid for i in account.watchlist()]
+
     assert not account.watchlist()
 
     # Add to watchlist from account
     account.addToWatchlist(movie)
-    assert movie in account.watchlist()
+    assert movie.guid in watchlist_guids()
 
     # Add to watchlist from object
     show.addToWatchlist(account)
-    assert show in account.watchlist()
+    assert show.guid in watchlist_guids()
 
     # Remove from watchlist from account
     account.removeFromWatchlist(show)
-    assert show not in account.watchlist()
+    assert show.guid not in watchlist_guids()
 
     # Remove from watchlist from object
     movie.removeFromWatchlist(account)
-    assert movie not in account.watchlist()
+    assert movie.guid not in watchlist_guids()
 
     # Add multiple items to watchlist
     account.addToWatchlist([movie, show])
-    watchlist = account.watchlist()
-    assert movie in watchlist and show in watchlist
+    guids = watchlist_guids()
+    assert movie.guid in guids and show.guid in guids
+
+    # Filter and sort watchlist
+    watchlist = account.watchlist(filter='released', sort='titleSort', libtype='movie')
+    guids = [i.guid for i in watchlist]
+    assert movie.guid in guids and show.guid not in guids
 
     # Remove multiple items from watchlist
     account.removeFromWatchlist([movie, show])
-    watchlist = account.watchlist()
-    assert movie not in watchlist and show not in watchlist
+    guids = watchlist_guids()
+    assert movie.guid not in guids and show.guid not in guids
 
     with pytest.raises(BadRequest):
         account.addToWatchlist(artist)

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -262,31 +262,27 @@ def test_myplex_claimToken(account):
 
 
 def test_myplex_watchlist(account, movie, show, artist):
-    # Need to match using guid because ratingKey is different
-    watchlist_guids = lambda: [i.guid for i in account.watchlist()]
-
     assert not account.watchlist()
 
     # Add to watchlist from account
     account.addToWatchlist(movie)
-    assert movie.guid in watchlist_guids()
+    assert account.onWatchlist(movie)
 
     # Add to watchlist from object
     show.addToWatchlist(account)
-    assert show.guid in watchlist_guids()
+    assert show.onWatchlist(account)
 
     # Remove from watchlist from account
     account.removeFromWatchlist(show)
-    assert show.guid not in watchlist_guids()
+    assert not account.onWatchlist(show)
 
     # Remove from watchlist from object
     movie.removeFromWatchlist(account)
-    assert movie.guid not in watchlist_guids()
+    assert not movie.onWatchlist(account)
 
     # Add multiple items to watchlist
     account.addToWatchlist([movie, show])
-    guids = watchlist_guids()
-    assert movie.guid in guids and show.guid in guids
+    assert movie.onWatchlist(account) and show.onWatchlist(account)
 
     # Filter and sort watchlist
     watchlist = account.watchlist(filter='released', sort='titleSort', libtype='movie')
@@ -295,8 +291,8 @@ def test_myplex_watchlist(account, movie, show, artist):
 
     # Remove multiple items from watchlist
     account.removeFromWatchlist([movie, show])
-    guids = watchlist_guids()
-    assert movie.guid not in guids and show.guid not in guids
+    assert not movie.onWatchlist(account) and not show.onWatchlist(account)
 
+    # Test adding invalid item to watchlist
     with pytest.raises(BadRequest):
         account.addToWatchlist(artist)

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -289,9 +289,17 @@ def test_myplex_watchlist(account, movie, show, artist):
     guids = [i.guid for i in watchlist]
     assert movie.guid in guids and show.guid not in guids
 
+    # Test adding existing item to watchlist
+    with pytest.raises(BadRequest):
+        account.addToWatchlist(movie)
+
     # Remove multiple items from watchlist
     account.removeFromWatchlist([movie, show])
     assert not movie.onWatchlist(account) and not show.onWatchlist(account)
+
+    # Test removing non-existing item from watchlist
+    with pytest.raises(BadRequest):
+        account.removeFromWatchlist(movie)
 
     # Test adding invalid item to watchlist
     with pytest.raises(BadRequest):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -905,6 +905,11 @@ def test_video_Show_PlexWebURL(plex, show):
     assert quote_plus(show.key) in url
 
 
+@pytest.mark.authenticated
+def test_video_Show_streamingServices(show):
+    assert show.streamingServices()
+
+
 def test_video_Season(show):
     seasons = show.seasons()
     assert len(seasons) == 2


### PR DESCRIPTION
## Description

Adds new methods to retrieve a user's watchlist, as well as add/remove `Movie`/`Show` objects to/from the watchlist:
* `MyPlexAccount.watchlist()`
* `MyPlexAccount.onWatchlist(item)`
* `MyPlexAccount.addToWatchlist(items)`
* `MyPlexAccount.removeFromWatchlist(items)`
* `MyPlexAccount.searchDiscover(query)`

Adds `WatchlistMixin` to `Movie` and `Show` so that the object can be added/removed from the watchlist from the object.
* `Movie.onWatchlist(account)`
* `Movie.addToWatchlist(account)`
* `Movie.removeFromWatchlist(account)`
* `Show.onWatchlist(account)`
* `Show.addToWatchlist(account)`
* `Show.removeFromWatchlist(account)`

A list of streaming service `Availability` objects can be returned by using:
* `Movie.streamingServices()`
* `Show.streamingServices()`

Also removes the deprecated `MyPlexAccount.news()`, `webShows()`, and `podcasts()` methods.

Closes #923

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
