### PR TITLE
Fix `PlexServer.isBrowsable(path)` when running Plex API on a different OS

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -393,7 +393,6 @@ class PlexServer(PlexObject):
         """
         if isinstance(path, Path):
             path = path.path
-        path = os.path.normpath(path)
         paths = [p.path for p in self.browse(os.path.dirname(path), includeFiles=False)]
         return path in paths
 


### PR DESCRIPTION
## Description

Removes path normalization for `PlexServer.isBrowsable(path)` otherwise the path is incorrect when running Plex API on a different OS from the Plex server.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
