### PR TITLE
Make sure `PlexObject` private attributes are set before loading data

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -50,12 +50,12 @@ class PlexObject(object):
         self._initpath = initpath or self.key
         self._parent = weakref.ref(parent) if parent is not None else None
         self._details_key = None
+        self._overwriteNone = True  # Allow overwriting previous attribute values with `None` when manually reloading
+        self._autoReload = True  # Automatically reload the object when accessing a missing attribute
+        self._edits = None  # Save batch edits for a single API call
         if data is not None:
             self._loadData(data)
         self._details_key = self._buildDetailsKey()
-        self._overwriteNone = True
-        self._edits = None  # Save batch edits for a single API call
-        self._autoReload = True  # Automatically reload the object when accessing a missing attribute
 
     def __repr__(self):
         uid = self._clean(self.firstAttr('_baseurl', 'key', 'id', 'playQueueID', 'uri'))


### PR DESCRIPTION
## Description

In some cases loading object data checks some of the private flags in `PlexObject`. Make sure those private flags are set before loading data.

Fixes #945

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
