### PR TITLE
Check object is instance of `PlexPartialObject` for `__eq__` comparison

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -489,7 +489,9 @@ class PlexPartialObject(PlexObject):
     }
 
     def __eq__(self, other):
-        return other not in [None, []] and self.key == other.key
+        if isinstance(other, PlexPartialObject):
+            return other not in [None, []] and self.key == other.key
+        return NotImplemented
 
     def __hash__(self):
         return hash(repr(self))


### PR DESCRIPTION
## Description

Check object is instance of `PlexPartialObject` for `__eq__` comparison.

Fixes #1175

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
