### PR TITLE
Create separate `PlexHistory` objects

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -3,7 +3,7 @@ import os
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject, PlexSession
+from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
 from plexapi.exceptions import BadRequest, NotFound
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
@@ -482,3 +482,16 @@ class TrackSession(PlexSession, Track):
         """ Load attribute values from Plex XML response. """
         Track._loadData(self, data)
         PlexSession._loadData(self, data)
+
+
+@utils.registerPlexObject
+class TrackHistory(PlexHistory, Track):
+    """ Represents a single Track history entry
+        loaded from :func:`~plexapi.server.PlexServer.history`.
+    """
+    _HISTORYTYPE = True
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        Track._loadData(self, data)
+        PlexHistory._loadData(self, data)

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -130,7 +130,9 @@ def registerPlexObject(cls):
     etype = getattr(cls, 'STREAMTYPE', getattr(cls, 'TAGTYPE', cls.TYPE))
     ehash = f'{cls.TAG}.{etype}' if etype else cls.TAG
     if getattr(cls, '_SESSIONTYPE', None):
-        ehash = f"{ehash}.{'session'}"
+        ehash = f"{ehash}.session"
+    elif getattr(cls, '_HISTORYTYPE', None):
+        ehash = f"{ehash}.history"
     if ehash in PLEXOBJECTS:
         raise Exception(f'Ambiguous PlexObject definition {cls.__name__}(tag={cls.TAG}, type={etype}) '
                         f'with {PLEXOBJECTS[ehash].__name__}')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -3,7 +3,7 @@ import os
 from urllib.parse import quote_plus
 
 from plexapi import media, utils
-from plexapi.base import Playable, PlexPartialObject, PlexSession
+from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
@@ -1119,3 +1119,42 @@ class ClipSession(PlexSession, Clip):
         """ Load attribute values from Plex XML response. """
         Clip._loadData(self, data)
         PlexSession._loadData(self, data)
+
+
+@utils.registerPlexObject
+class MovieHistory(PlexHistory, Movie):
+    """ Represents a single Movie history entry
+        loaded from :func:`~plexapi.server.PlexServer.history`.
+    """
+    _HISTORYTYPE = True
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        Movie._loadData(self, data)
+        PlexHistory._loadData(self, data)
+
+
+@utils.registerPlexObject
+class EpisodeHistory(PlexHistory, Episode):
+    """ Represents a single Episode history entry
+        loaded from :func:`~plexapi.server.PlexServer.history`.
+    """
+    _HISTORYTYPE = True
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        Episode._loadData(self, data)
+        PlexHistory._loadData(self, data)
+
+
+@utils.registerPlexObject
+class ClipHistory(PlexHistory, Clip):
+    """ Represents a single Clip history entry
+        loaded from :func:`~plexapi.server.PlexServer.history`.
+    """
+    _HISTORYTYPE = True
+
+    def _loadData(self, data):
+        """ Load attribute values from Plex XML response. """
+        Clip._loadData(self, data)
+        PlexHistory._loadData(self, data)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -318,7 +318,6 @@ def test_audio_Track_attrs(album):
     assert utils.is_datetime(track.updatedAt)
     assert utils.is_int(track.viewCount, gte=0)
     assert track.viewOffset == 0
-    assert track.viewedAt is None
     assert track.year is None
     assert track.url(None) is None
     assert media.aspectRatio is None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from . import conftest as utils
 
 
 def test_history_Movie(movie):
@@ -81,6 +82,24 @@ def test_history_MyServer(plex, movie):
     history = plex.history()
     assert len(history)
     movie.markUnplayed()
+
+
+def test_history_PlexHistory(plex, movie):
+    movie.markPlayed()
+    history = plex.history()
+    assert len(history)
+    
+    hist = history[0]
+    assert hist.source() == movie
+    assert hist.accountID
+    assert hist.deviceID
+    assert hist.historyKey
+    assert utils.is_datetime(hist.viewedAt)
+    assert hist.guid is None
+    hist.delete()
+
+    history = plex.history()
+    assert hist not in history
 
 
 def test_history_User(account, shared_username):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -183,13 +183,6 @@ def test_server_playlists(plex, show):
         playlist.delete()
 
 
-def test_server_history(plex, movie):
-    movie.markPlayed()
-    history = plex.history()
-    assert len(history)
-    movie.markUnplayed()
-
-
 def test_server_Server_query(plex):
     assert plex.query("/")
     with pytest.raises(NotFound):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -106,7 +106,6 @@ def test_video_Movie_attrs(movies):
     assert movie.userRating is None
     assert movie.viewCount == 0
     assert utils.is_int(movie.viewOffset, gte=0)
-    assert movie.viewedAt is None
     assert movie.year == 2009
     # Audio
     audio = movie.media[0].parts[0].audioStreams()[0]


### PR DESCRIPTION
## Description

`PlexHistory` objects are unique from their base media objects. These objects are built from `/status/sessions/history` instead of `/library/metadata/<ratingKey>`.

* New `PlexHistory.source()` to return the source media object for the history object.
* New `PlexHistory.delete()` to delete the history entry from the server.

### Examples

```python
>> history = plex.history()
>> historyObj = history[0]  # New `MovieHistory` object
>> historyObj 
<MovieHistory:1039:Big-Buck-Bunny>
>> historyObj.reload()  # Cannot reload a history object
NotImplementedError: History objects cannot be reloaded. Use source() to get the source media item.
>> historyObj.source()  # Returns the source `Movie` object.
<Movie:1039:Big-Buck-Bunny>
```

All existing methods _should_ work with the new history objects, however, there may be some unknown behaviour since the object attributes may be different. It is recommended to work on the source media object to be safe.

```python
>> history = plex.history()
>> historyObj = history[0]  # New `MovieHistory` object
>> historyObj
<EpisodeHistory:765:Game-of-Thrones-s01e01>
>> historyObj.show()  # Still able to call existing methods on history objects.
<Show:763:Game-of-Thrones>
>> historyObj.editTitle('New Title')  # Not recommended to work on the history object.
>> episode = historyObj.source()  # Get the source `Episode` object.
>> episode.editTitle('New Title')  # Recommended to work on the source media object.
```


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
