### PR TITLE
Add methods to change Plex Home PIN

### DIFF
--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from plexapi.exceptions import BadRequest, NotFound
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.myplex import MyPlexInvite
 
 from . import conftest as utils
@@ -331,3 +331,26 @@ def test_myplex_viewStateSync(account):
     assert account.viewStateSync is True
     account.disableViewStateSync()
     assert account.viewStateSync is False
+
+
+@pytest.mark.authenticated
+def test_myplex_pin(account, plex):
+    assert account.pin is None
+
+    account.setPin("0000")
+
+    with pytest.raises(Unauthorized):
+        account.setPin("1111")
+    account.setPin("1111", currentPin="0000")
+
+    with pytest.raises(Unauthorized):
+        account.removePin("1111")
+    account.removePin("1111")
+
+    homeuser = "Test PIN User"
+    try:
+        account.createHomeUser(homeuser, plex)
+        account.setManagedUserPin(homeuser, "0000")
+        account.removeManagedUserPin(homeuser)
+    finally:
+        account.removeHomeUser(homeuser)


### PR DESCRIPTION
## Description

Adds new methods to change an account's Plex Home PIN.
* `MyPlexAccount().setPin()`
* `MyPlexAccount().removePin()`
* `MyPlexAccount().setManagedUserPin()`
* `MyPlexAccount().removeManagedUserPin()`


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
