### PR TITLE
Remove sync tests from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,18 +175,6 @@ jobs:
           --cov=plexapi \
           tests 
 
-    - name: Sync tests with ${{ matrix.plex }} server
-      if: matrix.plex == 'claimed'
-      run: |
-        . venv/bin/activate
-        pytest \
-          -rxXs \
-          --tb=native \
-          --verbose \
-          --cov=plexapi \
-          --cov-append \
-          tests/test_sync.py
-
     - name: Unlink PMS from MyPlex account
       if: matrix.plex == 'claimed' && always()
       run: |


### PR DESCRIPTION
## Description

Mobile Sync is officially deprecated. Remove sync tests from CI.

https://forums.plex.tv/t/official-sunset-of-mobile-sync-as-of-2022-08-01/802430

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
