### PR TITLE
Allow disabling auto-reloading when accessing missing attributes

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -39,9 +39,6 @@ class PlexObject(object):
             data (ElementTree): Response from PlexServer used to build this object (optional).
             initpath (str): Relative path requested when retrieving specified `data` (optional).
             parent (:class:`~plexapi.base.PlexObject`): The parent object that this object is built from (optional).
-
-        Attributes:
-            autoReload (bool): Automatically reload the object when accessing a missing attribute. Default True.
     """
     TAG = None      # xml element tag
     TYPE = None     # xml element type
@@ -58,7 +55,7 @@ class PlexObject(object):
         self._details_key = self._buildDetailsKey()
         self._overwriteNone = True
         self._edits = None  # Save batch edits for a single API call
-        self.autoReload = True  # Automatically reload the object when accessing a missing attribute
+        self._autoReload = True  # Automatically reload the object when accessing a missing attribute
 
     def __repr__(self):
         uid = self._clean(self.firstAttr('_baseurl', 'key', 'id', 'playQueueID', 'uri'))
@@ -476,7 +473,7 @@ class PlexPartialObject(PlexObject):
         if attr.startswith('_'): return value
         if value not in (None, []): return value
         if self.isFullObject(): return value
-        if self.autoReload is False: return value
+        if self._autoReload is False: return value
         # Log the reload.
         clsname = self.__class__.__name__
         title = self.__dict__.get('title', self.__dict__.get('name'))

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -39,6 +39,9 @@ class PlexObject(object):
             data (ElementTree): Response from PlexServer used to build this object (optional).
             initpath (str): Relative path requested when retrieving specified `data` (optional).
             parent (:class:`~plexapi.base.PlexObject`): The parent object that this object is built from (optional).
+
+        Attributes:
+            autoReload (bool): Automatically reload the object when accessing a missing attribute. Default True.
     """
     TAG = None      # xml element tag
     TYPE = None     # xml element type
@@ -55,6 +58,7 @@ class PlexObject(object):
         self._details_key = self._buildDetailsKey()
         self._overwriteNone = True
         self._edits = None  # Save batch edits for a single API call
+        self.autoReload = True  # Automatically reload the object when accessing a missing attribute
 
     def __repr__(self):
         uid = self._clean(self.firstAttr('_baseurl', 'key', 'id', 'playQueueID', 'uri'))
@@ -472,6 +476,7 @@ class PlexPartialObject(PlexObject):
         if attr.startswith('_'): return value
         if value not in (None, []): return value
         if self.isFullObject(): return value
+        if self.autoReload is False: return value
         # Log the reload.
         clsname = self.__class__.__name__
         title = self.__dict__.get('title', self.__dict__.get('name'))

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -339,6 +339,10 @@ def test_video_Movie_isFullObject_and_reload(plex):
 
 def test_video_Movie_isPartialObject(movie):
     assert movie.isPartialObject()
+    movie.autoReload = False
+    assert movie.originalTitle is None
+    assert movie.isPartialObject()
+    movie.autoReload = True
 
 
 def test_video_Movie_media_delete(movie, patched_http_call):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -339,10 +339,10 @@ def test_video_Movie_isFullObject_and_reload(plex):
 
 def test_video_Movie_isPartialObject(movie):
     assert movie.isPartialObject()
-    movie.autoReload = False
+    movie._autoReload = False
     assert movie.originalTitle is None
     assert movie.isPartialObject()
-    movie.autoReload = True
+    movie._autoReload = True
 
 
 def test_video_Movie_media_delete(movie, patched_http_call):


### PR DESCRIPTION
## Description

Allows disabling auto-reloading when accessing missing attributes by setting `autoReload = False`.

Renames the previous `_autoReload` from #765 to `_overwriteNone` to be less confusing.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
