### PR TITLE
Add `seasonCount` attribute to `Show`

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -440,7 +440,7 @@ class Show(
                 after being watched for the show (0 = Never, 1 = After a day, 7 = After a week,
                 100 = On next refresh).
             banner (str): Key to banner artwork (/library/metadata/<ratingkey>/banner/<bannerid>).
-            childCount (int): Number of seasons in the show.
+            childCount (int): Number of seasons (including Specials) in the show.
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
             contentRating (str) Content rating (PG-13; NR; TV-G).
             duration (int): Typical duration of the show episodes in milliseconds.
@@ -463,6 +463,7 @@ class Show(
             rating (float): Show rating (7.9; 9.8; 8.1).
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
+            seasonCount (int): Number of seasons (excluding Specials) in the show.
             showOrdering (str): Setting that indicates the episode ordering for the show
                 (None = Library default).
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
@@ -508,6 +509,7 @@ class Show(
         self.rating = utils.cast(float, data.attrib.get('rating'))
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
+        self.seasonCount = utils.cast(int, data.attrib.get('seasonCount', self.childCount))
         self.showOrdering = data.attrib.get('showOrdering')
         self.similar = self.findItems(data, media.Similar)
         self.studio = data.attrib.get('studio')

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -983,7 +983,7 @@ def test_video_Season_attrs(show):
     assert utils.is_int(season.viewCount, gte=0)
     assert utils.is_int(season.viewedLeafCount, gte=0)
     assert utils.is_int(season.seasonNumber)
-    assert season.year is None
+    assert season.year == 2011
 
 
 def test_video_Season_show(show):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -983,7 +983,7 @@ def test_video_Season_attrs(show):
     assert utils.is_int(season.viewCount, gte=0)
     assert utils.is_int(season.viewedLeafCount, gte=0)
     assert utils.is_int(season.seasonNumber)
-    assert season.year == 2011
+    assert season.year in (None, 2011)
 
 
 def test_video_Season_show(show):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -753,7 +753,7 @@ def test_video_Show_attrs(show):
     assert show._server._baseurl == utils.SERVER_BASEURL
     assert utils.is_int(show.seasonCount)
     assert show.showOrdering in (None, 'aired')
-    assert show.studio == "Generator Entertainment"
+    assert show.studio == "Revolution Sun Studios"
     assert utils.is_string(show.summary, gte=100)
     assert show.tagline == "Winter is coming."
     assert utils.is_metadata(show.theme, contains="/theme/")
@@ -964,7 +964,7 @@ def test_video_Season_attrs(show):
     assert season.parentIndex == 1
     assert utils.is_metadata(season.parentKey)
     assert utils.is_int(season.parentRatingKey)
-    assert season.parentStudio == "Generator Entertainment"
+    assert season.parentStudio == "Revolution Sun Studios"
     assert utils.is_metadata(season.parentTheme)
     if season.parentThumb:
         assert utils.is_thumb(season.parentThumb)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -751,6 +751,7 @@ def test_video_Show_attrs(show):
         assert "Emilia Clarke" in [i.tag for i in show.roles]
         assert show.actors == show.roles
     assert show._server._baseurl == utils.SERVER_BASEURL
+    assert utils.is_int(show.seasonCount)
     assert show.showOrdering in (None, 'aired')
     assert show.studio == "Generator Entertainment"
     assert utils.is_string(show.summary, gte=100)


### PR DESCRIPTION
## Description

Adds the `seasonCount` attribute to `Show`. This is the number of seasons excluding Specials.

Ref: Plex Media Server 1.31.1.6716
* (TV) Provide clients with the number of non-Specials seasons for display when browsing (#14036)

https://forums.plex.tv/t/plex-media-server/30447/555


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
