### PR TITLE
Fix unable to remove tags with special characters

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
-from urllib.parse import parse_qsl, quote_plus, unquote, urlencode, urlsplit
+from urllib.parse import parse_qsl, quote, quote_plus, unquote, urlencode, urlsplit
 
 from plexapi import media, settings, utils
 from plexapi.exceptions import BadRequest, NotFound
@@ -804,7 +804,7 @@ class EditTagsMixin:
 
         if remove:
             tagname = f'{tag}[].tag.tag-'
-            data[tagname] = ','.join([str(t) for t in items])
+            data[tagname] = ','.join([quote(str(t)) for t in items])
         else:
             for i, item in enumerate(items):
                 tagname = f'{str(tag)}[{i}].tag.tag'

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -8,7 +8,7 @@ from . import conftest as utils
 
 TEST_MIXIN_FIELD = "Test Field"
 TEST_MIXIN_DATE = utils.MIN_DATETIME
-TEST_MIXIN_TAG = "Test Tag"
+TEST_MIXIN_TAG = "Test Tag !@#$%^&*()-_=+[];:'\"/?,."
 CUTE_CAT_SHA1 = "9f7003fc401761d8e0b0364d428b2dab2f789dbb"
 AUDIO_STUB_SHA1 = "1abc20d5fdc904201bf8988ca6ef30f96bb73617"
 


### PR DESCRIPTION
## Description

Removing tags requires the tag values to be URL encoded twice.
* e.g. `"," --> "%2C" --> "%252C"`

Fixes #1101

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
