### PR TITLE
Add convenience method to set default audio and subtitle streams

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -399,6 +399,10 @@ class AudioStream(MediaPartStream):
             self.peak = utils.cast(float, data.attrib.get('peak'))
             self.startRamp = data.attrib.get('startRamp')
 
+    def setDefault(self):
+        """ Sets this audio stream as the default audio stream. """
+        return self._parent().setDefaultAudioStream(self)
+
 
 @utils.registerPlexObject
 class SubtitleStream(MediaPartStream):
@@ -424,6 +428,10 @@ class SubtitleStream(MediaPartStream):
         self.format = data.attrib.get('format')
         self.headerCompression = data.attrib.get('headerCompression')
         self.transient = data.attrib.get('transient')
+
+    def setDefault(self):
+        """ Sets this subtitle stream as the default subtitle stream. """
+        return self._parent().setDefaultSubtitleStream(self)
 
 
 class LyricStream(MediaPartStream):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -101,6 +101,9 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
         """ Returns a list of :class:`~plexapi.media.AudioStream` objects for all MediaParts. """
         streams = []
 
+        if self.isPartialObject():
+            self.reload()
+
         parts = self.iterParts()
         for part in parts:
             streams += part.audioStreams()
@@ -109,6 +112,9 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
     def subtitleStreams(self):
         """ Returns a list of :class:`~plexapi.media.SubtitleStream` objects for all MediaParts. """
         streams = []
+
+        if self.isPartialObject():
+            self.reload()
 
         parts = self.iterParts()
         for part in parts:

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -97,6 +97,18 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
         """ Returns str, default title for a new syncItem. """
         return self.title
 
+    def videoStreams(self):
+        """ Returns a list of :class:`~plexapi.media.videoStream` objects for all MediaParts. """
+        streams = []
+
+        if self.isPartialObject():
+            self.reload()
+
+        parts = self.iterParts()
+        for part in parts:
+            streams += part.videoStreams()
+        return streams
+
     def audioStreams(self):
         """ Returns a list of :class:`~plexapi.media.AudioStream` objects for all MediaParts. """
         streams = []

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -382,8 +382,11 @@ def test_video_Movie_download(monkeydownload, tmpdir, movie):
     assert filename in with_resolution[0]
 
 
+def test_video_Movie_videoStreams(movie):
+    assert movie.videoStreams()
+
+    
 def test_video_Movie_audioStreams(movie):
-    movie.reload()
     assert movie.audioStreams()
 
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -400,14 +400,11 @@ def test_video_Movie_upload_select_remove_subtitle(movie, subtitle):
     filepath = os.path.realpath(subtitle.name)
 
     movie.uploadSubtitles(filepath)
-    movie.reload()
     subtitles = [sub.title for sub in movie.subtitleStreams()]
     subname = subtitle.name.rsplit(".", 1)[0]
     assert subname in subtitles
 
-    subtitleSelection = movie.subtitleStreams()[0]
-    parts = list(movie.iterParts())
-    parts[0].setDefaultSubtitleStream(subtitleSelection)
+    movie.subtitleStreams()[0].setDefault()
     movie.reload()
 
     subtitleSelection = movie.subtitleStreams()[0]


### PR DESCRIPTION
## Description

* Add a convenience method `Video.videoStreams()` to return all video streams.
* Auto-reload when accessing `Video.videoStreams()`, `Video.audioStreams()`, and `Video.subtitleStreams()`.
* Add a convenience methods to set audio streams or subtitle streams as default.

```python
# Simplified video.media[0].parts[0].setDefaultAudioStream(video.audioStreams()[0])
video.audioStreams()[0].setDefault()

# Simplified video.media[0].parts[0].setDefaultSubtitleStream(video.subtitleStreams()[0])
video.subtitleStreams()[0].setDefault()
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
