### PR TITLE
Remove check for playQueueType when adding items to a PlayQueue

### DIFF
--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -3,7 +3,7 @@ from urllib.parse import quote_plus
 
 from plexapi import utils
 from plexapi.base import PlexObject
-from plexapi.exceptions import BadRequest, Unsupported
+from plexapi.exceptions import BadRequest
 
 
 class PlayQueue(PlexObject):
@@ -191,7 +191,6 @@ class PlayQueue(PlexObject):
         path = "/playQueues{args}".format(args=utils.joinArgs(args))
         data = server.query(path, method=server._session.post)
         c = cls(server, data, initpath=path)
-        c.playQueueType = args["type"]
         c._server = server
         return c
 
@@ -227,7 +226,6 @@ class PlayQueue(PlexObject):
         path = f"/playQueues{utils.joinArgs(args)}"
         data = server.query(path, method=server._session.post)
         c = cls(server, data, initpath=path)
-        c.playQueueType = args["type"]
         c._server = server
         return c
 
@@ -250,14 +248,9 @@ class PlayQueue(PlexObject):
         args = {}
         if item.type == "playlist":
             args["playlistID"] = item.ratingKey
-            itemType = item.playlistType
         else:
             uuid = item.section().uuid
-            itemType = item.listType
             args["uri"] = "library://{uuid}/item{key}".format(uuid=uuid, key=item.key)
-
-        if itemType != self.playQueueType:
-            raise Unsupported("Item type does not match PlayQueue type")
 
         if playNext:
             args["next"] = 1

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -13,7 +13,7 @@ class PlayQueue(PlexObject):
         TAG (str): 'PlayQueue'
         TYPE (str): 'playqueue'
         identifier (str): com.plexapp.plugins.library
-        items (list): List of :class:`~plexapi.media.Media` or :class:`~plexapi.playlist.Playlist`
+        items (list): List of :class:`~plexapi.base.Playable` or :class:`~plexapi.playlist.Playlist`
         mediaTagPrefix (str): Fx /system/bundle/media/flags/
         mediaTagVersion (int): Fx 1485957738
         playQueueID (int): ID of the PlayQueue.
@@ -27,7 +27,7 @@ class PlayQueue(PlexObject):
         playQueueSourceURI (str): Original URI used to create the PlayQueue.
         playQueueTotalCount (int): How many items in the PlayQueue.
         playQueueVersion (int): Version of the PlayQueue. Increments every time a change is made to the PlayQueue.
-        selectedItem (:class:`~plexapi.media.Media`): Media object for the currently selected item.
+        selectedItem (:class:`~plexapi.base.Playable`): Media object for the currently selected item.
         _server (:class:`~plexapi.server.PlexServer`): PlexServer associated with the PlayQueue.
         size (int): Alias for playQueueTotalCount.
     """
@@ -150,9 +150,9 @@ class PlayQueue(PlexObject):
 
         Parameters:
             server (:class:`~plexapi.server.PlexServer`): Server you are connected to.
-            items (:class:`~plexapi.media.Media` or :class:`~plexapi.playlist.Playlist`):
+            items (:class:`~plexapi.base.Playable` or :class:`~plexapi.playlist.Playlist`):
                 A media item, list of media items, or Playlist.
-            startItem (:class:`~plexapi.media.Media`, optional):
+            startItem (:class:`~plexapi.base.Playable`, optional):
                 Media item in the PlayQueue where playback should begin.
             shuffle (int, optional): Start the playqueue shuffled.
             repeat (int, optional): Start the playqueue shuffled.
@@ -235,7 +235,7 @@ class PlayQueue(PlexObject):
         Items can only be added to the section immediately following the current playing item.
 
         Parameters:
-            item (:class:`~plexapi.media.Media` or :class:`~plexapi.playlist.Playlist`): Single media item or Playlist.
+            item (:class:`~plexapi.base.Playable` or :class:`~plexapi.playlist.Playlist`): Single media item or Playlist.
             playNext (bool, optional): If True, add this item to the front of the "Up Next" section.
                 If False, the item will be appended to the end of the "Up Next" section.
                 Only has an effect if an item has already been added to the "Up Next" section.


### PR DESCRIPTION
## Description

Removes the check for `playQueueType` when adding items to a `PlayQueue.` Mixed media types can be added to the same play queue.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
