### PR TITLE
Use /related endpoint for hubs

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -250,8 +250,9 @@ class HubsMixin:
     def hubs(self):
         """ Returns a list of :class:`~plexapi.library.Hub` objects. """
         from plexapi.library import Hub
-        data = self._server.query(self._details_key)
-        return self.findItems(data, Hub, rtag='Related')
+        key = f'{self.key}/related'
+        data = self._server.query(key)
+        return self.findItems(data, Hub)
 
 
 class RatingMixin:


### PR DESCRIPTION
## Description

Switch `HubsMixin.hubs()` to use the `{self.key}/related` endpoint to return more items by default and save an extra reload in some instances.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
