### PR TITLE
Add advanced settings for show/season preferred audio/subtitle settings

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -457,6 +457,7 @@ class Show(
             TYPE (str): 'show'
             audienceRating (float): Audience rating (TMDB or TVDB).
             audienceRatingImage (str): Key to audience rating image (tmdb://image.rating).
+            audioLanguage (str): Setting that indicates the preferred audio language.
             autoDeletionItemPolicyUnwatchedLibrary (int): Setting that indicates the number of unplayed
                 episodes to keep for the show (0 = All episodes, 5 = 5 latest episodes, 3 = 3 latest episodes,
                 1 = 1 latest episode, -3 = Episodes added in the past 3 days, -7 = Episodes added in the
@@ -494,6 +495,9 @@ class Show(
                 (None = Library default).
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             studio (str): Studio that created show (Di Bonaventura Pictures; 21 Laps Entertainment).
+            subtitleLanguage (str): Setting that indicates the preferred subtitle language.
+            subtitleMode (int): Setting that indicates the auto-select subtitle mode.
+                (-1 = Account default, 0 = Manually selected, 1 = Shown with foreign audio, 2 = Always enabled).
             tagline (str): Show tag line.
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
             useOriginalTitle (int): Setting that indicates if the original title is used for the show
@@ -510,6 +514,7 @@ class Show(
         Video._loadData(self, data)
         self.audienceRating = utils.cast(float, data.attrib.get('audienceRating'))
         self.audienceRatingImage = data.attrib.get('audienceRatingImage')
+        self.audioLanguage = data.attrib.get('audioLanguage', '')
         self.autoDeletionItemPolicyUnwatchedLibrary = utils.cast(
             int, data.attrib.get('autoDeletionItemPolicyUnwatchedLibrary', '0'))
         self.autoDeletionItemPolicyWatchedLibrary = utils.cast(
@@ -540,6 +545,8 @@ class Show(
         self.showOrdering = data.attrib.get('showOrdering')
         self.similar = self.findItems(data, media.Similar)
         self.studio = data.attrib.get('studio')
+        self.subtitleLanguage = data.attrib.get('audioLanguage', '')
+        self.subtitleMode = utils.cast(int, data.attrib.get('subtitleMode', '-1'))
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')
         self.useOriginalTitle = utils.cast(int, data.attrib.get('useOriginalTitle', '-1'))
@@ -648,7 +655,7 @@ class Show(
 @utils.registerPlexObject
 class Season(
     Video,
-    ExtrasMixin, RatingMixin,
+    AdvancedSettingsMixin, ExtrasMixin, RatingMixin,
     ArtMixin, PosterMixin, ThemeUrlMixin,
     SummaryMixin, TitleMixin,
     CollectionMixin, LabelMixin
@@ -658,6 +665,7 @@ class Season(
         Attributes:
             TAG (str): 'Directory'
             TYPE (str): 'season'
+            audioLanguage (str): Setting that indicates the preferred audio language.
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
             guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             index (int): Season number.
@@ -673,6 +681,9 @@ class Season(
             parentThumb (str): URL to show thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the show for the season.
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
+            subtitleLanguage (str): Setting that indicates the preferred subtitle language.
+            subtitleMode (int): Setting that indicates the auto-select subtitle mode.
+                (-1 = Series default, 0 = Manually selected, 1 = Shown with foreign audio, 2 = Always enabled).
             viewedLeafCount (int): Number of items marked as played in the season view.
             year (int): Year the season was released.
     """
@@ -683,6 +694,7 @@ class Season(
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
         Video._loadData(self, data)
+        self.audioLanguage = data.attrib.get('audioLanguage', '')
         self.collections = self.findItems(data, media.Collection)
         self.guids = self.findItems(data, media.Guid)
         self.index = utils.cast(int, data.attrib.get('index'))
@@ -698,6 +710,8 @@ class Season(
         self.parentThumb = data.attrib.get('parentThumb')
         self.parentTitle = data.attrib.get('parentTitle')
         self.ratings = self.findItems(data, media.Rating)
+        self.subtitleLanguage = data.attrib.get('audioLanguage', '')
+        self.subtitleMode = utils.cast(int, data.attrib.get('subtitleMode', '-1'))
         self.viewedLeafCount = utils.cast(int, data.attrib.get('viewedLeafCount'))
         self.year = utils.cast(int, data.attrib.get('year'))
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -724,6 +724,7 @@ def test_video_Show_attrs(show):
     show.reload()
     assert utils.is_float(show.audienceRating)
     assert show.audienceRatingImage == "themoviedb://image.rating"
+    assert show.audioLanguage == ''
     assert show.autoDeletionItemPolicyUnwatchedLibrary == 0
     assert show.autoDeletionItemPolicyWatchedLibrary == 0
     assert show.enableCreditsMarkerGeneration == -1
@@ -758,6 +759,8 @@ def test_video_Show_attrs(show):
     assert show.showOrdering in (None, 'aired')
     assert show.studio == "Revolution Sun Studios"
     assert utils.is_string(show.summary, gte=100)
+    assert show.subtitleLanguage == ''
+    assert show.subtitleMode == -1
     assert show.tagline == "Winter is coming."
     assert utils.is_metadata(show.theme, contains="/theme/")
     if show.thumb:
@@ -955,6 +958,7 @@ def test_video_Season_attrs(show):
     assert utils.is_datetime(season.addedAt)
     if season.art:
         assert utils.is_art(season.art)
+    assert season.audioLanguage == ''
     assert season.guid == "plex://season/602e67d31d3358002c411c39"
     assert "tvdb://364731" in [i.id for i in season.guids]
     assert season.index == 1
@@ -978,6 +982,8 @@ def test_video_Season_attrs(show):
     assert utils.is_int(season.ratingKey)
     assert season._server._baseurl == utils.SERVER_BASEURL
     assert utils.is_string(season.summary, gte=100)
+    assert season.subtitleLanguage == ''
+    assert season.subtitleMode == -1
     if season.thumb:
         assert utils.is_thumb(season.thumb)
     assert season.title == "Season 1"


### PR DESCRIPTION
## Description

Plex Media Server 1.31.2.6739 added advanced settings for shows/seasons to set the preferred audio/subtitle settings.

Ref: https://forums.plex.tv/t/plex-media-server/30447/558


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
