### PR TITLE
Expose `callbackError` parameter in `PlexServer.startAlertListener()`

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -758,15 +758,17 @@ class PlexServer(PlexObject):
             notifications. These often include messages from Plex about media scans
             as well as updates to currently running Transcode Sessions.
 
-            NOTE: You need websocket-client installed in order to use this feature.
-            >> pip install websocket-client
+            Returns a new :class:`~plexapi.alert.AlertListener` object.
+
+            Note: ``websocket-client`` must be installed in order to use this feature.
+
+            .. code-block:: python
+
+                >> pip install websocket-client
 
             Parameters:
                 callback (func): Callback function to call on received messages.
                 callbackError (func): Callback function to call on errors.
-                
-                Both arguments match the ones passed to AlertListener (see that class
-                for details).
 
             Raises:
                 :exc:`~plexapi.exception.Unsupported`: Websocket-client not installed.

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -763,6 +763,10 @@ class PlexServer(PlexObject):
 
             Parameters:
                 callback (func): Callback function to call on received messages.
+                callbackError (func): Callback function to call on errors.
+                
+                Both arguments match the ones passed to AlertListener (see that class
+                for details).
 
             Raises:
                 :exc:`~plexapi.exception.Unsupported`: Websocket-client not installed.

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -753,7 +753,7 @@ class PlexServer(PlexObject):
         """ Returns a list of all active :class:`~plexapi.media.TranscodeSession` objects. """
         return self.fetchItems('/transcode/sessions')
 
-    def startAlertListener(self, callback=None):
+    def startAlertListener(self, callback=None, callbackError=None):
         """ Creates a websocket connection to the Plex Server to optionally receive
             notifications. These often include messages from Plex about media scans
             as well as updates to currently running Transcode Sessions.
@@ -767,7 +767,7 @@ class PlexServer(PlexObject):
             Raises:
                 :exc:`~plexapi.exception.Unsupported`: Websocket-client not installed.
         """
-        notifier = AlertListener(self, callback)
+        notifier = AlertListener(self, callback, callbackError)
         notifier.start()
         return notifier
 


### PR DESCRIPTION
This makes it easier to catch errors without separately instantiating an AlertListener

## Description

AlertListener got a callbackError parameter that is not exposed. This fixes that and makes it easier to catch connection errors.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
