### PR TITLE
Add `Rating` media tag

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -898,6 +898,28 @@ class Guid(PlexObject):
 
 
 @utils.registerPlexObject
+class Rating(PlexObject):
+    """ Represents a single Rating media tag.
+
+        Attributes:
+            TAG (str): 'Rating'
+            image (str): The uri for the rating image
+                (e.g. ``imdb://image.rating``, ``rottentomatoes://image.rating.ripe``,
+                ``rottentomatoes://image.rating.upright``, ``themoviedb://image.rating``).
+            type (str): The type of rating (e.g. audience or critic).
+            value (float): The rating value.
+    """
+    TAG = 'Rating'
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        self._data = data
+        self.image = data.attrib.get('image')
+        self.type = data.attrib.get('type')
+        self.value = utils.cast(float, data.attrib.get('value'))
+
+
+@utils.registerPlexObject
 class Review(PlexObject):
     """ Represents a single Review for a Movie.
 

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -881,27 +881,20 @@ class Writer(MediaTag):
     FILTER = 'writer'
 
 
-class GuidTag(PlexObject):
-    """ Base class for guid tags used only for Guids, as they contain only a string identifier
+@utils.registerPlexObject
+class Guid(PlexObject):
+    """ Represents a single Guid media tag.
 
         Attributes:
+            TAG (str): 'Guid'
             id (id): The guid for external metadata sources (e.g. IMDB, TMDB, TVDB, MBID).
     """
+    TAG = 'Guid'
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
         self._data = data
         self.id = data.attrib.get('id')
-
-
-@utils.registerPlexObject
-class Guid(GuidTag):
-    """ Represents a single Guid media tag.
-
-        Attributes:
-            TAG (str): 'Guid'
-    """
-    TAG = 'Guid'
 
 
 @utils.registerPlexObject

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -672,6 +672,7 @@ class MediaTag(PlexObject):
             role (str): The name of the character role for :class:`~plexapi.media.Role` only.
             tag (str): Name of the tag. This will be Animation, SciFi etc for Genres. The name of
                 person for Directors and Roles (ex: Animation, Stephen Graham, etc).
+            tagKey (str): Plex GUID for the actor/actress for :class:`~plexapi.media.Role` only.
             thumb (str): URL to thumbnail image for :class:`~plexapi.media.Role` only.
     """
 
@@ -687,6 +688,7 @@ class MediaTag(PlexObject):
         self.key = data.attrib.get('key')
         self.role = data.attrib.get('role')
         self.tag = data.attrib.get('tag')
+        self.tagKey = data.attrib.get('tagKey')
         self.thumb = data.attrib.get('thumb')
 
         parent = self._parent()

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -903,7 +903,7 @@ class Review(PlexObject):
 
         Attributes:
             TAG (str): 'Review'
-            filter (str): filter for reviews?
+            filter (str): The library filter for the review.
             id (int): The ID of the review.
             image (str): The image uri for the review.
             link (str): The url to the online review.
@@ -978,18 +978,34 @@ class Chapter(PlexObject):
 
         Attributes:
             TAG (str): 'Chapter'
+            end (int): The end time of the chapter in milliseconds.
+            filter (str): The library filter for the chapter.
+            id (int): The ID of the chapter.
+            index (int): The index of the chapter.
+            tag (str): The name of the chapter.
+            title (str): The title of the chapter.
+            thumb (str): The URL to retrieve the chapter thumbnail.
+            start (int): The start time of the chapter in milliseconds.
     """
     TAG = 'Chapter'
 
+    def __repr__(self):
+        name = self._clean(self.firstAttr('tag'))
+        start = utils.millisecondToHumanstr(self._clean(self.firstAttr('start')))
+        end = utils.millisecondToHumanstr(self._clean(self.firstAttr('end')))
+        offsets = f'{start}-{end}'
+        return f"<{':'.join([self.__class__.__name__, name, offsets])}>"
+
     def _loadData(self, data):
         self._data = data
+        self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
+        self.filter = data.attrib.get('filter')
         self.id = utils.cast(int, data.attrib.get('id', 0))
-        self.filter = data.attrib.get('filter')  # I couldn't filter on it anyways
+        self.index = utils.cast(int, data.attrib.get('index'))
         self.tag = data.attrib.get('tag')
         self.title = self.tag
-        self.index = utils.cast(int, data.attrib.get('index'))
+        self.thumb = data.attrib.get('thumb')
         self.start = utils.cast(int, data.attrib.get('startTimeOffset'))
-        self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
 
 
 @utils.registerPlexObject
@@ -998,6 +1014,10 @@ class Marker(PlexObject):
 
         Attributes:
             TAG (str): 'Marker'
+            end (int): The end time of the marker in milliseconds.
+            id (int): The ID of the marker.
+            type (str): The type of marker.
+            start (int): The start time of the marker in milliseconds.
     """
     TAG = 'Marker'
 
@@ -1010,10 +1030,10 @@ class Marker(PlexObject):
 
     def _loadData(self, data):
         self._data = data
+        self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
         self.id = utils.cast(int, data.attrib.get('id'))
         self.type = data.attrib.get('type')
         self.start = utils.cast(int, data.attrib.get('startTimeOffset'))
-        self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
 
 
 @utils.registerPlexObject
@@ -1022,13 +1042,15 @@ class Field(PlexObject):
 
         Attributes:
             TAG (str): 'Field'
+            locked (bool): True if the field is locked.
+            name (str): The name of the field.
     """
     TAG = 'Field'
 
     def _loadData(self, data):
         self._data = data
-        self.name = data.attrib.get('name')
         self.locked = utils.cast(bool, data.attrib.get('locked'))
+        self.name = data.attrib.get('name')
 
 
 @utils.registerPlexObject

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -323,6 +323,7 @@ class Movie(
             producers (List<:class:`~plexapi.media.Producer`>): List of producers objects.
             rating (float): Movie critic rating (7.9; 9.8; 8.1).
             ratingImage (str): Key to critic rating image (rottentomatoes://image.rating.rotten).
+            ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
@@ -363,6 +364,7 @@ class Movie(
         self.producers = self.findItems(data, media.Producer)
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.ratingImage = data.attrib.get('ratingImage')
+        self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.similar = self.findItems(data, media.Similar)
         self.studio = data.attrib.get('studio')
@@ -459,6 +461,7 @@ class Show(
             originallyAvailableAt (datetime): Datetime the show was released.
             originalTitle (str): The original title of the show.
             rating (float): Show rating (7.9; 9.8; 8.1).
+            ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             showOrdering (str): Setting that indicates the episode ordering for the show
                 (None = Library default).
@@ -503,6 +506,7 @@ class Show(
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.originalTitle = data.attrib.get('originalTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
+        self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.showOrdering = data.attrib.get('showOrdering')
         self.similar = self.findItems(data, media.Similar)
@@ -639,6 +643,7 @@ class Season(
             parentTheme (str): URL to show theme resource (/library/metadata/<parentRatingkey>/theme/<themeid>).
             parentThumb (str): URL to show thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the show for the season.
+            ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             viewedLeafCount (int): Number of items marked as played in the season view.
             year (int): Year the season was released.
     """
@@ -663,6 +668,7 @@ class Season(
         self.parentTheme = data.attrib.get('parentTheme')
         self.parentThumb = data.attrib.get('parentThumb')
         self.parentTitle = data.attrib.get('parentTitle')
+        self.ratings = self.findItems(data, media.Rating)
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
 
@@ -800,6 +806,7 @@ class Episode(
             parentYear (int): Year the season was released.
             producers (List<:class:`~plexapi.media.Producer`>): List of producers objects.
             rating (float): Episode rating (7.9; 9.8; 8.1).
+            ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             skipParent (bool): True if the show's seasons are set to hidden.
             viewOffset (int): View offset in milliseconds.
@@ -845,6 +852,7 @@ class Episode(
         self.parentYear = utils.cast(int, data.attrib.get('parentYear'))
         self.producers = self.findItems(data, media.Producer)
         self.rating = utils.cast(float, data.attrib.get('rating'))
+        self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.skipParent = utils.cast(bool, data.attrib.get('skipParent', '0'))
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -52,6 +52,8 @@ def test_video_Movie_attrs(movies):
     assert movie.ratingImage == 'rottentomatoes://image.rating.ripe'
     assert utils.is_float(movie.audienceRating)
     assert movie.audienceRatingImage == 'rottentomatoes://image.rating.upright'
+    if movie.ratings:
+        assert "imdb://image.rating" in [i.image for i in movie.ratings]
     movie.reload()  # RELOAD
     assert movie.chapterSource is None
     assert not movie.collections
@@ -742,6 +744,8 @@ def test_video_Show_attrs(show):
     assert utils.is_datetime(show.originallyAvailableAt)
     assert show.originalTitle is None
     assert show.rating is None
+    if show.ratings:
+        assert "themoviedb://image.rating" in [i.image for i in show.ratings]
     assert utils.is_int(show.ratingKey)
     if show.roles:
         assert "Emilia Clarke" in [i.tag for i in show.roles]
@@ -964,6 +968,8 @@ def test_video_Season_attrs(show):
     if season.parentThumb:
         assert utils.is_thumb(season.parentThumb)
     assert season.parentTitle == "Game of Thrones"
+    if show.ratings:
+        assert "themoviedb://image.rating" in [i.image for i in show.ratings]
     assert utils.is_int(season.ratingKey)
     assert season._server._baseurl == utils.SERVER_BASEURL
     assert utils.is_string(season.summary, gte=100)
@@ -1156,6 +1162,8 @@ def test_video_Episode_attrs(episode):
     if episode.producers:
         assert episode.producers  # Test episode doesn't have producers
     assert episode.rating is None
+    if episode.ratings:
+        assert "themoviedb://image.rating" in [i.image for i in episode.ratings]
     assert utils.is_int(episode.ratingKey)
     if episode.roles:
         assert "Jason Momoa" in [i.tag for i in episode.roles]


### PR DESCRIPTION
## Description

* Adds  new `tagKey` attribute for `Role` objects (Plex GUID for the actor/actress).
* Adds new `Rating` media tag object.
* Adds new `ratings` attribute to `Movie`, `Show`, `Season`, and `Episode` objects.

Example `<Rating>` tags from Plex XML:
```xml
<Rating image="imdb://image.rating" value="9.0" type="audience"/>
<Rating image="rottentomatoes://image.rating.ripe" value="10.0" type="critic"/>
<Rating image="rottentomatoes://image.rating.upright" value="9.7" type="audience"/>
<Rating image="themoviedb://image.rating" value="8.5" type="audience"/>
```


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
