### PR TITLE
Add edition support for movies

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -517,6 +517,19 @@ class ContentRatingMixin(EditFieldMixin):
         return self.editField('contentRating', contentRating, locked=locked)
 
 
+class EditionTitleMixin(EditFieldMixin):
+    """ Mixin for Plex objects that can have an edition title. """
+
+    def editEditionTitle(self, editionTitle, locked=True):
+        """ Edit the edition title. Plex Pass is required to edit this field.
+
+            Parameters:
+                editionTitle (str): The new value.
+                locked (bool): True (default) to lock the field, False to unlock the field.
+        """
+        return self.editField('editionTitle', editionTitle, locked=locked)
+
+
 class OriginallyAvailableMixin(EditFieldMixin):
     """ Mixin for Plex objects that can have an originally available date. """
 

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -414,6 +414,16 @@ class Movie(
         data = self._server.query(self._details_key)
         return self.findItems(data, media.Review, rtag='Video')
 
+    def editions(self):
+        """ Returns a list of :class:`~plexapi.video.Movie` objects
+            for other editions of the same movie.
+        """
+        filters = {
+            'guid': self.guid,
+            'id!': self.ratingKey
+        }
+        return self.section().search(filters=filters)
+
 
 @utils.registerPlexObject
 class Show(

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -8,7 +8,7 @@ from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, RatingMixin,
     ArtUrlMixin, ArtMixin, BannerMixin, PosterUrlMixin, PosterMixin, ThemeUrlMixin, ThemeMixin,
-    ContentRatingMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
+    ContentRatingMixin, EditionTitleMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
     SummaryMixin, TaglineMixin, TitleMixin,
     CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin,
     WatchlistMixin
@@ -303,7 +303,7 @@ class Movie(
     Video, Playable,
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, RatingMixin,
     ArtMixin, PosterMixin, ThemeMixin,
-    ContentRatingMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
+    ContentRatingMixin, EditionTitleMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
     SummaryMixin, TaglineMixin, TitleMixin,
     CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin,
     WatchlistMixin

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -322,6 +322,7 @@ class Movie(
             countries (List<:class:`~plexapi.media.Country`>): List of countries objects.
             directors (List<:class:`~plexapi.media.Director`>): List of director objects.
             duration (int): Duration of the movie in milliseconds.
+            editionTitle (str): The edition title of the movie (e.g. Director's Cut, Extended Edition, etc.).
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
             guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
@@ -362,6 +363,7 @@ class Movie(
         self.countries = self.findItems(data, media.Country)
         self.directors = self.findItems(data, media.Director)
         self.duration = utils.cast(int, data.attrib.get('duration'))
+        self.editionTitle = data.attrib.get('editionTitle')
         self.genres = self.findItems(data, media.Genre)
         self.guids = self.findItems(data, media.Guid)
         self.labels = self.findItems(data, media.Label)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -46,6 +46,10 @@ def edit_content_rating(obj):
     _test_mixins_field(obj, "contentRating", "ContentRating")
 
 
+def edit_edition_title(obj):
+    _test_mixins_field(obj, "editionTitle", "EditionTitle")
+
+
 def edit_originally_available(obj):
     _test_mixins_field(obj, "originallyAvailableAt", "OriginallyAvailable")
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -56,6 +56,7 @@ def test_video_Movie_attrs(movies):
     assert movie.chapterSource is None
     assert not movie.collections
     assert movie.contentRating in utils.CONTENTRATINGS
+    assert movie.editionTitle is None
     if movie.countries:
         assert "United States of America" in [i.tag for i in movie.countries]
     if movie.producers:
@@ -657,6 +658,13 @@ def test_video_Movie_mixins_fields(movie):
     test_mixins.edit_summary(movie)
     test_mixins.edit_tagline(movie)
     test_mixins.edit_title(movie)
+    with pytest.raises(BadRequest):
+        test_mixins.edit_edition_title(movie)
+
+
+@pytest.mark.authenticated
+def test_video_Movie_mixins_fields(movie):
+    test_mixins.edit_edition_title(movie)
 
 
 def test_video_Movie_mixins_tags(movie):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -577,6 +577,10 @@ def test_video_Movie_reviews(movies):
     assert review.text
 
 
+def test_video_Movie_editions(movie):
+    assert len(movie.editions()) == 0
+
+
 @pytest.mark.authenticated
 def test_video_Movie_extras(movies):
     movie = movies.get("Sita Sings The Blues")


### PR DESCRIPTION
## Description

* Adds the `editionTitle` attribute to `Movie` objects.
* Adds the `EditionTitleMixin` with the `editEditionTitle()` method to `Movie` objects.
* Adds the `editions()` method to `Movie` objects to return other editions of the same movie.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
