### PR TITLE
Update `getStreamURL()` for dash protocol

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -695,38 +695,45 @@ class Playable:
         self.playlistItemID = utils.cast(int, data.attrib.get('playlistItemID'))    # playlist
         self.playQueueItemID = utils.cast(int, data.attrib.get('playQueueItemID'))  # playqueue
 
-    def getStreamURL(self, **params):
+    def getStreamURL(self, **kwargs):
         """ Returns a stream url that may be used by external applications such as VLC.
 
             Parameters:
-                **params (dict): optional parameters to manipulate the playback when accessing
+                **kwargs (dict): optional parameters to manipulate the playback when accessing
                     the stream. A few known parameters include: maxVideoBitrate, videoResolution
-                    offset, copyts, protocol, mediaIndex, platform.
+                    offset, copyts, protocol, mediaIndex, partIndex, platform.
 
             Raises:
                 :exc:`~plexapi.exceptions.Unsupported`: When the item doesn't support fetching a stream URL.
         """
         if self.TYPE not in ('movie', 'episode', 'track', 'clip'):
             raise Unsupported(f'Fetching stream URL for {self.TYPE} is unsupported.')
-        mvb = params.get('maxVideoBitrate')
-        vr = params.get('videoResolution', '')
+
+        mvb = kwargs.pop('maxVideoBitrate', None)
+        vr = kwargs.pop('videoResolution', '')
+        protocol = kwargs.pop('protocol', None)
+
         params = {
             'path': self.key,
-            'offset': params.get('offset', 0),
-            'copyts': params.get('copyts', 1),
-            'protocol': params.get('protocol'),
-            'mediaIndex': params.get('mediaIndex', 0),
-            'X-Plex-Platform': params.get('platform', 'Chrome'),
+            'mediaIndex': kwargs.pop('mediaIndex', 0),
+            'partIndex': kwargs.pop('mediaIndex', 0),
+            'protocol': protocol,
+            'fastSeek': kwargs.pop('fastSeek', 1),
+            'copyts': kwargs.pop('copyts', 1),
+            'offset': kwargs.pop('offset', 0),
             'maxVideoBitrate': max(mvb, 64) if mvb else None,
-            'videoResolution': vr if re.match(r'^\d+x\d+$', vr) else None
+            'videoResolution': vr if re.match(r'^\d+x\d+$', vr) else None,
+            'X-Plex-Platform': kwargs.pop('platform', 'Chrome')
         }
+        params.update(kwargs)
+
         # remove None values
         params = {k: v for k, v in params.items() if v is not None}
         streamtype = 'audio' if self.TYPE in ('track', 'album') else 'video'
-        # sort the keys since the randomness fucks with my tests..
-        sorted_params = sorted(params.items(), key=lambda val: val[0])
+        ext = 'mpd' if protocol == 'dash' else 'm3u8'
+
         return self._server.url(
-            f'/{streamtype}/:/transcode/universal/start.m3u8?{urlencode(sorted_params)}',
+            f'/{streamtype}/:/transcode/universal/start.{ext}?{urlencode(params)}',
             includeToken=True
         )
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -309,20 +309,19 @@ def test_video_Movie_media_tags_collection(movie, collection):
 
 
 def test_video_Movie_getStreamURL(movie, account):
-    key = movie.ratingKey
-    assert movie.getStreamURL() == (
-        "{0}/video/:/transcode/universal/start.m3u8?"
-        "X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&"
-        "offset=0&path=%2Flibrary%2Fmetadata%2F{1}&X-Plex-Token={2}").format(
-        utils.SERVER_BASEURL, key, account.authenticationToken
-    )  # noqa
-    assert movie.getStreamURL(
-        videoResolution="800x600"
-    ) == ("{0}/video/:/transcode/universal/start.m3u8?"
-        "X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&"
-        "offset=0&path=%2Flibrary%2Fmetadata%2F{1}&videoResolution=800x600&X-Plex-Token={2}").format(
-        utils.SERVER_BASEURL, key, account.authenticationToken
-    )  # noqa
+    key = movie.key
+
+    url = movie.getStreamURL()
+    assert url.startswith(f"{utils.SERVER_BASEURL}/video/:/transcode/universal/start.m3u8")
+    assert account.authenticationToken in url
+    assert f"path={quote_plus(key)}" in url
+    assert "protocol" not in url
+    assert "videoResolution" not in url
+
+    url = movie.getStreamURL(videoResolution="800x600", protocol='dash')
+    assert url.startswith(f"{utils.SERVER_BASEURL}/video/:/transcode/universal/start.mpd")
+    assert "protocol=dash" in url
+    assert "videoResolution=800x600" in url
 
 
 def test_video_Movie_isFullObject_and_reload(plex):


### PR DESCRIPTION
## Description

* Update `getStreamURL()` to allow additional custom `kwargs`.
* Automatically use `.mpd` instead of `.m3u8` when specifying dash protocol `getStreamURL(protocol='dash')`.
* Add `partIndex` and `fastSeek` parameter to the stream URL.

Closes #1116

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
