### PR TITLE
Allow using `MyPlexUser` object for switchUser

### DIFF
--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -433,7 +433,8 @@ class Playlist(
         """ Copy playlist to another user account.
         
             Parameters:
-                user (str): Username, email or user id of the user to copy the playlist to.
+                user (:class:`~plexapi.myplex.MyPlexUser` or str): `MyPlexUser` object, username,
+                    email, or user id of the user to copy the playlist to.
         """
         userServer = self._server.switchUser(user)
         return self.create(server=userServer, title=self.title, items=self.items())

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -236,12 +236,13 @@ class PlexServer(PlexObject):
         q = self.query(f'/security/token?type={type}&scope={scope}')
         return q.attrib.get('token')
 
-    def switchUser(self, username, session=None, timeout=None):
+    def switchUser(self, user, session=None, timeout=None):
         """ Returns a new :class:`~plexapi.server.PlexServer` object logged in as the given username.
             Note: Only the admin account can switch to other users.
         
             Parameters:
-                username (str): Username, email or user id of the user to log in to the server.
+                user (:class:`~plexapi.myplex.MyPlexUser` or str): `MyPlexUser` object, username,
+                    email, or user id of the user to log in to the server.
                 session (requests.Session, optional): Use your own session object if you want to
                     cache the http responses from the server. This will default to the same
                     session as the admin account if no new session is provided.
@@ -260,7 +261,8 @@ class PlexServer(PlexObject):
                     userPlex = plex.switchUser("Username")
 
         """
-        user = self.myPlexAccount().user(username)
+        from plexapi.myplex import MyPlexUser
+        user = user if isinstance(user, MyPlexUser) else self.myPlexAccount().user(user)
         userToken = user.get_token(self.machineIdentifier)
         if session is None:
             session = self._session


### PR DESCRIPTION
## Description

Allow using `MyPlexUser` object for `PlexServer.switchUser(user)`.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
