### PR TITLE
Fix initializing Plex online metadata server multiple times

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -960,10 +960,12 @@ class MyPlexAccount(PlexObject):
         """ Convert a list of media objects to online metadata objects. """
         # TODO: Add proper support for metadata.provider.plex.tv
         # Temporary workaround to allow reloading and browsing of online media objects
+        server = PlexServer(self.METADATA, self._token)
+
         if not isinstance(objs, list):
             objs = [objs]
         for obj in objs:
-            obj._server = PlexServer(self.METADATA, self._token)
+            obj._server = server
 
             # Parse details key to modify query string
             url = urlsplit(obj._details_key)


### PR DESCRIPTION
## Description

Fix initializing Plex online metadata server multiple times when retrieving watchlist or Discover results.

Fixes #1026

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
