### PR TITLE
Add container size to seasons request to allow more than 20 to be pulled

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -558,7 +558,7 @@ class Show(
     def seasons(self, **kwargs):
         """ Returns a list of :class:`~plexapi.video.Season` objects in the show. """
         key = f'{self.key}/children?excludeAllLeaves=1'
-        return self.fetchItems(key, Season,container_size=self.childCount, **kwargs)
+        return self.fetchItems(key, Season, container_size=self.childCount, **kwargs)
 
     def episode(self, title=None, season=None, episode=None):
         """ Find a episode using a title or season and episode.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -557,8 +557,8 @@ class Show(
 
     def seasons(self, **kwargs):
         """ Returns a list of :class:`~plexapi.video.Season` objects in the show. """
-        key = f'{self.key}/children?excludeAllLeaves=1&X-Plex-Container-Size={self.childCount}'
-        return self.fetchItems(key, Season, **kwargs)
+        key = f'{self.key}/children?excludeAllLeaves=1'
+        return self.fetchItems(key, Season,container_size=self.childCount, **kwargs)
 
     def episode(self, title=None, season=None, episode=None):
         """ Find a episode using a title or season and episode.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -167,7 +167,7 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
             Example:
 
                 .. code-block:: python
-                
+
                 # Optimize for mobile using defaults
                 video.optimize(target="mobile")
 
@@ -557,7 +557,7 @@ class Show(
 
     def seasons(self, **kwargs):
         """ Returns a list of :class:`~plexapi.video.Season` objects in the show. """
-        key = f'{self.key}/children?excludeAllLeaves=1'
+        key = f'{self.key}/children?excludeAllLeaves=1&X-Plex-Container-Size={self.childCount}'
         return self.fetchItems(key, Season, **kwargs)
 
     def episode(self, title=None, season=None, episode=None):


### PR DESCRIPTION
## Description

Added `&X-Plex-Container-Size={self.childCount}` to seasons function in the Show class. This allows a user to pull all seasons for a shot in one call. Previously, this would be limited to the default container size (20).

Fixes #1018


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
