### PR TITLE
Add support for editing `addedAt` field

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -8,14 +8,14 @@ from plexapi.exceptions import BadRequest, NotFound
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
     ArtUrlMixin, ArtMixin, PosterUrlMixin, PosterMixin, ThemeMixin, ThemeUrlMixin,
-    OriginallyAvailableMixin, SortTitleMixin, StudioMixin, SummaryMixin, TitleMixin,
+    AddedAtMixin, OriginallyAvailableMixin, SortTitleMixin, StudioMixin, SummaryMixin, TitleMixin,
     TrackArtistMixin, TrackDiscNumberMixin, TrackNumberMixin,
     CollectionMixin, CountryMixin, GenreMixin, LabelMixin, MoodMixin, SimilarArtistMixin, StyleMixin
 )
 from plexapi.playlist import Playlist
 
 
-class Audio(PlexPartialObject, PlayedUnplayedMixin):
+class Audio(PlexPartialObject, PlayedUnplayedMixin, AddedAtMixin):
     """ Base class for all audio objects including :class:`~plexapi.audio.Artist`,
         :class:`~plexapi.audio.Album`, and :class:`~plexapi.audio.Track`.
 

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -8,7 +8,7 @@ from plexapi.library import LibrarySection, ManagedHub
 from plexapi.mixins import (
     AdvancedSettingsMixin, SmartFilterMixin, HubsMixin, RatingMixin,
     ArtMixin, PosterMixin, ThemeMixin,
-    ContentRatingMixin, SortTitleMixin, SummaryMixin, TitleMixin,
+    AddedAtMixin, ContentRatingMixin, SortTitleMixin, SummaryMixin, TitleMixin,
     LabelMixin
 )
 from plexapi.utils import deprecated
@@ -19,7 +19,7 @@ class Collection(
     PlexPartialObject,
     AdvancedSettingsMixin, SmartFilterMixin, HubsMixin, RatingMixin,
     ArtMixin, PosterMixin, ThemeMixin,
-    ContentRatingMixin, SortTitleMixin, SummaryMixin, TitleMixin,
+    AddedAtMixin, ContentRatingMixin, SortTitleMixin, SummaryMixin, TitleMixin,
     LabelMixin
 ):
     """ Represents a single Collection.

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -557,6 +557,24 @@ class EditFieldMixin:
         return self._edit(**edits)
 
 
+class AddedAtMixin(EditFieldMixin):
+    """ Mixin for Plex objects that can have an added at date. """
+
+    def editAddedAt(self, addedAt, locked=True):
+        """ Edit the added at date.
+
+            Parameters:
+                addedAt (int or str or datetime): The new value as a unix timestamp (int),
+                    "YYYY-MM-DD" (str), or datetime object.
+                locked (bool): True (default) to lock the field, False to unlock the field.
+        """
+        if isinstance(addedAt, str):
+            addedAt = int(round(datetime.strptime(addedAt, '%Y-%m-%d').timestamp()))
+        elif isinstance(addedAt, datetime):
+            addedAt = int(round(addedAt.timestamp()))
+        return self.editField('addedAt', addedAt, locked=locked)
+
+
 class ContentRatingMixin(EditFieldMixin):
     """ Mixin for Plex objects that can have a content rating. """
 
@@ -590,7 +608,7 @@ class OriginallyAvailableMixin(EditFieldMixin):
         """ Edit the originally available date.
 
             Parameters:
-                originallyAvailable (str or datetime): The new value (YYYY-MM-DD) or datetime object.
+                originallyAvailable (str or datetime): The new value "YYYY-MM-DD (str) or datetime object.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         if isinstance(originallyAvailable, datetime):
@@ -726,7 +744,7 @@ class PhotoCapturedTimeMixin(EditFieldMixin):
         """ Edit the photo captured time.
 
             Parameters:
-                capturedTime (str or datetime): The new value (YYYY-MM-DD hh:mm:ss) or datetime object.
+                capturedTime (str or datetime): The new value "YYYY-MM-DD hh:mm:ss" (str) or datetime object.
                 locked (bool): True (default) to lock the field, False to unlock the field.
         """
         if isinstance(capturedTime, datetime):

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -8,7 +8,7 @@ from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     RatingMixin,
     ArtUrlMixin, ArtMixin, PosterUrlMixin, PosterMixin,
-    SortTitleMixin, SummaryMixin, TitleMixin, PhotoCapturedTimeMixin,
+    AddedAtMixin, SortTitleMixin, SummaryMixin, TitleMixin, PhotoCapturedTimeMixin,
     TagMixin
 )
 
@@ -18,7 +18,7 @@ class Photoalbum(
     PlexPartialObject,
     RatingMixin,
     ArtMixin, PosterMixin,
-    SortTitleMixin, SummaryMixin, TitleMixin
+    AddedAtMixin, SortTitleMixin, SummaryMixin, TitleMixin
 ):
     """ Represents a single Photoalbum (collection of photos).
 
@@ -146,7 +146,7 @@ class Photo(
     PlexPartialObject, Playable,
     RatingMixin,
     ArtUrlMixin, PosterUrlMixin,
-    PhotoCapturedTimeMixin, SortTitleMixin, SummaryMixin, TitleMixin,
+    AddedAtMixin, PhotoCapturedTimeMixin, SortTitleMixin, SummaryMixin, TitleMixin,
     TagMixin
 ):
     """ Represents a single Photo.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -8,14 +8,14 @@ from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
     ArtUrlMixin, ArtMixin, BannerMixin, PosterUrlMixin, PosterMixin, ThemeUrlMixin, ThemeMixin,
-    ContentRatingMixin, EditionTitleMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin, StudioMixin,
-    SummaryMixin, TaglineMixin, TitleMixin,
+    AddedAtMixin, ContentRatingMixin, EditionTitleMixin, OriginallyAvailableMixin, OriginalTitleMixin, SortTitleMixin,
+    StudioMixin, SummaryMixin, TaglineMixin, TitleMixin,
     CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin,
     WatchlistMixin
 )
 
 
-class Video(PlexPartialObject, PlayedUnplayedMixin):
+class Video(PlexPartialObject, PlayedUnplayedMixin, AddedAtMixin):
     """ Base class for all video objects including :class:`~plexapi.video.Movie`,
         :class:`~plexapi.video.Show`, :class:`~plexapi.video.Season`,
         :class:`~plexapi.video.Episode`, and :class:`~plexapi.video.Clip`.

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -106,6 +106,7 @@ def test_audio_Artist_mixins_rating(artist):
 
 
 def test_audio_Artist_mixins_fields(artist):
+    test_mixins.edit_added_at(artist)
     test_mixins.edit_sort_title(artist)
     test_mixins.edit_summary(artist)
     test_mixins.edit_title(artist)
@@ -231,6 +232,7 @@ def test_audio_Album_mixins_rating(album):
 
 
 def test_audio_Album_mixins_fields(album):
+    test_mixins.edit_added_at(album)
     test_mixins.edit_originally_available(album)
     test_mixins.edit_sort_title(album)
     test_mixins.edit_studio(album)
@@ -401,6 +403,7 @@ def test_audio_Track_mixins_rating(track):
 
 
 def test_audio_Track_mixins_fields(track):
+    test_mixins.edit_added_at(track)
     test_mixins.edit_title(track)
     test_mixins.edit_track_artist(track)
     test_mixins.edit_track_number(track)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -342,6 +342,7 @@ def test_Collection_mixins_rating(collection):
 
 
 def test_Collection_mixins_fields(collection):
+    test_mixins.edit_added_at(collection)
     test_mixins.edit_content_rating(collection)
     test_mixins.edit_sort_title(collection)
     test_mixins.edit_summary(collection)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -45,6 +45,10 @@ def _test_mixins_field(obj, attr, field_method):
     assert not fields
 
 
+def edit_added_at(obj):
+    _test_mixins_field(obj, "addedAt", "AddedAt")
+
+
 def edit_content_rating(obj):
     _test_mixins_field(obj, "contentRating", "ContentRating")
 

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -30,6 +30,7 @@ def test_photo_Photoalbum_mixins_rating(photoalbum):
 
 
 def test_photo_Photoalbum_mixins_fields(photoalbum):
+    test_mixins.edit_added_at(photoalbum)
     test_mixins.edit_sort_title(photoalbum)
     test_mixins.edit_summary(photoalbum)
     test_mixins.edit_title(photoalbum)
@@ -49,6 +50,7 @@ def test_photo_Photo_mixins_rating(photo):
 
 
 def test_photo_Photo_mixins_fields(photo):
+    test_mixins.edit_added_at(photo)
     test_mixins.edit_sort_title(photo)
     test_mixins.edit_summary(photo)
     test_mixins.edit_title(photo)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -660,6 +660,7 @@ def test_video_Movie_mixins_rating(movie):
 
 
 def test_video_Movie_mixins_fields(movie):
+    test_mixins.edit_added_at(movie)
     test_mixins.edit_content_rating(movie)
     test_mixins.edit_originally_available(movie)
     test_mixins.edit_original_title(movie)
@@ -903,6 +904,7 @@ def test_video_Show_mixins_rating(show):
 
 
 def test_video_Show_mixins_fields(show):
+    test_mixins.edit_added_at(show)
     test_mixins.edit_content_rating(show)
     test_mixins.edit_originally_available(show)
     test_mixins.edit_original_title(show)
@@ -1054,6 +1056,7 @@ def test_video_Season_mixins_rating(show):
 
 def test_video_Season_mixins_fields(show):
     season = show.season(season=1)
+    test_mixins.edit_added_at(season)
     test_mixins.edit_summary(season)
     test_mixins.edit_title(season)
 
@@ -1261,6 +1264,7 @@ def test_video_Episode_mixins_rating(episode):
 
 
 def test_video_Episode_mixins_fields(episode):
+    test_mixins.edit_added_at(episode)
     test_mixins.edit_content_rating(episode)
     test_mixins.edit_originally_available(episode)
     test_mixins.edit_sort_title(episode)


### PR DESCRIPTION
## Description

Plex Media Server now supports changing the `addedAt` field through the API.

New `AddedAtMixin` with the `editAddedAt(addedAt)` method added to `Movie`, `Show`, `Season`, `Episode`, `Artist`, `Album`, `Track`, `Photoalbum`, `Photo`, and `Collection`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
