### PR TITLE
"repeat" should not be a boolean: 0, 1 or 2

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -621,7 +621,7 @@ class ClientTimeline(PlexObject):
         self.protocol = data.attrib.get('protocol')
         self.providerIdentifier = data.attrib.get('providerIdentifier')
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
-        self.repeat = utils.cast(bool, data.attrib.get('repeat'))
+        self.repeat = data.attrib.get('repeat')
         self.seekRange = data.attrib.get('seekRange')
         self.shuffle = utils.cast(bool, data.attrib.get('shuffle'))
         self.state = data.attrib.get('state')


### PR DESCRIPTION
## Description

The PlexAmp player has three modes:
- 0=off
- 1=repeatone
- 2=repeatall

When `plexapi` tries to create a `ClientTimeline` object it casts the `repeat` attribute to a `bool`. If the player is in repeat mode `2` (repeatall) `utils.cast()` throws a `ValueError` exception:

```
Traceback (most recent call last):
  File "/home/pi/plexapi-repeat.py", line 7, in <module>
    if client.isPlayingMedia(includePaused=False):
  File "/home/pi/.pyenv/versions/3.10.0/lib/python3.10/site-packages/PlexAPI-4.13.0-py3.10.egg/plexapi/client.py", line 594, in isPlayingMedia
  File "/home/pi/.pyenv/versions/3.10.0/lib/python3.10/site-packages/PlexAPI-4.13.0-py3.10.egg/plexapi/client.py", line 585, in timeline
  File "/home/pi/.pyenv/versions/3.10.0/lib/python3.10/site-packages/PlexAPI-4.13.0-py3.10.egg/plexapi/client.py", line 578, in timelines
  File "/home/pi/.pyenv/versions/3.10.0/lib/python3.10/site-packages/PlexAPI-4.13.0-py3.10.egg/plexapi/client.py", line 578, in <listcomp>
  File "/home/pi/.pyenv/versions/3.10.0/lib/python3.10/site-packages/PlexAPI-4.13.0-py3.10.egg/plexapi/base.py", line 56, in __init__
  File "/home/pi/.pyenv/versions/3.10.0/lib/python3.10/site-packages/PlexAPI-4.13.0-py3.10.egg/plexapi/client.py", line 624, in _loadData
  File "/home/pi/.pyenv/versions/3.10.0/lib/python3.10/site-packages/PlexAPI-4.13.0-py3.10.egg/plexapi/utils.py", line 145, in cast
ValueError: 2
```

The `PlexClient.setRepeat()` method is already documented to support all three modes and expects the input parameter to be an `int`.

## Type of change

This fix changes the type of the `ClientTimeline.repeat` attribute from `bool` to `int`.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
