### PR TITLE
Properly close file object in mixin uploads

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qsl, quote_plus, unquote, urlencode, urlsplit
 
 from plexapi import media, settings, utils
 from plexapi.exceptions import BadRequest, NotFound
-from plexapi.utils import deprecated
+from plexapi.utils import deprecated, openOrRead
 
 
 class AdvancedSettingsMixin:
@@ -341,14 +341,14 @@ class ArtMixin(ArtUrlMixin):
         
             Parameters:
                 url (str): The full URL to the image to upload.
-                filepath (str): The full file path the the image to upload.
+                filepath (str): The full file path the the image to upload or file-like object.
         """
         if url:
             key = f'/library/metadata/{self.ratingKey}/arts?url={quote_plus(url)}'
             self._server.query(key, method=self._server._session.post)
         elif filepath:
             key = f'/library/metadata/{self.ratingKey}/arts'
-            data = open(filepath, 'rb').read()
+            data = openOrRead(filepath)
             self._server.query(key, method=self._server._session.post, data=data)
         return self
 
@@ -392,14 +392,14 @@ class BannerMixin(BannerUrlMixin):
         
             Parameters:
                 url (str): The full URL to the image to upload.
-                filepath (str): The full file path the the image to upload.
+                filepath (str): The full file path the the image to upload or file-like object.
         """
         if url:
             key = f'/library/metadata/{self.ratingKey}/banners?url={quote_plus(url)}'
             self._server.query(key, method=self._server._session.post)
         elif filepath:
             key = f'/library/metadata/{self.ratingKey}/banners'
-            data = open(filepath, 'rb').read()
+            data = openOrRead(filepath)
             self._server.query(key, method=self._server._session.post, data=data)
         return self
 
@@ -448,14 +448,14 @@ class PosterMixin(PosterUrlMixin):
 
             Parameters:
                 url (str): The full URL to the image to upload.
-                filepath (str): The full file path the the image to upload.
+                filepath (str): The full file path the the image to upload or file-like object.
         """
         if url:
             key = f'/library/metadata/{self.ratingKey}/posters?url={quote_plus(url)}'
             self._server.query(key, method=self._server._session.post)
         elif filepath:
             key = f'/library/metadata/{self.ratingKey}/posters'
-            data = open(filepath, 'rb').read()
+            data = openOrRead(filepath)
             self._server.query(key, method=self._server._session.post, data=data)
         return self
 
@@ -501,14 +501,14 @@ class ThemeMixin(ThemeUrlMixin):
 
             Parameters:
                 url (str): The full URL to the theme to upload.
-                filepath (str): The full file path to the theme to upload.
+                filepath (str): The full file path to the theme to upload or file-like object.
         """
         if url:
             key = f'/library/metadata/{self.ratingKey}/themes?url={quote_plus(url)}'
             self._server.query(key, method=self._server._session.post)
         elif filepath:
             key = f'/library/metadata/{self.ratingKey}/themes'
-            data = open(filepath, 'rb').read()
+            data = openOrRead(filepath)
             self._server.query(key, method=self._server._session.post, data=data)
         return self
 

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -618,3 +618,10 @@ def toJson(obj, **kwargs):
             return obj.isoformat()
         return {k: v for k, v in obj.__dict__.items() if not k.startswith('_')}
     return json.dumps(obj, default=serialize, **kwargs)
+
+
+def openOrRead(file):
+    if hasattr(file, 'read'):
+        return file.read()
+    with open(file, 'rb') as f:
+        return f.read()


### PR DESCRIPTION
## Description

Properly close file objects in mixin upload methods.
* `uploadArt()`, `uploadBanner()`, `uploadPoster()`, `uploadTheme()`

Also support file-like objects for the `filepath` parameter (e.g.g `requests.Response.raw`).


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
