### PR TITLE
Add `SubtitleStream` attributes for on-demand subtitles

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -415,7 +415,11 @@ class SubtitleStream(MediaPartStream):
             forced (bool): True if this is a forced subtitle.
             format (str): The format of the subtitle stream (ex: srt).
             headerCompression (str): The header compression of the subtitle stream.
+            providerTitle (str): The provider title where the on-demand subtitle is downloaded from.
+            score (int): The match score of the on-demand subtitle.
+            sourceKey (str): The source key of the on-demand subtitle.
             transient (str): Unknown.
+            userID (int): The user id of the user that downloaded the on-demand subtitle.
     """
     TAG = 'Stream'
     STREAMTYPE = 3
@@ -427,7 +431,11 @@ class SubtitleStream(MediaPartStream):
         self.forced = utils.cast(bool, data.attrib.get('forced', '0'))
         self.format = data.attrib.get('format')
         self.headerCompression = data.attrib.get('headerCompression')
+        self.providerTitle = data.attrib.get('providerTitle')
+        self.score = utils.cast(int, data.attrib.get('score'))
+        self.sourceKey = data.attrib.get('sourceKey')
         self.transient = data.attrib.get('transient')
+        self.userID = utils.cast(int, data.attrib.get('userID'))
 
     def setDefault(self):
         """ Sets this subtitle stream as the default subtitle stream. """


### PR DESCRIPTION
## Description

Add `SubtitleStream` attributes for on-demand subtitles.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
