### PR TITLE
Add workflow dispatch to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,11 @@
 name: CI
 
 on:
+  workflow_dispatch: ~
+  pull_request: ~
   push:
     branches:
       - master
-  pull_request: ~
 
 env:
   CACHE_VERSION: 1


### PR DESCRIPTION
## Description

This allows us to manually trigger the CI workflow. e.g. to run the CI tests against a new PMS release without need to merge/push to master.

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
