### PR TITLE
Detect invalid token with myplex

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -188,6 +188,8 @@ class MyPlexAccount(PlexObject):
                 raise Unauthorized(message)
             elif response.status_code == 404:
                 raise NotFound(message)
+            elif response.status_code == 422 and "Invalid token" in response.text:
+                raise Unauthorized(message)
             else:
                 raise BadRequest(message)
         if headers.get('Accept') == 'application/json':


### PR DESCRIPTION
## Description

It seems that hitting plex.tv with a deauthorized token will not return a 401 as expected, but instead a 422 with an XML response similar to:
```xml
<?xml version="1.0" encoding="UTF-8"?> <errors> <error>Invalid token</error> </errors>
```

This raises an `Unauthorized` exception instead of the generic `BadRequest`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
