### PR TITLE
Fix: Inherit session when creating internal PlexServer objects

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1009,7 +1009,7 @@ class MyPlexAccount(PlexObject):
         """ Convert a list of media objects to online metadata objects. """
         # TODO: Add proper support for metadata.provider.plex.tv
         # Temporary workaround to allow reloading and browsing of online media objects
-        server = PlexServer(self.METADATA, self._token)
+        server = PlexServer(self.METADATA, self._token, session=self._session)
 
         if not isinstance(objs, list):
             objs = [objs]

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -318,7 +318,7 @@ class PlexServer(PlexObject):
         """
         if self._myPlexAccount is None:
             from plexapi.myplex import MyPlexAccount
-            self._myPlexAccount = MyPlexAccount(token=self._token)
+            self._myPlexAccount = MyPlexAccount(token=self._token, session=self._session)
         return self._myPlexAccount
 
     def _myPlexClientPorts(self):


### PR DESCRIPTION
## Description

To be able to use custom session like requests-cache

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
