### PR TITLE
Add support for using `MediaTag` objects when editing tags

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -673,6 +673,10 @@ class MediaTag(PlexObject):
             thumb (str): URL to thumbnail image for :class:`~plexapi.media.Role` only.
     """
 
+    def __str__(self):
+        """ Returns the tag name. """
+        return self.tag
+
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
         self._data = data

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -497,8 +497,8 @@ class EditFieldMixin:
 
         """
         edits = {
-            '%s.value' % field: value or '',
-            '%s.locked' % field: 1 if locked else 0
+            f'{field}.value': value or '',
+            f'{field}.locked': 1 if locked else 0
         }
         edits.update(kwargs)
         return self._edit(**edits)
@@ -681,7 +681,7 @@ class EditTagsMixin:
 
             Parameters:
                 tag (str): Name of the tag to edit.
-                items (List<str>): List of tags to add or remove.
+                items (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags to add or remove.
                 locked (bool): True (default) to lock the tags, False to unlock the tags.
                 remove (bool): True to remove the tags in items.
 
@@ -696,9 +696,11 @@ class EditTagsMixin:
         if not isinstance(items, list):
             items = [items]
 
-        value = getattr(self, self._tagPlural(tag))
-        existing_tags = [t.tag for t in value if t and remove is False]
-        edits = self._tagHelper(self._tagSingular(tag), existing_tags + items, locked, remove)
+        if not remove:
+            tags = getattr(self, self._tagPlural(tag))
+            items = tags + items
+
+        edits = self._tagHelper(self._tagSingular(tag), items, locked, remove)
         edits.update(kwargs)
         return self._edit(**edits)
 
@@ -731,15 +733,15 @@ class EditTagsMixin:
             items = [items]
 
         data = {
-            '%s.locked' % tag: 1 if locked else 0
+            f'{tag}.locked': 1 if locked else 0
         }
 
         if remove:
-            tagname = '%s[].tag.tag-' % tag
-            data[tagname] = ','.join(items)
+            tagname = f'{tag}[].tag.tag-'
+            data[tagname] = ','.join([str(t) for t in items])
         else:
             for i, item in enumerate(items):
-                tagname = '%s[%s].tag.tag' % (tag, i)
+                tagname = f'{str(tag)}[{i}].tag.tag'
                 data[tagname] = item
 
         return data
@@ -752,7 +754,7 @@ class CollectionMixin(EditTagsMixin):
         """ Add a collection tag(s).
 
             Parameters:
-                collections (list): List of strings.
+                collections (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('collection', collections, locked=locked)
@@ -761,7 +763,7 @@ class CollectionMixin(EditTagsMixin):
         """ Remove a collection tag(s).
 
             Parameters:
-                collections (list): List of strings.
+                collections (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('collection', collections, locked=locked, remove=True)
@@ -774,7 +776,7 @@ class CountryMixin(EditTagsMixin):
         """ Add a country tag(s).
 
             Parameters:
-                countries (list): List of strings.
+                countries (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('country', countries, locked=locked)
@@ -783,7 +785,7 @@ class CountryMixin(EditTagsMixin):
         """ Remove a country tag(s).
 
             Parameters:
-                countries (list): List of strings.
+                countries (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('country', countries, locked=locked, remove=True)
@@ -796,7 +798,7 @@ class DirectorMixin(EditTagsMixin):
         """ Add a director tag(s).
 
             Parameters:
-                directors (list): List of strings.
+                directors (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('director', directors, locked=locked)
@@ -805,7 +807,7 @@ class DirectorMixin(EditTagsMixin):
         """ Remove a director tag(s).
 
             Parameters:
-                directors (list): List of strings.
+                directors (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('director', directors, locked=locked, remove=True)
@@ -818,7 +820,7 @@ class GenreMixin(EditTagsMixin):
         """ Add a genre tag(s).
 
             Parameters:
-                genres (list): List of strings.
+                genres (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('genre', genres, locked=locked)
@@ -827,7 +829,7 @@ class GenreMixin(EditTagsMixin):
         """ Remove a genre tag(s).
 
             Parameters:
-                genres (list): List of strings.
+                genres (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('genre', genres, locked=locked, remove=True)
@@ -840,7 +842,7 @@ class LabelMixin(EditTagsMixin):
         """ Add a label tag(s).
 
             Parameters:
-                labels (list): List of strings.
+                labels (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('label', labels, locked=locked)
@@ -849,7 +851,7 @@ class LabelMixin(EditTagsMixin):
         """ Remove a label tag(s).
 
             Parameters:
-                labels (list): List of strings.
+                labels (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('label', labels, locked=locked, remove=True)
@@ -862,7 +864,7 @@ class MoodMixin(EditTagsMixin):
         """ Add a mood tag(s).
 
             Parameters:
-                moods (list): List of strings.
+                moods (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('mood', moods, locked=locked)
@@ -871,7 +873,7 @@ class MoodMixin(EditTagsMixin):
         """ Remove a mood tag(s).
 
             Parameters:
-                moods (list): List of strings.
+                moods (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('mood', moods, locked=locked, remove=True)
@@ -884,7 +886,7 @@ class ProducerMixin(EditTagsMixin):
         """ Add a producer tag(s).
 
             Parameters:
-                producers (list): List of strings.
+                producers (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('producer', producers, locked=locked)
@@ -893,7 +895,7 @@ class ProducerMixin(EditTagsMixin):
         """ Remove a producer tag(s).
 
             Parameters:
-                producers (list): List of strings.
+                producers (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('producer', producers, locked=locked, remove=True)
@@ -906,7 +908,7 @@ class SimilarArtistMixin(EditTagsMixin):
         """ Add a similar artist tag(s).
 
             Parameters:
-                artists (list): List of strings.
+                artists (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('similar', artists, locked=locked)
@@ -915,7 +917,7 @@ class SimilarArtistMixin(EditTagsMixin):
         """ Remove a similar artist tag(s).
 
             Parameters:
-                artists (list): List of strings.
+                artists (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('similar', artists, locked=locked, remove=True)
@@ -928,7 +930,7 @@ class StyleMixin(EditTagsMixin):
         """ Add a style tag(s).
 
             Parameters:
-                styles (list): List of strings.
+                styles (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('style', styles, locked=locked)
@@ -937,7 +939,7 @@ class StyleMixin(EditTagsMixin):
         """ Remove a style tag(s).
 
             Parameters:
-                styles (list): List of strings.
+                styles (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('style', styles, locked=locked, remove=True)
@@ -950,7 +952,7 @@ class TagMixin(EditTagsMixin):
         """ Add a tag(s).
 
             Parameters:
-                tags (list): List of strings.
+                tags (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('tag', tags, locked=locked)
@@ -959,7 +961,7 @@ class TagMixin(EditTagsMixin):
         """ Remove a tag(s).
 
             Parameters:
-                tags (list): List of strings.
+                tags (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('tag', tags, locked=locked, remove=True)
@@ -972,7 +974,7 @@ class WriterMixin(EditTagsMixin):
         """ Add a writer tag(s).
 
             Parameters:
-                writers (list): List of strings.
+                writers (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('writer', writers, locked=locked)
@@ -981,7 +983,7 @@ class WriterMixin(EditTagsMixin):
         """ Remove a writer tag(s).
 
             Parameters:
-                writers (list): List of strings.
+                writers (List<str> or List<:class:`~plexapi.media.MediaTag`>): List of tags.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         return self.editTags('writer', writers, locked=locked, remove=True)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -96,17 +96,33 @@ def _test_mixins_tag(obj, attr, tag_method):
     field_name = obj._tagSingular(attr)
     _tags = lambda: [t.tag for t in getattr(obj, attr)]
     _fields = lambda: [f for f in obj.fields if f.name == field_name]
+
     # Check tag is not present to begin with
     tags = _tags()
     assert TEST_MIXIN_TAG not in tags
-    # Add tag and lock the field
+
+    # Add tag string and lock the field
     add_tag_method(TEST_MIXIN_TAG)
     obj.reload()
     tags = _tags()
     fields = _fields()
     assert TEST_MIXIN_TAG in tags
     assert fields and fields[0].locked
-    # Remove tag and unlock to field to restore the clean state
+
+    # Remove MediaTag object
+    mediaTag = next(t for t in getattr(obj, attr) if t.tag == TEST_MIXIN_TAG)
+    remove_tag_method(mediaTag)
+    obj.reload()
+    tags = _tags()
+    assert TEST_MIXIN_TAG not in tags
+
+    # Add MediaTag object
+    add_tag_method(mediaTag)
+    obj.reload()
+    tags = _tags()
+    assert TEST_MIXIN_TAG in tags
+
+    # Remove tag string and unlock to field to restore the clean state
     remove_tag_method(TEST_MIXIN_TAG, locked=False)
     obj.reload()
     tags = _tags()


### PR DESCRIPTION
## Description

Add support for using `MediaTag` objects when editing tags. Using tag strings is still supported.

#### Examples

Previously editing tags required providing the tag strings.
```py
>>> movie.genres
[<Genre:77:Drama>, <Genre:3070:Action>, <Genre:3952:Crime>, <Genre:79:Thriller>]
>>> movie.removeGenre([genre.tag for genre in movies.genres[2:]]).reload()
>>> movie.genres
[<Genre:77:Drama>, <Genre:3070:Action>]
```

Now it can be simplified by using the `MediaTag` objects directly.
```py
>>> movie.genres
[<Genre:77:Drama>, <Genre:3070:Action>, <Genre:3952:Crime>, <Genre:79:Thriller>]
>>> movie.removeGenre(movies.genres[2:]).reload()
>>> movie.genres
[<Genre:77:Drama>, <Genre:3070:Action>]
```

Or adding tags from another object.
```py
>>> tvshow.genres
[<Genre:154:Fantasy>]
>>> movie.genres
[<Genre:77:Drama>, <Genre:3070:Action>, <Genre:3952:Crime>, <Genre:79:Thriller>]
>>> movie.addGenre(tvshow.genres).reload()
>>> moive.genres
[<Genre:77:Drama>, <Genre:3070:Action>, <Genre:3952:Crime>, <Genre:79:Thriller>, <Genre:154:Fantasy>]
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
