### PR TITLE
Fix mutable default args for resource connection

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1324,8 +1324,8 @@ class MyPlexResource(PlexObject):
     def preferred_connections(
         self,
         ssl=None,
-        locations=DEFAULT_LOCATION_ORDER,
-        schemes=DEFAULT_SCHEME_ORDER,
+        locations=None,
+        schemes=None,
     ):
         """ Returns a sorted list of the available connection addresses for this resource.
             Often times there is more than one address specified for a server or client.
@@ -1336,6 +1336,11 @@ class MyPlexResource(PlexObject):
                     only connect to HTTP connections. Set None (default) to connect to any
                     HTTP or HTTPS connection.
         """
+        if locations is None:
+            locations = self.DEFAULT_LOCATION_ORDER[:]
+        if schemes is None:
+            schemes = self.DEFAULT_SCHEME_ORDER[:]
+
         connections_dict = {location: {scheme: [] for scheme in schemes} for location in locations}
         for connection in self.connections:
             # Only check non-local connections unless we own the resource
@@ -1359,8 +1364,8 @@ class MyPlexResource(PlexObject):
         self,
         ssl=None,
         timeout=None,
-        locations=DEFAULT_LOCATION_ORDER,
-        schemes=DEFAULT_SCHEME_ORDER,
+        locations=None,
+        schemes=None,
     ):
         """ Returns a new :class:`~plexapi.server.PlexServer` or :class:`~plexapi.client.PlexClient` object.
             Uses `MyPlexResource.preferred_connections()` to generate the priority order of connection addresses.
@@ -1376,6 +1381,11 @@ class MyPlexResource(PlexObject):
             Raises:
                 :exc:`~plexapi.exceptions.NotFound`: When unable to connect to any addresses for this resource.
         """
+        if locations is None:
+            locations = self.DEFAULT_LOCATION_ORDER[:]
+        if schemes is None:
+            schemes = self.DEFAULT_SCHEME_ORDER[:]
+
         connections = self.preferred_connections(ssl, locations, schemes)
         # Try connecting to all known resource connections in parallel, but
         # only return the first server (in order) that provides a response.


### PR DESCRIPTION
## Description

Removes the mutable default `locations` and `schemes` default arguments from `MyPlexResource.preferred_connections()` and `MyPlexResource.connect()`. Fixes connection failures on subsequent connections after setting the `ssl` argument.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
