### PR TITLE
Factor out `playQueue()` method to `PlexPartialObject`

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -666,6 +666,13 @@ class PlexPartialObject(PlexObject):
         """
         return self._getWebURL(base=base)
 
+    def playQueue(self, *args, **kwargs):
+        """ Returns a new :class:`~plexapi.playqueue.PlayQueue` from this media item.
+            See :func:`~plexapi.playqueue.PlayQueue.create` for available parameters.
+        """
+        from plexapi.playqueue import PlayQueue
+        return PlayQueue.create(self._server, self, *args, **kwargs)
+
 
 class Playable:
     """ This is a general place to store functions specific to media that is Playable.

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -11,7 +11,6 @@ from plexapi.mixins import (
     ContentRatingMixin, SortTitleMixin, SummaryMixin, TitleMixin,
     LabelMixin
 )
-from plexapi.playqueue import PlayQueue
 from plexapi.utils import deprecated
 
 
@@ -426,10 +425,6 @@ class Collection(
     def delete(self):
         """ Delete the collection. """
         super(Collection, self).delete()
-
-    def playQueue(self, *args, **kwargs):
-        """ Returns a new :class:`~plexapi.playqueue.PlayQueue` from the collection. """
-        return PlayQueue.create(self._server, self.items(), *args, **kwargs)
 
     @classmethod
     def _create(cls, server, title, section, items):

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -7,7 +7,6 @@ from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection
 from plexapi.mixins import SmartFilterMixin, ArtMixin, PosterMixin
-from plexapi.playqueue import PlayQueue
 from plexapi.utils import deprecated
 
 
@@ -329,10 +328,6 @@ class Playlist(
     def delete(self):
         """ Delete the playlist. """
         self._server.query(self.key, method=self._server._session.delete)
-
-    def playQueue(self, *args, **kwargs):
-        """ Returns a new :class:`~plexapi.playqueue.PlayQueue` from the playlist. """
-        return PlayQueue.create(self._server, self, *args, **kwargs)
 
     @classmethod
     def _create(cls, server, title, items):

--- a/plexapi/playqueue.py
+++ b/plexapi/playqueue.py
@@ -150,8 +150,8 @@ class PlayQueue(PlexObject):
 
         Parameters:
             server (:class:`~plexapi.server.PlexServer`): Server you are connected to.
-            items (:class:`~plexapi.base.Playable` or :class:`~plexapi.playlist.Playlist`):
-                A media item, list of media items, or Playlist.
+            items (:class:`~plexapi.base.PlexPartialObject`):
+                A media item or a list of media items.
             startItem (:class:`~plexapi.base.Playable`, optional):
                 Media item in the PlayQueue where playback should begin.
             shuffle (int, optional): Start the playqueue shuffled.
@@ -174,16 +174,13 @@ class PlayQueue(PlexObject):
             uri_args = quote_plus(f"/library/metadata/{item_keys}")
             args["uri"] = f"library:///directory/{uri_args}"
             args["type"] = items[0].listType
-        elif items.type == "playlist":
-            args["type"] = items.playlistType
-            if items.radio:
-                args["uri"] = f"server://{server.machineIdentifier}/{server.library.identifier}{items.key}"
-            else:
-                args["playlistID"] = items.ratingKey
         else:
-            uuid = items.section().uuid
-            args["type"] = items.listType
-            args["uri"] = f"library://{uuid}/item/{items.key}"
+            if items.type == "playlist":
+                args["type"] = items.playlistType
+                args["playlistID"] = items.ratingKey
+            else:
+                args["type"] = items.listType
+            args["uri"] = f"server://{server.machineIdentifier}/{server.library.identifier}{items.key}"
 
         if startItem:
             args["key"] = startItem.key

--- a/tests/test_playqueue.py
+++ b/tests/test_playqueue.py
@@ -133,7 +133,6 @@ def test_create_playqueue_from_playlist(plex, album):
         playlist = plex.createPlaylist("test_playlist", items=album)
         pq = playlist.playQueue(shuffle=1)
         assert pq.playQueueShuffled is True
-        assert len(playlist) == len(album.tracks())
         assert len(pq) == len(playlist)
         pq.addItem(playlist)
         assert len(pq) == 2 * len(playlist)
@@ -146,8 +145,7 @@ def test_create_playqueue_from_collection(plex, music, album):
         collection = plex.createCollection("test_collection", music, album)
         pq = collection.playQueue(shuffle=1)
         assert pq.playQueueShuffled is True
-        assert len(collection) == len(album.tracks())
-        assert len(pq) == len(collection)
+        assert len(pq) == len(album.tracks())
         pq.addItem(collection.items()[0])
         assert len(pq) == len(collection) + 1
     finally:


### PR DESCRIPTION
## Description

Factor out the `playQueue()` method from `Playlist` and `Collection` to `PlexPartialObject`. This makes creating a `PlayQueue` more convenient from all media objects (movie, show, season, episode, artist, album, track, photo album, photo, playlist, and collection).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
