### PR TITLE
Fix library guid search

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1444,7 +1444,7 @@ class LibrarySection(PlexObject):
             * ``<<``: ``is before``
             * ``>>``: ``is after``
 
-            Type: *resolution*
+            Type: *resolution* or *guid*
 
             * no operator: ``is``
 


### PR DESCRIPTION
## Description

PMS 1.28.2.6151-914ddd2b3 no longer allows `guid!=` (`is not`) search.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
