### PR TITLE
Add guids attribute to Artist, Album, and Track

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -146,6 +146,7 @@ class Artist(
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
             countries (List<:class:`~plexapi.media.Country`>): List country objects.
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
+            guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             key (str): API URL (/library/metadata/<ratingkey>).
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
             locations (List<str>): List of folder paths where the artist is found on disk.
@@ -163,6 +164,7 @@ class Artist(
         self.collections = self.findItems(data, media.Collection)
         self.countries = self.findItems(data, media.Country)
         self.genres = self.findItems(data, media.Genre)
+        self.guids = self.findItems(data, media.Guid)
         self.key = self.key.replace('/children', '')  # FIX_BUG_50
         self.labels = self.findItems(data, media.Label)
         self.locations = self.listAttrs(data, 'path', etag='Location')
@@ -253,6 +255,7 @@ class Album(
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
             formats (List<:class:`~plexapi.media.Format`>): List of format objects.
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
+            guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             key (str): API URL (/library/metadata/<ratingkey>).
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
             leafCount (int): Number of items in the album view.
@@ -280,6 +283,7 @@ class Album(
         self.collections = self.findItems(data, media.Collection)
         self.formats = self.findItems(data, media.Format)
         self.genres = self.findItems(data, media.Genre)
+        self.guids = self.findItems(data, media.Guid)
         self.key = self.key.replace('/children', '')  # FIX_BUG_50
         self.labels = self.findItems(data, media.Label)
         self.leafCount = utils.cast(int, data.attrib.get('leafCount'))
@@ -380,6 +384,7 @@ class Track(
             grandparentThumb (str): URL to album artist thumbnail image
                 (/library/metadata/<grandparentRatingKey>/thumb/<thumbid>).
             grandparentTitle (str): Name of the album artist for the track.
+            guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             originalTitle (str): The artist for the track.
@@ -412,6 +417,7 @@ class Track(
         self.grandparentTheme = data.attrib.get('grandparentTheme')
         self.grandparentThumb = data.attrib.get('grandparentThumb')
         self.grandparentTitle = data.attrib.get('grandparentTitle')
+        self.guids = self.findItems(data, media.Guid)
         self.labels = self.findItems(data, media.Label)
         self.media = self.findItems(data, media.Media)
         self.originalTitle = data.attrib.get('originalTitle')

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -871,7 +871,7 @@ class GuidTag(PlexObject):
     """ Base class for guid tags used only for Guids, as they contain only a string identifier
 
         Attributes:
-            id (id): The guid for external metadata sources (e.g. IMDB, TMDB, TVDB).
+            id (id): The guid for external metadata sources (e.g. IMDB, TMDB, TVDB, MBID).
     """
 
     def _loadData(self, data):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -17,7 +17,8 @@ def test_audio_Artist_attr(artist):
     if artist.countries:
         assert "United States of America" in [i.tag for i in artist.countries]
     # assert "Electronic" in [i.tag for i in artist.genres]
-    assert utils.is_string(artist.guid, gte=5)
+    assert artist.guid == "plex://artist/5d07bdaf403c64029060f8c4"
+    assert "mbid://069a1c1f-14eb-4d36-b0a0-77dffbd67713" in [i.id for i in artist.guids]
     assert artist.index == 1
     assert utils.is_metadata(artist._initpath)
     assert utils.is_metadata(artist.key)
@@ -144,6 +145,8 @@ def test_audio_Album_attrs(album):
         assert utils.is_art(album.art)
     assert isinstance(album.formats, list)
     assert isinstance(album.genres, list)
+    assert album.guid == "plex://album/5d07c7e5403c640290bb5bfc"
+    assert "mbid://80b4a679-a2a4-4d18-835d-3e081185d7ba" in [i.id for i in album.guids]
     assert album.index == 1
     assert utils.is_metadata(album._initpath)
     assert utils.is_metadata(album.key)
@@ -275,7 +278,8 @@ def test_audio_Track_attrs(album):
     if track.grandparentThumb:
         assert utils.is_thumb(track.grandparentThumb)
     assert track.grandparentTitle == "Broke For Free"
-    assert track.guid.startswith("mbid://") or track.guid.startswith("plex://track/")
+    assert track.guid == "plex://track/5d07e453403c6402907b80aa"
+    assert "mbid://6524bc2d-3f58-4afa-9e06-00a651f5d813" in [i.id for i in track.guids]
     assert track.hasSonicAnalysis is False
     assert track.index == 1
     assert track.trackNumber == track.index


### PR DESCRIPTION
## Description

Adds external MusicBrainz guids for `Artist`, `Album`, and `Track`.

Requires PMS 1.27.0.5897 for `<Guid>` tags.

https://forums.plex.tv/t/plex-media-server-forum-preview-for-music-metadata/785088
https://forums.plex.tv/t/plex-media-server/30447/510


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
