### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     url='https://github.com/pkkid/python-plexapi',
     packages=['plexapi'],
     install_requires=requirements,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     long_description=readme,
     keywords=['plex', 'api'],
     classifiers=[


### PR DESCRIPTION
## Description

Drops explicit support for Python 3.6.

Python 3.6 has been EOL since December 2021 and `requests` (a primary dependency) has dropped support with the [2.28.0 release](https://github.com/psf/requests/releases/tag/v2.28.0).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
