### PR TITLE
Pass session from MyPlexAccount to server/device connection

### DIFF
--- a/tools/plex-listtokens.py
+++ b/tools/plex-listtokens.py
@@ -47,7 +47,7 @@ def _list_devices(account, servers):
 def _test_servers(servers):
     items, seen = [], set()
     print('Finding Plex clients..')
-    listargs = [[PlexServer, s, t, 5] for s,t in servers.items()]
+    listargs = [[PlexServer, s, t, None, 5] for s,t in servers.items()]
     results = utils.threaded(_connect, listargs)
     for url, token, plex, runtime in results:
         clients = plex.clients() if plex else []


### PR DESCRIPTION
## Description

Pass the `requests.Session()` object from `MyPlexAccount` to `PlexServer` or `PlexClient` on connection.

Fixes #1100

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
