### PR TITLE
Change server continue watching endpoint

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -797,7 +797,7 @@ class PlexServer(PlexObject):
 
     def continueWatching(self):
         """ Return a list of all items in the Continue Watching hub. """
-        return self.fetchItems('/hubs/home/continueWatching')
+        return self.fetchItems('/hubs/continueWatching/items')
 
     def sessions(self):
         """ Returns a list of all active session (currently playing) media objects. """


### PR DESCRIPTION
## Description

Update the `PlexServer.continueWatching()` Plex API endpoint.

Fixes #1168

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
