### PR TITLE
Fix `Artists.matches()` when searching by title

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -191,7 +191,7 @@ class UnmatchMatchMixin:
                     params['title'] = title
 
                 if year is None:
-                    params['year'] = self.year
+                    params['year'] = getattr(self, 'year', '')
                 else:
                     params['year'] = year
 


### PR DESCRIPTION
## Description

Fixes `AttributeError` when calling `Artists.matches(title)` since artists do not have a `year` attribute.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
