### PR TITLE
Remove unused timeout parameter from preferred_connections doc string

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1219,7 +1219,6 @@ class MyPlexResource(PlexObject):
     def preferred_connections(
         self,
         ssl=None,
-        timeout=None,
         locations=DEFAULT_LOCATION_ORDER,
         schemes=DEFAULT_SCHEME_ORDER,
     ):
@@ -1231,7 +1230,6 @@ class MyPlexResource(PlexObject):
                 ssl (bool, optional): Set True to only connect to HTTPS connections. Set False to
                     only connect to HTTP connections. Set None (default) to connect to any
                     HTTP or HTTPS connection.
-                timeout (int, optional): The timeout in seconds to attempt each connection.
         """
         connections_dict = {location: {scheme: [] for scheme in schemes} for location in locations}
         for connection in self.connections:


### PR DESCRIPTION
## Description

Remove unused timeout parameter from `MyPlexResource.preferred_connections()` doc string.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
