### PR TITLE
Performance: Use `totalSize` attribute for watchlist walking

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -861,6 +861,11 @@ class MyPlexAccount(PlexObject):
             results += subresults[:maxresults - len(results)]
             params['X-Plex-Container-Start'] += params['X-Plex-Container-Size']
 
+            # totalSize is available in first response, update maxresults from it
+            totalSize = utils.cast(int, data.attrib.get('totalSize'))
+            if maxresults > totalSize:
+                maxresults = totalSize
+
         return self._toOnlineMetadata(results)
 
     def onWatchlist(self, item):


### PR DESCRIPTION
## Description

I noticed watchlist walking xml contains totalSize attribute. This could be used to know if next page should be fetched.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
