### PR TITLE
Add `pin` parameter to `switchHomeUser`

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -393,12 +393,13 @@ class MyPlexAccount(PlexObject):
         url = self.HOMEUSER.format(userId=user.id)
         return self.query(url, self._session.delete)
 
-    def switchHomeUser(self, user):
+    def switchHomeUser(self, user, pin=None):
         """ Returns a new :class:`~plexapi.myplex.MyPlexAccount` object switched to the given home user.
 
             Parameters:
                 user (:class:`~plexapi.myplex.MyPlexUser` or str): :class:`~plexapi.myplex.MyPlexUser`,
                     username, or email of the home user to switch to.
+                pin (str): PIN for the home user (required if the home user has a PIN set).
 
             Example:
 
@@ -413,9 +414,12 @@ class MyPlexAccount(PlexObject):
         """
         user = user if isinstance(user, MyPlexUser) else self.user(user)
         url = f'{self.HOMEUSERS}/{user.id}/switch'
-        data = self.query(url, self._session.post)
+        params = {}
+        if pin:
+            params['pin'] = pin
+        data = self.query(url, self._session.post, params=params)
         userToken = data.attrib.get('authenticationToken')
-        return MyPlexAccount(token=userToken)
+        return MyPlexAccount(token=userToken, session=self._session)
 
     def setPin(self, newPin, currentPin=None):
         """ Set a new Plex Home PIN for the account.


### PR DESCRIPTION
## Description

Add `pin` parameter to `MyPlexAccount.switchHomeUser()`.
* Admin can switch to any home user without knowing the PIN.
* Other home users can only switch by knowing the PIN.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
