### PR TITLE
Refactor `fetchItems` for pagination

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -4,7 +4,7 @@ import weakref
 from urllib.parse import urlencode
 from xml.etree import ElementTree
 
-from plexapi import log, utils, X_PLEX_CONTAINER_SIZE
+from plexapi import X_PLEX_CONTAINER_SIZE, log, utils
 from plexapi.exceptions import BadRequest, NotFound, UnknownType, Unsupported
 from plexapi.utils import cached_property
 

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -657,7 +657,7 @@ class PlexPartialObject(PlexObject):
                 'have not allowed items to be deleted', self.key)
             raise
 
-    def history(self, maxresults=9999999, mindate=None):
+    def history(self, maxresults=None, mindate=None):
         """ Get Play History for a media item.
 
             Parameters:

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -3,6 +3,7 @@ import time
 from xml.etree import ElementTree
 
 import requests
+
 from plexapi import BASE_HEADERS, CONFIG, TIMEOUT, log, logfilter, utils
 from plexapi.base import PlexObject
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized, Unsupported

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -352,7 +352,7 @@ class Library(PlexObject):
             part += urlencode(kwargs)
         return self._server.query(part, method=self._server._session.post)
 
-    def history(self, maxresults=9999999, mindate=None):
+    def history(self, maxresults=None, mindate=None):
         """ Get Play History for all library Sections for the owner.
             Parameters:
                 maxresults (int): Only return the specified number of results (optional).
@@ -1568,7 +1568,7 @@ class LibrarySection(PlexObject):
 
         return myplex.sync(client=client, clientId=clientId, sync_item=sync_item)
 
-    def history(self, maxresults=9999999, mindate=None):
+    def history(self, maxresults=None, mindate=None):
         """ Get Play History for this library Section for the owner.
             Parameters:
                 maxresults (int): Only return the specified number of results (optional).

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
-
 from urllib.parse import parse_qsl, quote, quote_plus, unquote, urlencode, urlsplit
 
 from plexapi import media, settings, utils

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -786,7 +786,7 @@ class MyPlexAccount(PlexObject):
             raise BadRequest(f'({response.status_code}) {codename} {response.url}; {errtext}')
         return response.json()['token']
 
-    def history(self, maxresults=9999999, mindate=None):
+    def history(self, maxresults=None, mindate=None):
         """ Get Play History for all library sections on all servers for the owner.
 
             Parameters:
@@ -1148,7 +1148,7 @@ class MyPlexUser(PlexObject):
 
         raise NotFound(f'Unable to find server {name}')
 
-    def history(self, maxresults=9999999, mindate=None):
+    def history(self, maxresults=None, mindate=None):
         """ Get all Play History for a user in all shared servers.
             Parameters:
                 maxresults (int): Only return the specified number of results (optional).
@@ -1222,7 +1222,7 @@ class Section(PlexObject):
         self.sectionId = self.id  # For backwards compatibility
         self.sectionKey = self.key  # For backwards compatibility
 
-    def history(self, maxresults=9999999, mindate=None):
+    def history(self, maxresults=None, mindate=None):
         """ Get all Play History for a user for this section in this shared server.
             Parameters:
                 maxresults (int): Only return the specified number of results (optional).

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -7,8 +7,9 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from xml.etree import ElementTree
 
 import requests
-from plexapi import (BASE_HEADERS, CONFIG, TIMEOUT, X_PLEX_CONTAINER_SIZE,
-                     X_PLEX_ENABLE_FAST_CONNECT, X_PLEX_IDENTIFIER, log, logfilter, utils)
+
+from plexapi import (BASE_HEADERS, CONFIG, TIMEOUT, X_PLEX_ENABLE_FAST_CONNECT, X_PLEX_IDENTIFIER,
+                     log, logfilter, utils)
 from plexapi.base import PlexObject
 from plexapi.client import PlexClient
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+import os
 from urllib.parse import urlencode
 from xml.etree import ElementTree
 
 import requests
-import os
-from plexapi import (BASE_HEADERS, CONFIG, TIMEOUT, X_PLEX_CONTAINER_SIZE, log,
-                     logfilter)
+
+from plexapi import BASE_HEADERS, CONFIG, TIMEOUT, log, logfilter
 from plexapi import utils
 from plexapi.alert import AlertListener
 from plexapi.base import PlexObject

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -637,7 +637,7 @@ class PlexServer(PlexObject):
             # figure out what method this is..
             return self.query(part, method=self._session.put)
 
-    def history(self, maxresults=9999999, mindate=None, ratingKey=None, accountID=None, librarySectionID=None):
+    def history(self, maxresults=None, mindate=None, ratingKey=None, accountID=None, librarySectionID=None):
         """ Returns a list of media items from watched history. If there are many results, they will
             be fetched from the server in batches of X_PLEX_CONTAINER_SIZE amounts. If you're only
             looking for the first <num> results, it would be wise to set the maxresults option to that
@@ -651,7 +651,6 @@ class PlexServer(PlexObject):
                 accountID (int/str) Request history for a specific account ID.
                 librarySectionID (int/str) Request history for a specific library section ID.
         """
-        results, subresults = [], '_init'
         args = {'sort': 'viewedAt:desc'}
         if ratingKey:
             args['metadataItemID'] = ratingKey
@@ -661,14 +660,9 @@ class PlexServer(PlexObject):
             args['librarySectionID'] = librarySectionID
         if mindate:
             args['viewedAt>'] = int(mindate.timestamp())
-        args['X-Plex-Container-Start'] = 0
-        args['X-Plex-Container-Size'] = min(X_PLEX_CONTAINER_SIZE, maxresults)
-        while subresults and maxresults > len(results):
-            key = f'/status/sessions/history/all{utils.joinArgs(args)}'
-            subresults = self.fetchItems(key)
-            results += subresults[:maxresults - len(results)]
-            args['X-Plex-Container-Start'] += args['X-Plex-Container-Size']
-        return results
+        
+        key = f'/status/sessions/history/all{utils.joinArgs(args)}'
+        return self.fetchItems(key, maxresults=maxresults)
 
     def playlists(self, playlistType=None, sectionId=None, title=None, sort=None, **kwargs):
         """ Returns a list of all :class:`~plexapi.playlist.Playlist` objects on the server.

--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import requests
+
 from plexapi import CONFIG, X_PLEX_IDENTIFIER
 from plexapi.client import PlexClient
 from plexapi.exceptions import BadRequest

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -18,6 +18,7 @@ from urllib.parse import quote
 from requests.status_codes import _codes as codes
 
 import requests
+
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 
 try:


### PR DESCRIPTION
## Description

Refactor the base `fetchItems` method so pagination works globally across the entire Plex API library using `X-Plex-Container-Start` and `X-Plex-Container-Size` headers.

Ref. #990
Fixes #1048

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
