### PR TITLE
Allow overriding `includeUserState` for `_toOnlineMetadata`

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -861,7 +861,7 @@ class MyPlexAccount(PlexObject):
             results += subresults[:maxresults - len(results)]
             params['X-Plex-Container-Start'] += params['X-Plex-Container-Size']
 
-        return self._toOnlineMetadata(results)
+        return self._toOnlineMetadata(results, **kwargs)
 
     def onWatchlist(self, item):
         """ Returns True if the item is on the user's watchlist.

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1005,11 +1005,12 @@ class MyPlexAccount(PlexObject):
         data = {'code': pin}
         self.query(self.LINK, self._session.put, headers=headers, data=data)
 
-    def _toOnlineMetadata(self, objs):
+    def _toOnlineMetadata(self, objs, **kwargs):
         """ Convert a list of media objects to online metadata objects. """
         # TODO: Add proper support for metadata.provider.plex.tv
         # Temporary workaround to allow reloading and browsing of online media objects
         server = PlexServer(self.METADATA, self._token)
+        includeUserState = int(bool(kwargs.pop('includeUserState', True)))
 
         if not isinstance(objs, list):
             objs = [objs]
@@ -1019,7 +1020,7 @@ class MyPlexAccount(PlexObject):
             # Parse details key to modify query string
             url = urlsplit(obj._details_key)
             query = dict(parse_qsl(url.query))
-            query['includeUserState'] = 1
+            query['includeUserState'] = includeUserState
             query.pop('includeFields', None)
             obj._details_key = urlunsplit((url.scheme, url.netloc, url.path, urlencode(query), url.fragment))
 


### PR DESCRIPTION
## Description

Might not want `userState` in watchlist data, to be able to cache request longer.

```py
myplex.watchlist(includeUserState=0)
```

Turning it off, changes these attributes:
```diff
-               watchlistedAt="1668968787" viewedLeafCount="0"
+               userState="0"
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
