### PR TITLE
Add support for Continue Watching hubs

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -781,6 +781,11 @@ class LibrarySection(PlexObject):
         key = f'/library/sections/{self.key}/onDeck'
         return self.fetchItems(key)
 
+    def continueWatching(self):
+        """ Return a list of media items in the library's Continue Watching hub. """
+        key = f'/hubs/sections/{self.key}/continueWatching/items'
+        return self.fetchItems(key)
+
     def recentlyAdded(self, maxresults=50, libtype=None):
         """ Returns a list of media items recently added from this library section.
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -794,6 +794,10 @@ class PlexServer(PlexObject):
                 results += hub.items
         return results
 
+    def continueWatching(self):
+        """ Return a list of all items in the Continue Watching hub. """
+        return self.fetchItems('/hubs/home/continueWatching')
+
     def sessions(self):
         """ Returns a list of all active session (currently playing) media objects. """
         return self.fetchItems('/status/sessions')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -441,6 +441,13 @@ class Movie(
         }
         return self.section().search(filters=filters)
 
+    def removeFromContinueWatching(self):
+        """ Remove the movie from continue watching. """
+        key = '/actions/removeFromContinueWatching'
+        params = {'ratingKey': self.ratingKey}
+        self._server.query(key, params=params, method=self._server._session.put)
+        return self
+
 
 @utils.registerPlexObject
 class Show(
@@ -992,6 +999,13 @@ class Episode(
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """
         return f'{self.grandparentTitle} - {self.parentTitle} - ({self.seasonEpisode}) {self.title}'
+
+    def removeFromContinueWatching(self):
+        """ Remove the movie from continue watching. """
+        key = '/actions/removeFromContinueWatching'
+        params = {'ratingKey': self.ratingKey}
+        self._server.query(key, params=params, method=self._server._session.put)
+        return self
 
 
 @utils.registerPlexObject

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -712,6 +712,17 @@ def test_video_Movie_PlexWebURL(plex, movie):
     assert url.startswith(base)
 
 
+def test_video_Movie_continueWatching(plex, movies, movie):
+    assert movie not in plex.continueWatching()
+    assert movie not in movies.continueWatching()
+    movie.updateProgress(90000)
+    assert movie in plex.continueWatching()
+    assert movie in movies.continueWatching()
+    movie.markUnplayed()
+    assert movie not in plex.continueWatching()
+    assert movie not in movies.continueWatching()
+
+
 def test_video_Show_attrs(show):
     assert utils.is_datetime(show.addedAt)
     if show.art:
@@ -1297,6 +1308,17 @@ def test_video_Episode_PlexWebURL(plex, episode):
     assert plex.machineIdentifier in url
     assert 'details' in url
     assert quote_plus(episode.key) in url
+
+
+def test_video_Episode_continueWatching(plex, tvshows, episode):
+    assert episode not in plex.continueWatching()
+    assert episode not in tvshows.continueWatching()
+    episode.updateProgress(90000)
+    assert episode in plex.continueWatching()
+    assert episode in tvshows.continueWatching()
+    episode.markUnplayed()
+    assert episode not in plex.continueWatching()
+    assert episode not in tvshows.continueWatching()
 
 
 def test_that_reload_return_the_same_object(plex):


### PR DESCRIPTION
## Description

* Adds new methods `PlexServer.continueWatching()` and `LibrarySection.continueWatching()` to retrieve a list of items in the continue watching hub for the server and library, respectively.
* Adds new methods `Movie.removeFromContinueWatching()` and `Episode.removeFromContinueWatching()` to remove a movie or episode from the continue watching hub, respectively.



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
