### PR TITLE
Minor improvements to fetching season/show

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -872,7 +872,7 @@ class Episode(
     def seasonNumber(self):
         """ Returns the episode's season number. """
         if self._seasonNumber is None:
-            self._seasonNumber = self.parentIndex if self.parentIndex else self.season().seasonNumber
+            self._seasonNumber = self.parentIndex if isinstance(self.parentIndex, int) else self.season().seasonNumber
         return utils.cast(int, self._seasonNumber)
 
     @property

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -702,7 +702,7 @@ class Season(
 
     def show(self):
         """ Return the season's :class:`~plexapi.video.Show`. """
-        return self.fetchItem(self.parentRatingKey)
+        return self.fetchItem(self.parentKey)
 
     def watched(self):
         """ Returns list of watched :class:`~plexapi.video.Episode` objects. """
@@ -901,7 +901,7 @@ class Episode(
 
     def show(self):
         """" Return the episode's :class:`~plexapi.video.Show`. """
-        return self.fetchItem(self.grandparentRatingKey)
+        return self.fetchItem(self.grandparentKey)
 
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """


### PR DESCRIPTION
## Description

* Check `parentIndex` is an integer for `Episode.seasonEpisode` to save an extra API call to `season()` for Season 0 (Specials).
* Use `parentKey` and `grandparentKey` to fetch a show to save string formatting with the rating key.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
