### PR TITLE
Do not add empty string to secrets log filter

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -106,7 +106,7 @@ class SecretsFilter(logging.Filter):
         self.secrets = secrets or set()
 
     def add_secret(self, secret):
-        if secret is not None:
+        if secret is not None and secret != '':
             self.secrets.add(secret)
         return secret
 


### PR DESCRIPTION
## Description

An empty string could be added to the secrets log filter when a Plex server is accessed without authentication and a blank token. This prevents a blank string from being added to the secrets log filter. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
