### PR TITLE
Read version from file instead of import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,14 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from plexapi import const
+# Get version
+version = {}
+with open('plexapi/const.py') as handle:
+    exec(handle.read(), version)
 
 # Get README.rst contents
-readme = open('README.rst', 'r').read()
+with open('README.rst') as handle:
+    readme = handle.read()
 
 # Get requirements
 with open('requirements.txt') as handle:
@@ -20,7 +24,7 @@ with open('requirements.txt') as handle:
 
 setup(
     name='PlexAPI',
-    version=const.__version__,
+    version=version['__version__'],
     description='Python bindings for the Plex API.',
     author='Michael Shepanski',
     author_email='michael.shepanski@gmail.com',


### PR DESCRIPTION
## Description

Read version from file instead of import in `setup.py`.

User packages (i.e. `requests`) are no longer available during the build process which causes a `ModuleNotFound` error.

Ref: https://packaging.python.org/en/latest/guides/single-sourcing-package-version/


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
