### PR TITLE
Add support for credit markers

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1037,7 +1037,7 @@ class Marker(PlexObject):
         Attributes:
             TAG (str): 'Marker'
             end (int): The end time of the marker in milliseconds.
-            final (bool): True if the marker is the final credit marker.
+            final (bool): True if the marker is the final credits marker.
             id (int): The ID of the marker.
             type (str): The type of marker.
             start (int): The start time of the marker in milliseconds.
@@ -1062,6 +1062,17 @@ class Marker(PlexObject):
 
         attributes = data.find('Attributes')
         self.version = attributes.attrib.get('version')
+
+    @property
+    def first(self):
+        """ Returns True if the marker in the first credits marker. """
+        if self.type != 'credits':
+            return None
+        first = min(
+            (marker for marker in self._parent().markers if marker.type == 'credits'),
+            key=lambda m: m.start
+        )
+        return first == self
 
 
 @utils.registerPlexObject

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1037,9 +1037,11 @@ class Marker(PlexObject):
         Attributes:
             TAG (str): 'Marker'
             end (int): The end time of the marker in milliseconds.
+            final (bool): True if the marker is the final credit marker.
             id (int): The ID of the marker.
             type (str): The type of marker.
             start (int): The start time of the marker in milliseconds.
+            version (int): The Plex marker version.
     """
     TAG = 'Marker'
 
@@ -1053,9 +1055,13 @@ class Marker(PlexObject):
     def _loadData(self, data):
         self._data = data
         self.end = utils.cast(int, data.attrib.get('endTimeOffset'))
+        self.final = utils.cast(bool, data.attrib.get('final'))
         self.id = utils.cast(int, data.attrib.get('id'))
         self.type = data.attrib.get('type')
         self.start = utils.cast(int, data.attrib.get('startTimeOffset'))
+
+        attributes = data.find('Attributes')
+        self.version = attributes.attrib.get('version')
 
 
 @utils.registerPlexObject

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -391,6 +391,11 @@ class Movie(
         return [part.file for part in self.iterParts() if part]
 
     @property
+    def hasCreditsMarker(self):
+        """ Returns True if the movie has a credits marker. """
+        return any(marker.type == 'credits' for marker in self.markers)
+
+    @property
     def hasPreviewThumbnails(self):
         """ Returns True if any of the media parts has generated preview (BIF) thumbnails. """
         return any(part.hasPreviewThumbnails for media in self.media for part in media.parts)
@@ -920,13 +925,18 @@ class Episode(
 
     @property
     def hasCommercialMarker(self):
-        """ Returns True if the episode has a commercial marker in the xml. """
+        """ Returns True if the episode has a commercial marker. """
         return any(marker.type == 'commercial' for marker in self.markers)
 
     @property
     def hasIntroMarker(self):
-        """ Returns True if the episode has an intro marker in the xml. """
+        """ Returns True if the episode has an intro marker. """
         return any(marker.type == 'intro' for marker in self.markers)
+
+    @property
+    def hasCreditsMarker(self):
+        """ Returns True if the episode has a credits marker. """
+        return any(marker.type == 'credits' for marker in self.markers)
 
     @property
     def hasPreviewThumbnails(self):

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -311,6 +311,7 @@ class Movie(
             directors (List<:class:`~plexapi.media.Director`>): List of director objects.
             duration (int): Duration of the movie in milliseconds.
             editionTitle (str): The edition title of the movie (e.g. Director's Cut, Extended Edition, etc.).
+            enableCreditsMarkerGeneration (int): Setting that indicates if credits markers detection is enabled.
             genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
             guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
@@ -353,6 +354,7 @@ class Movie(
         self.directors = self.findItems(data, media.Director)
         self.duration = utils.cast(int, data.attrib.get('duration'))
         self.editionTitle = data.attrib.get('editionTitle')
+        self.enableCreditsMarkerGeneration = utils.cast(int, data.attrib.get('enableCreditsMarkerGeneration', '-1'))
         self.genres = self.findItems(data, media.Genre)
         self.guids = self.findItems(data, media.Guid)
         self.labels = self.findItems(data, media.Label)
@@ -449,6 +451,7 @@ class Show(
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
             contentRating (str) Content rating (PG-13; NR; TV-G).
             duration (int): Typical duration of the show episodes in milliseconds.
+            enableCreditsMarkerGeneration (int): Setting that indicates if credits markers detection is enabled.
             episodeSort (int): Setting that indicates how episodes are sorted for the show
                 (-1 = Library default, 0 = Oldest first, 1 = Newest first).
             flattenSeasons (int): Setting that indicates if seasons are set to hidden for the show
@@ -498,6 +501,7 @@ class Show(
         self.collections = self.findItems(data, media.Collection)
         self.contentRating = data.attrib.get('contentRating')
         self.duration = utils.cast(int, data.attrib.get('duration'))
+        self.enableCreditsMarkerGeneration = utils.cast(int, data.attrib.get('enableCreditsMarkerGeneration', '-1'))
         self.episodeSort = utils.cast(int, data.attrib.get('episodeSort', '-1'))
         self.flattenSeasons = utils.cast(int, data.attrib.get('flattenSeasons', '-1'))
         self.genres = self.findItems(data, media.Genre)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -59,6 +59,7 @@ def test_video_Movie_attrs(movies):
     assert not movie.collections
     assert movie.contentRating in utils.CONTENTRATINGS
     assert movie.editionTitle is None
+    assert movie.enableCreditsMarkerGeneration == -1
     if movie.countries:
         assert "United States of America" in [i.tag for i in movie.countries]
     if movie.producers:
@@ -724,6 +725,7 @@ def test_video_Show_attrs(show):
     assert show.audienceRatingImage == "themoviedb://image.rating"
     assert show.autoDeletionItemPolicyUnwatchedLibrary == 0
     assert show.autoDeletionItemPolicyWatchedLibrary == 0
+    assert show.enableCreditsMarkerGeneration == -1
     assert show.episodeSort == -1
     assert show.flattenSeasons == -1
     assert "Drama" in [i.tag for i in show.genres]

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -502,6 +502,7 @@ if __name__ == "__main__":
     # These tasks won't work on the test server since we are using fake media files
     if not opts.unclaimed and account and account.subscriptionActive:
         server.settings.get("GenerateIntroMarkerBehavior").set("never")
+        server.settings.get("GenerateCreditsMarkerBehavior").set("never")
     server.settings.get("GenerateBIFBehavior").set("never")
     server.settings.get("GenerateChapterThumbBehavior").set("never")
     server.settings.get("LoudnessAnalysisBehavior").set("never")


### PR DESCRIPTION
## Description

Add support for credit markers.

Ref: https://forums.plex.tv/t/forum-preview-credits-detection-for-plex-media-server/822998

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
