### PR TITLE
Add ability to toggle account view state syncing

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -77,6 +77,7 @@ class MyPlexAccount(PlexObject):
     WEBHOOKS = 'https://plex.tv/api/v2/user/webhooks'                                           # get, post with data
     OPTOUTS = 'https://plex.tv/api/v2/user/{userUUID}/settings/opt_outs'                        # get
     LINK = 'https://plex.tv/api/v2/pins/link'                                                   # put
+    VIEWSTATESYNC = 'https://plex.tv/api/v2/user/view_state_sync'                               # put
     # Hub sections
     VOD = 'https://vod.provider.plex.tv'                                                        # get
     MUSIC = 'https://music.provider.plex.tv'                                                    # get
@@ -903,6 +904,32 @@ class MyPlexAccount(PlexObject):
             results.append(self._manuallyLoadXML(xml))
 
         return self._toOnlineMetadata(results)
+
+    @property
+    def viewStateSync(self):
+        """ Returns True or False if syncing of watch state and ratings
+            is enabled or disabled, respectively, for the account.
+        """
+        headers = {'Accept': 'application/json'}
+        data = self.query(self.VIEWSTATESYNC, headers=headers)
+        return data.get('consent')
+
+    def enableViewStateSync(self):
+        """ Enable syncing of watch state and ratings for the account. """
+        self._updateViewStateSync(True)
+
+    def disableViewStateSync(self):
+        """ Disable syncing of watch state and ratings for the account. """
+        self._updateViewStateSync(False)
+
+    def _updateViewStateSync(self, consent):
+        """ Enable or disable syncing of watch state and ratings for the account.
+
+            Parameters:
+                consent (bool): True to enable, False to disable.
+        """
+        params = {'consent': consent}
+        self.query(self.VIEWSTATESYNC, method=self._session.put, params=params)
 
     def link(self, pin):
         """ Link a device to the account using a pin code.

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -318,3 +318,11 @@ def test_myplex_searchDiscover(account, movie, show):
     assert show.guid in [r.guid for r in results]
     results = account.searchDiscover(show.title, libtype="movie")
     assert show.guid not in guids(results)
+
+
+@pytest.mark.authenticated
+def test_myplex_viewStateSync(account):
+    account.enableViewStateSync()
+    assert account.viewStateSync is True
+    account.disableViewStateSync()
+    assert account.viewStateSync is False


### PR DESCRIPTION
## Description

* Adds new `MyPlexAccount.viewStateSync` property to determine if view state syncing is enabled/disabled for the account.
* Adds new methods `MyPlexAccount.enableViewStateSync()` and `MyPlexAccount.disableViewStateSync()` to enable and disable view state syncing for the account, respectively.

Ref: https://forums.plex.tv/t/sync-watch-state-and-ratings-announcement-feedback/800885


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
