### PR TITLE
Add support for Plex guid in `LibrarySection.getGuid()`

### DIFF
--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -58,8 +58,12 @@ def test_library_section_get_movie(movies):
 
 
 def test_library_MovieSection_getGuid(movies, movie):
+    result = movies.getGuid(guid=movie.guid)
+    assert result == movie
     result = movies.getGuid(guid=movie.guids[0].id)
     assert result == movie
+    with pytest.raises(NotFound):
+        movies.getGuid(guid='plex://movie/abcdefg')
     with pytest.raises(NotFound):
         movies.getGuid(guid='imdb://tt00000000')
 


### PR DESCRIPTION
## Description

Allows searching a library by Plex guid using `LibrarySection.getGuid()`

Example:
```
LibrarySection.getGuid('plex://show/5d9c086c46115600200aa2fe')
```


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
