### PR TITLE
Fix missing `markers` attribute for `Movie`

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -335,6 +335,7 @@ class Movie(
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
             languageOverride (str): Setting that indicates if a language is used to override metadata
                 (eg. en-CA, None = Library default).
+            markers (List<:class:`~plexapi.media.Marker`>): List of marker objects.
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             originallyAvailableAt (datetime): Datetime the movie was released.
             originalTitle (str): Original title, often the foreign title (転々; 엽기적인 그녀).
@@ -377,6 +378,7 @@ class Movie(
         self.guids = self.findItems(data, media.Guid)
         self.labels = self.findItems(data, media.Label)
         self.languageOverride = data.attrib.get('languageOverride')
+        self.markers = self.findItems(data, media.Marker)
         self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
         self.originalTitle = data.attrib.get('originalTitle')


### PR DESCRIPTION
## Description

Fix missing `marker` attribute for `Movie`

Fixes #1094

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
