### PR TITLE
Add method to switch Plex Home users

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -65,6 +65,7 @@ class MyPlexAccount(PlexObject):
             _session (obj): Requests session object used to access this client.
     """
     FRIENDINVITE = 'https://plex.tv/api/servers/{machineId}/shared_servers'                     # post with data
+    HOMEUSERS = 'https://plex.tv/api/home/users'
     HOMEUSERCREATE = 'https://plex.tv/api/home/users?title={title}'                             # post with data
     EXISTINGUSER = 'https://plex.tv/api/home/users?invitedEmail={username}'                     # post with data
     FRIENDSERVERS = 'https://plex.tv/api/servers/{machineId}/shared_servers/{serverId}'         # put with data
@@ -381,6 +382,29 @@ class MyPlexAccount(PlexObject):
         user = user if isinstance(user, MyPlexUser) else self.user(user)
         url = self.REMOVEHOMEUSER.format(userId=user.id)
         return self.query(url, self._session.delete)
+
+    def switchHomeUser(self, user):
+        """ Returns a new :class:`~plexapi.myplex.MyPlexAccount` object switched to the given home user.
+
+            Parameters:
+                user (str): :class:`~plexapi.myplex.MyPlexUser`, username, or email of the home user to switch to.
+
+            Example:
+
+                .. code-block:: python
+
+                    from plexapi.myplex import MyPlexAccount
+                    # Login to a Plex Home account
+                    account = MyPlexAccount('<USERNAME>', '<PASSWORD>')
+                    # Switch to a different Plex Home user
+                    userAccount = account.switchHomeUser('Username')
+
+        """
+        user = user if isinstance(user, MyPlexUser) else self.user(user)
+        url = f'{self.HOMEUSERS}/{user.id}/switch'
+        data = self.query(url, self._session.post)
+        userToken = data.attrib.get('authenticationToken')
+        return MyPlexAccount(token=userToken)
 
     def acceptInvite(self, user):
         """ Accept a pending firend invite from the specified user.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -367,7 +367,8 @@ class MyPlexAccount(PlexObject):
         """ Remove the specified user from your friends.
 
             Parameters:
-                user (str): :class:`~plexapi.myplex.MyPlexUser`, username, or email of the user to be removed.
+                user (:class:`~plexapi.myplex.MyPlexUser` or str): :class:`~plexapi.myplex.MyPlexUser`,
+                    username, or email of the user to be removed.
         """
         user = user if isinstance(user, MyPlexUser) else self.user(user)
         url = self.FRIENDUPDATE.format(userId=user.id)
@@ -377,7 +378,8 @@ class MyPlexAccount(PlexObject):
         """ Remove the specified user from your home users.
 
             Parameters:
-                user (str): :class:`~plexapi.myplex.MyPlexUser`, username, or email of the user to be removed.
+                user (:class:`~plexapi.myplex.MyPlexUser` or str): :class:`~plexapi.myplex.MyPlexUser`,
+                    username, or email of the user to be removed.
         """
         user = user if isinstance(user, MyPlexUser) else self.user(user)
         url = self.REMOVEHOMEUSER.format(userId=user.id)
@@ -387,7 +389,8 @@ class MyPlexAccount(PlexObject):
         """ Returns a new :class:`~plexapi.myplex.MyPlexAccount` object switched to the given home user.
 
             Parameters:
-                user (str): :class:`~plexapi.myplex.MyPlexUser`, username, or email of the home user to switch to.
+                user (:class:`~plexapi.myplex.MyPlexUser` or str): :class:`~plexapi.myplex.MyPlexUser`,
+                    username, or email of the home user to switch to.
 
             Example:
 
@@ -410,7 +413,8 @@ class MyPlexAccount(PlexObject):
         """ Accept a pending firend invite from the specified user.
 
             Parameters:
-                user (str): :class:`~plexapi.myplex.MyPlexInvite`, username, or email of the friend invite to accept.
+                user (:class:`~plexapi.myplex.MyPlexInvite` or str): :class:`~plexapi.myplex.MyPlexInvite`,
+                    username, or email of the friend invite to accept.
         """
         invite = user if isinstance(user, MyPlexInvite) else self.pendingInvite(user, includeSent=False)
         params = {
@@ -425,7 +429,8 @@ class MyPlexAccount(PlexObject):
         """ Cancel a pending firend invite for the specified user.
 
             Parameters:
-                user (str): :class:`~plexapi.myplex.MyPlexInvite`, username, or email of the friend invite to cancel.
+                user (:class:`~plexapi.myplex.MyPlexInvite` or str): :class:`~plexapi.myplex.MyPlexInvite`,
+                    username, or email of the friend invite to cancel.
         """
         invite = user if isinstance(user, MyPlexInvite) else self.pendingInvite(user, includeReceived=False)
         params = {


### PR DESCRIPTION
## Description

Adds a new method `MyPlexAccount.switchHomeUser(user)` to switch Plex Home user accounts. The method returns a new `MyPlexAccount` object for the given Plex Home user.

Closes #957

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
