### PR TITLE
Use pagination for `/all` endpoints

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -4,7 +4,7 @@ from urllib.parse import quote_plus
 
 from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject, PlexSession
-from plexapi.exceptions import BadRequest
+from plexapi.exceptions import BadRequest, NotFound
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, RatingMixin,
     ArtUrlMixin, ArtMixin, PosterUrlMixin, PosterMixin, ThemeMixin, ThemeUrlMixin,
@@ -181,13 +181,14 @@ class Artist(
             Parameters:
                 title (str): Title of the album to return.
         """
-        key = f"/library/sections/{self.librarySectionID}/all?artist.id={self.ratingKey}&type=9"
-        return self.fetchItem(key, Album, title__iexact=title)
+        try:
+            return self.section().search(title, libtype='album', filters={'artist.id': self.ratingKey})[0]
+        except IndexError:
+            raise NotFound(f"Unable to find album '{title}'") from None
 
     def albums(self, **kwargs):
         """ Returns a list of :class:`~plexapi.audio.Album` objects by the artist. """
-        key = f"/library/sections/{self.librarySectionID}/all?artist.id={self.ratingKey}&type=9"
-        return self.fetchItems(key, Album, **kwargs)
+        return self.section().search(libtype='album', filters={'artist.id': self.ratingKey}, **kwargs)
 
     def track(self, title=None, album=None, track=None):
         """ Returns the :class:`~plexapi.audio.Track` that matches the specified title.

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 from datetime import datetime
-from urllib.parse import quote, quote_plus, urlencode
+from urllib.parse import quote_plus, urlencode
 
 from plexapi import X_PLEX_CONTAINER_SIZE, log, media, utils
 from plexapi.base import OPERATORS, PlexObject
@@ -606,8 +606,10 @@ class LibrarySection(PlexObject):
             Raises:
                 :exc:`~plexapi.exceptions.NotFound`: The title is not found in the library.
         """
-        key = '/library/sections/%s/all?includeGuids=1&title=%s' % (self.key, quote(title, safe=''))
-        return self.fetchItem(key, title__iexact=title)
+        try:
+            return self.search(title)[0]
+        except IndexError:
+            raise NotFound(f"Unable to find item '{title}'") from None
 
     def getGuid(self, guid):
         """ Returns the media item with the specified external Plex, IMDB, TMDB, or TVDB ID.


### PR DESCRIPTION
## Description

PMS 1.28 displays the following warning message in the logs whenever the `/library/section/<librarySectionID>/all` endpoint is called without pagination using `X-Plex-Container-Size`.
```
Missing X-Plex-Container-Size header. This will fail with status code 400 in the future.
```

This changes `LibrarySection.get()`, `Artist.album()`, and `Artist.albums()` to use `LibrarySection.search()` which already has pagination implemented using the `/all` endpoint. A `NotFound` exception is re-raised where necessary to maintain the same behaviour as before.  There should be no impact for the user.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable (No changes to tests required)
