### PR TITLE
Add config option to disable auto-reloading

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,6 +55,11 @@ Section [plexapi] Options
     Timeout in seconds to use when making requests to the Plex Media Server or Plex Client
     resources (default: 30).
 
+**autoreload**
+    By default PlexAPI will automatically :func:`~plexapi.base.PlexObject.reload` any :any:`PlexPartialObject`
+    when accessing a missing attribute. When this option is set to `false`, automatic reloading will be
+    disabled and :func:`~plexapi.base.PlexObject.reload` must be called manually (default: true).
+
 **enable_fast_connect**
     By default Plex will be trying to connect with all available connection methods simultaneously,
     combining local and remote addresses, http and https, and be waiting for all connection to
@@ -62,7 +67,7 @@ Section [plexapi] Options
     to connect to your Plex Server outside of your home network.
 
     When the options is set to `true` the connection procedure will be aborted with first successfully
-    established connection.
+    established connection (default: false).
 
 
 Section [auth] Options

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -4,7 +4,7 @@ import weakref
 from urllib.parse import urlencode
 from xml.etree import ElementTree
 
-from plexapi import X_PLEX_CONTAINER_SIZE, log, utils
+from plexapi import CONFIG, X_PLEX_CONTAINER_SIZE, log, utils
 from plexapi.exceptions import BadRequest, NotFound, UnknownType, Unsupported
 from plexapi.utils import cached_property
 
@@ -50,9 +50,14 @@ class PlexObject:
         self._initpath = initpath or self.key
         self._parent = weakref.ref(parent) if parent is not None else None
         self._details_key = None
-        self._overwriteNone = True  # Allow overwriting previous attribute values with `None` when manually reloading
-        self._autoReload = True  # Automatically reload the object when accessing a missing attribute
-        self._edits = None  # Save batch edits for a single API call
+
+        # Allow overwriting previous attribute values with `None` when manually reloading
+        self._overwriteNone = True
+        # Automatically reload the object when accessing a missing attribute
+        self._autoReload = CONFIG.get('plexapi.autoreload', True, bool)
+        # Attribute to save batch edits for a single API call
+        self._edits = None
+
         if data is not None:
             self._loadData(data)
         self._details_key = self._buildDetailsKey()

--- a/plexapi/config.py
+++ b/plexapi/config.py
@@ -3,6 +3,8 @@ import os
 from collections import defaultdict
 from configparser import ConfigParser
 
+from plexapi import utils
+
 
 class PlexConfig(ConfigParser):
     """ PlexAPI configuration object. Settings are stored in an INI file within the
@@ -35,7 +37,7 @@ class PlexConfig(ConfigParser):
                 # Second: check the config file has attr
                 section, name = key.lower().split('.')
                 value = self.data.get(section, {}).get(name, default)
-            return cast(value) if cast else value
+            return utils.cast(cast, value) if cast else value
         except:  # noqa: E722
             return default
 


### PR DESCRIPTION
## Description

Add config option to disable auto-reloading.

https://python-plexapi.readthedocs.io/en/stable/configuration.html#section-plexapi-options

### Config file:
```
[plexapi]
autoreload = false
```

### Environment variable:

```
PLEXAPI_PLEXAPI_AUTORELOAD=false
```


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
