### PR TITLE
Use `cached_property` decorator

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -7,7 +7,7 @@ from plexapi import X_PLEX_CONTAINER_SIZE, log, media, utils
 from plexapi.base import OPERATORS, PlexObject
 from plexapi.exceptions import BadRequest, NotFound
 from plexapi.settings import Setting
-from plexapi.utils import deprecated
+from plexapi.utils import cached_property, deprecated
 
 
 class Library(PlexObject):
@@ -418,7 +418,6 @@ class LibrarySection(PlexObject):
         self._filterTypes = None
         self._fieldTypes = None
         self._totalViewSize = None
-        self._totalSize = None
         self._totalDuration = None
         self._totalStorage = None
 
@@ -456,12 +455,10 @@ class LibrarySection(PlexObject):
                 item.librarySectionID = librarySectionID
         return items
 
-    @property
+    @cached_property
     def totalSize(self):
         """ Returns the total number of items in the library for the default library type. """
-        if self._totalSize is None:
-            self._totalSize = self.totalViewSize(includeCollections=False)
-        return self._totalSize
+        return self.totalViewSize(includeCollections=False)
 
     @property
     def totalDuration(self):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -109,7 +109,6 @@ class PlexServer(PlexObject):
         self._showSecrets = CONFIG.get('log.show_secrets', '').lower() == 'true'
         self._session = session or requests.Session()
         self._timeout = timeout
-        self._settings = None   # cached settings
         self._myPlexAccount = None   # cached myPlexAccount
         self._systemAccounts = None   # cached list of SystemAccount
         self._systemDevices = None   # cached list of SystemDevice
@@ -183,13 +182,11 @@ class PlexServer(PlexObject):
             data = self.query('/library/sections/')
         return Library(self, data)
 
-    @property
+    @cached_property
     def settings(self):
         """ Returns a list of all server settings. """
-        if not self._settings:
-            data = self.query(Settings.key)
-            self._settings = Settings(self, data)
-        return self._settings
+        data = self.query(Settings.key)
+        return Settings(self, data)
 
     def account(self):
         """ Returns the :class:`~plexapi.server.Account` object this server belongs to. """

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -17,7 +17,7 @@ from plexapi.media import Conversion, Optimized
 from plexapi.playlist import Playlist
 from plexapi.playqueue import PlayQueue
 from plexapi.settings import Settings
-from plexapi.utils import deprecated
+from plexapi.utils import cached_property, deprecated
 from requests.status_codes import _codes as codes
 
 # Need these imports to populate utils.PLEXOBJECTS
@@ -109,7 +109,6 @@ class PlexServer(PlexObject):
         self._showSecrets = CONFIG.get('log.show_secrets', '').lower() == 'true'
         self._session = session or requests.Session()
         self._timeout = timeout
-        self._library = None   # cached library
         self._settings = None   # cached settings
         self._myPlexAccount = None   # cached myPlexAccount
         self._systemAccounts = None   # cached list of SystemAccount
@@ -173,19 +172,16 @@ class PlexServer(PlexObject):
     def _uriRoot(self):
         return f'server://{self.machineIdentifier}/com.plexapp.plugins.library'
 
-    @property
+    @cached_property
     def library(self):
         """ Library to browse or search your media. """
-        if not self._library:
-            try:
-                data = self.query(Library.key)
-                self._library = Library(self, data)
-            except BadRequest:
-                data = self.query('/library/sections/')
-                # Only the owner has access to /library
-                # so just return the library without the data.
-                return Library(self, data)
-        return self._library
+        try:
+            data = self.query(Library.key)
+        except BadRequest:
+            # Only the owner has access to /library
+            # so just return the library without the data.
+            data = self.query('/library/sections/')
+        return Library(self, data)
 
     @property
     def settings(self):

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -24,6 +24,11 @@ try:
 except ImportError:
     tqdm = None
 
+try:
+    from functools import cached_property
+except ImportError:
+    from backports.cached_property import cached_property  # noqa: F401
+
 log = logging.getLogger('plexapi')
 
 # Search Types - Plex uses these to filter specific media types when searching.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # pip install -r requirements.txt
 #---------------------------------------------------------
 requests
+backports.cached-property==1.0.2; python_version<="3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # pip install -r requirements.txt
 #---------------------------------------------------------
 requests
-backports.cached-property==1.0.2; python_version<="3.7"
+backports.cached-property; python_version<="3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@
 # PlexAPI requirements to run py.test.
 # pip install -r requirements_dev.txt
 #---------------------------------------------------------
+backports.cached-property==1.0.2; python_version<="3.7"
 coveralls==3.3.1
 flake8==5.0.4
 pillow==9.3.0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,7 +13,7 @@ def test_settings_set(plex):
     new_value = not old_value
     cd.set(new_value)
     plex.settings.save()
-    plex._settings = None
+    del plex.__dict__['settings']
     assert plex.settings.get("autoEmptyTrash").value == new_value
 
 
@@ -22,5 +22,5 @@ def test_settings_set_str(plex):
     new_value = 99
     cd.set(new_value)
     plex.settings.save()
-    plex._settings = None
+    del plex.__dict__['settings']
     assert plex.settings.get("OnDeckWindow").value == 99


### PR DESCRIPTION
<del>Fallback implementation from https://github.com/pydanny/cached-property</del>

Uses `functools.cached_property` or `backports.cached-property==1.0.2; python_version<="3.7"`

## Description

Adds decorator for the use:
- https://github.com/pkkid/python-plexapi/issues/1064

Adds use of the decorator

- [x] [def user(self): ](https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/base.py#L853)
- [x] [def library(self): ](https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/server.py#L177)
- [x] [def settings(self): ](https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/server.py#L191)
- [x] [def totalSize(self): ](https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/library.py#L460)
- [ ] [def totalDuration(self): ](https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/library.py#L467)
- [ ] [def totalStorage(self):](https://github.com/pkkid/python-plexapi/blob/3d3f9da5012428f5d703cf9f8e95f6aa10673ea6/plexapi/library.py#L474)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
