### PR TITLE
Add `score` and `tagKey` attribute to hub search results

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2095,8 +2095,10 @@ class LibraryMediaTag(PlexObject):
             reason (str): The reason for the search result.
             reasonID (int): The reason ID for the search result.
             reasonTitle (str): The reason title for the search result.
+            score (float): The score for the search result.
             type (str): The type of search result (tag).
             tag (str): The title of the tag.
+            tagKey (str): The Plex Discover ratingKey (guid) for people.
             tagType (int): The type ID of the tag.
             tagValue (int): The value of the tag.
             thumb (str): The URL for the thumbnail of the tag (if available).
@@ -2117,8 +2119,10 @@ class LibraryMediaTag(PlexObject):
         self.reason = data.attrib.get('reason')
         self.reasonID = utils.cast(int, data.attrib.get('reasonID'))
         self.reasonTitle = data.attrib.get('reasonTitle')
+        self.score = utils.cast(float, data.attrib.get('score'))
         self.type = data.attrib.get('type')
         self.tag = data.attrib.get('tag')
+        self.tagKey = data.attrib.get('tagKey')
         self.tagType = utils.cast(int, data.attrib.get('tagType'))
         self.tagValue = utils.cast(int, data.attrib.get('tagValue'))
         self.thumb = data.attrib.get('thumb')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -144,6 +144,7 @@ def test_server_search(plex, movie):
     assert hub_tag.reason == "section"
     assert hub_tag.reasonID == hub_tag.librarySectionID
     assert hub_tag.reasonTitle == hub_tag.librarySectionTitle
+    assert utils.is_float(hub_tag.score, gte=0.0)
     assert hub_tag.type == "tag"
     assert hub_tag.tag == genre.tag
     assert hub_tag.tagType == 1
@@ -155,7 +156,10 @@ def test_server_search(plex, movie):
     assert plex.search(director.tag, mediatype="director")
     # Test actor search
     role = movie.roles[0]
-    assert plex.search(role.tag, mediatype="actor")
+    results = plex.search(role.tag, mediatype="actor")
+    assert results
+    hub_tag = results[0]
+    assert hub_tag.tagKey
 
 
 def test_server_playlist(plex, show):


### PR DESCRIPTION
## Description

Add `score` and `tagKey` attribute to hub search results.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
