### PR TITLE
Fix `searchDiscover` handling invalid results

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -886,7 +886,10 @@ class MyPlexAccount(PlexObject):
 
         data = self.query(f'{self.METADATA}/library/search', headers=headers, params=params)
         searchResults = data['MediaContainer'].get('SearchResults', [])
-        searchResult = next((s['SearchResult'] for s in searchResults if s.get('id') == 'external' and s.get('SearchResult')), [])
+        searchResult = next(
+            (s['SearchResult'] for s in searchResults if s.get('id') == 'external' and s.get('SearchResult')),
+            []
+        )
 
         results = []
         for result in searchResult:

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -886,10 +886,7 @@ class MyPlexAccount(PlexObject):
 
         data = self.query(f'{self.METADATA}/library/search', headers=headers, params=params)
         searchResults = data['MediaContainer'].get('SearchResults', [])
-        searchResult = next(
-            (s['SearchResult'] for s in searchResults if s.get('id') == 'external' and s.get('SearchResult')),
-            []
-        )
+        searchResult = next((s.get('SearchResult', []) for s in searchResults if s.get('id') == 'external'), [])
 
         results = []
         for result in searchResult:

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -886,7 +886,7 @@ class MyPlexAccount(PlexObject):
 
         data = self.query(f'{self.METADATA}/library/search', headers=headers, params=params)
         searchResults = data['MediaContainer'].get('SearchResults', [])
-        searchResult = next((s['SearchResult'] for s in searchResults if s.get('id') == 'external'), [])
+        searchResult = next((s['SearchResult'] for s in searchResults if s.get('id') == 'external' and s.get('SearchResult')), [])
 
         results = []
         for result in searchResult:


### PR DESCRIPTION
## Description

I've been seeing the Plex Discover Search API sometimes return some weird objects when there's no results. It looks like:

```python
[{'id': 'plex', 'title': 'Free On Demand', 'size': 0}, {'id': 'external', 'title': 'More Ways To Watch', 'size': 0}]
```

The second item trips up the current search result filtering because it's mark as an external id but doesn't actually contain any results. Then errors on trying to access the `'SearchResult'` key.

```
  File "/opt/hostedtoolcache/Python/3.10.6/x64/lib/python3.10/site-packages/plexapi/myplex.py", line 889, in searchDiscover
    searchResult = next((s['SearchResult'] for s in searchResults if s.get('id') == 'external'), [])
  File "/opt/hostedtoolcache/Python/3.10.6/x64/lib/python3.10/site-packages/plexapi/myplex.py", line 889, in <genexpr>
    searchResult = next((s['SearchResult'] for s in searchResults if s.get('id') == 'external'), [])
KeyError: 'SearchResult'
```

This change just adds to simple filter handling to ensure any returned result has a `'SearchResult'` key.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
