### PR TITLE
Fix: Remove bogus space from `searchDiscover` `limit` parameter

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -941,7 +941,7 @@ class MyPlexAccount(PlexObject):
         }
         params = {
             'query': query,
-            'limit ': limit,
+            'limit': limit,
             'searchTypes': libtype,
             'includeMetadata': 1
         }


### PR DESCRIPTION
## Description

Slipped in fba0dbcc

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
