### PR TITLE
update plex-download.py to use server auth-token instead of account auth-token #1112

### DIFF
--- a/tools/plex-download.py
+++ b/tools/plex-download.py
@@ -82,6 +82,6 @@ if __name__ == '__main__':
             # We do this manually since we don't want to add a progress to Episode etc
             filename = '%s.%s' % (item._prettyfilename(), part.container)
             url = item._server.url('%s?download=1' % part.key)
-            filepath = utils.download(url, token=account.authenticationToken, filename=filename, savepath=os.getcwd(),
+            filepath = utils.download(url, token=item._server._token, filename=filename, savepath=os.getcwd(),
                                       session=item._server._session, showstatus=True)
             #print('  %s' % filepath)


### PR DESCRIPTION
## Description

Current implementation uses the account token as part of the download request . To download item from a server we need to use server specific auth-token for that given server.

Fixes https://github.com/pkkid/python-plexapi/issues/1112


## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)

