### PR TITLE
Fix parsing settings enum

### DIFF
--- a/plexapi/settings.py
+++ b/plexapi/settings.py
@@ -139,7 +139,14 @@ class Setting(PlexObject):
         if not enumstr:
             return None
         if ':' in enumstr:
-            return {self._cast(k): v for k, v in [kv.split(':') for kv in enumstr.split('|')]}
+            d = {}
+            for kv in enumstr.split('|'):
+                try:
+                    k, v = kv.split(':')
+                    d[self._cast(k)] = v
+                except ValueError:
+                    d[self._cast(kv)] = kv
+            return d
         return enumstr.split('|')
 
     def set(self, value):


### PR DESCRIPTION
## Description

Fix parsing settings enum values when a `key:value` pair is missing. Assume that the key and value are equal.

Fixes #1056

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
