### PR TITLE
Remove optional `title` argument from `PhotoSection.searchAlbums()` and `PhotoSection.searchPhotos()`

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1917,13 +1917,13 @@ class PhotoSection(LibrarySection):
     def collections(self, **kwargs):
         raise NotImplementedError('Collections are not available for a Photo library.')
 
-    def searchAlbums(self, title, **kwargs):
+    def searchAlbums(self, **kwargs):
         """ Search for a photo album. See :func:`~plexapi.library.LibrarySection.search` for usage. """
-        return self.search(libtype='photoalbum', title=title, **kwargs)
+        return self.search(libtype='photoalbum', **kwargs)
 
-    def searchPhotos(self, title, **kwargs):
+    def searchPhotos(self, **kwargs):
         """ Search for a photo. See :func:`~plexapi.library.LibrarySection.search` for usage. """
-        return self.search(libtype='photo', title=title, **kwargs)
+        return self.search(libtype='photo', **kwargs)
 
     def recentlyAddedAlbums(self, maxresults=50):
         """ Returns a list of recently added photo albums from this library section.

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -429,13 +429,12 @@ def test_library_MusicSection_recentlyAdded(music, artist):
 
 def test_library_PhotoSection_searchAlbums(photos, photoalbum):
     title = photoalbum.title
-    albums = photos.searchAlbums(title)
-    assert len(albums)
+    assert len(photos.searchAlbums(title=title))
 
 
 def test_library_PhotoSection_searchPhotos(photos, photoalbum):
     title = photoalbum.photos()[0].title
-    assert len(photos.searchPhotos(title))
+    assert len(photos.searchPhotos(title=title))
 
 
 def test_library_PhotoSection_recentlyAdded(photos, photoalbum):


### PR DESCRIPTION
## Description

Remove optional `title` argument from `PhotoSection.searchAlbums()` and `PhotoSection.searchPhotos()` to match the other library type `search*()` methods. `title` is passed as a `kwarg` to the underlying `search()`   method.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
