### PR TITLE
Change `updateProgress` and `updateTimeline` to return `self`

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -812,7 +812,7 @@ class Playable:
         """
         key = f'/:/progress?key={self.ratingKey}&identifier=com.plexapp.plugins.library&time={time}&state={state}'
         self._server.query(key)
-        self._reload(_overwriteNone=False)
+        return self
 
     def updateTimeline(self, time, state='stopped', duration=None):
         """ Set the timeline progress for this video.
@@ -830,7 +830,7 @@ class Playable:
         key = (f'/:/timeline?ratingKey={self.ratingKey}&key={self.key}&'
                f'identifier=com.plexapp.plugins.library&time={int(time)}&state={state}{durationStr}')
         self._server.query(key)
-        self._reload(_overwriteNone=False)
+        return self
 
 
 class PlexSession(object):


### PR DESCRIPTION
## Description

Change `updateProgress` and `updateTimeline` to return `self` instead of reloading internally. This makes them consistent with the other methods in the library.


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
