### PR TITLE
Set Sphinx language to en

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ version = plexapi.VERSION
 # for a list of supported languages.
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
## Description

Using Sphinx version 5, `None` gives a warning

```
Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
