### PR TITLE
Add search kwargs to `LibrarySection.get()`

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -4,7 +4,7 @@ from urllib.parse import quote_plus
 
 from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
-from plexapi.exceptions import BadRequest, NotFound
+from plexapi.exceptions import BadRequest
 from plexapi.mixins import (
     AdvancedSettingsMixin, SplitMergeMixin, UnmatchMatchMixin, ExtrasMixin, HubsMixin, PlayedUnplayedMixin, RatingMixin,
     ArtUrlMixin, ArtMixin, PosterUrlMixin, PosterMixin, ThemeMixin, ThemeUrlMixin,
@@ -178,14 +178,21 @@ class Artist(
             Parameters:
                 title (str): Title of the album to return.
         """
-        try:
-            return self.section().search(title, libtype='album', filters={'artist.id': self.ratingKey})[0]
-        except IndexError:
-            raise NotFound(f"Unable to find album '{title}'") from None
+        kwargs = {
+            'title': title,
+            'libtype': 'album',
+            'filters': {'artist.id': self.ratingKey}
+        }
+
+        return self.section().get(**kwargs)
 
     def albums(self, **kwargs):
         """ Returns a list of :class:`~plexapi.audio.Album` objects by the artist. """
-        return self.section().search(libtype='album', filters={'artist.id': self.ratingKey}, **kwargs)
+        return self.section().search(
+            libtype='album',
+            filters={'artist.id': self.ratingKey},
+            **kwargs
+        )
 
     def track(self, title=None, album=None, track=None):
         """ Returns the :class:`~plexapi.audio.Track` that matches the specified title.
@@ -198,17 +205,29 @@ class Artist(
             Raises:
                 :exc:`~plexapi.exceptions.BadRequest`: If title or album and track parameters are missing.
         """
-        key = f'{self.key}/allLeaves'
+        kwargs = {
+            'title': None,
+            'libtype': 'track',
+            'filters': {'artist.id': self.ratingKey}
+        }
+
         if title is not None:
-            return self.fetchItem(key, Track, title__iexact=title)
+            kwargs['title'] = title
         elif album is not None and track is not None:
-            return self.fetchItem(key, Track, parentTitle__iexact=album, index=track)
-        raise BadRequest('Missing argument: title or album and track are required')
+            kwargs['filters']['album.title'] = album
+            kwargs['filters']['track.index'] = track
+        else:
+            raise BadRequest('Missing argument: title or album and track are required')
+
+        return self.section().get(**kwargs)
 
     def tracks(self, **kwargs):
         """ Returns a list of :class:`~plexapi.audio.Track` objects by the artist. """
-        key = f'{self.key}/allLeaves'
-        return self.fetchItems(key, Track, **kwargs)
+        return self.section().search(
+            libtype='track',
+            filters={'artist.id': self.ratingKey},
+            **kwargs
+        )
 
     def get(self, title=None, album=None, track=None):
         """ Alias of :func:`~plexapi.audio.Artist.track`. """
@@ -312,21 +331,31 @@ class Album(
             Raises:
                 :exc:`~plexapi.exceptions.BadRequest`: If title or track parameter is missing.
         """
-        key = f'{self.key}/children'
+        kwargs = {
+            'title': None,
+            'libtype': 'track',
+            'filters': {'album.id': self.ratingKey}
+        }
+
         if title is not None and not isinstance(title, int):
-            return self.fetchItem(key, Track, title__iexact=title)
+            kwargs['title'] = title
         elif track is not None or isinstance(title, int):
             if isinstance(title, int):
-                index = title
+                kwargs['filters']['track.index'] = title
             else:
-                index = track
-            return self.fetchItem(key, Track, parentTitle__iexact=self.title, index=index)
-        raise BadRequest('Missing argument: title or track is required')
+                kwargs['filters']['track.index'] = track
+        else:
+            raise BadRequest('Missing argument: title or track is required')
+
+        return self.section().get(**kwargs)
 
     def tracks(self, **kwargs):
         """ Returns a list of :class:`~plexapi.audio.Track` objects in the album. """
-        key = f'{self.key}/children'
-        return self.fetchItems(key, Track, **kwargs)
+        return self.section().search(
+            libtype='track',
+            filters={'album.id': self.ratingKey},
+            **kwargs
+        )
 
     def get(self, title=None, track=None):
         """ Alias of :func:`~plexapi.audio.Album.track`. """
@@ -430,18 +459,6 @@ class Track(
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.year = utils.cast(int, data.attrib.get('year'))
 
-    def _prettyfilename(self):
-        """ Returns a filename for use in download. """
-        return f'{self.grandparentTitle} - {self.parentTitle} - {str(self.trackNumber).zfill(2)} - {self.title}'
-
-    def album(self):
-        """ Return the track's :class:`~plexapi.audio.Album`. """
-        return self.fetchItem(self.parentKey)
-
-    def artist(self):
-        """ Return the track's :class:`~plexapi.audio.Artist`. """
-        return self.fetchItem(self.grandparentKey)
-
     @property
     def locations(self):
         """ This does not exist in plex xml response but is added to have a common
@@ -456,6 +473,18 @@ class Track(
     def trackNumber(self):
         """ Returns the track number. """
         return self.index
+
+    def _prettyfilename(self):
+        """ Returns a filename for use in download. """
+        return f'{self.grandparentTitle} - {self.parentTitle} - {str(self.trackNumber).zfill(2)} - {self.title}'
+
+    def album(self):
+        """ Return the track's :class:`~plexapi.audio.Album`. """
+        return self.fetchItem(self.parentKey)
+
+    def artist(self):
+        """ Return the track's :class:`~plexapi.audio.Artist`. """
+        return self.fetchItem(self.grandparentKey)
 
     def _defaultSyncTitle(self):
         """ Returns str, default title for a new syncItem. """

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -186,10 +186,9 @@ class Collection(
     def items(self):
         """ Returns a list of all items in the collection. """
         if self._items is None:
-            self._items = self.section().search(
-                libtype=self.subtype,
-                filters={'collection': self.index}
-            )
+            key = f'{self.key}/children'
+            items = self.fetchItems(key)
+            self._items = items
         return self._items
 
     def visibility(self):

--- a/plexapi/collection.py
+++ b/plexapi/collection.py
@@ -186,9 +186,10 @@ class Collection(
     def items(self):
         """ Returns a list of all items in the collection. """
         if self._items is None:
-            key = f'{self.key}/children'
-            items = self.fetchItems(key)
-            self._items = items
+            self._items = self.section().search(
+                libtype=self.subtype,
+                filters={'collection': self.index}
+            )
         return self._items
 
     def visibility(self):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -588,19 +588,24 @@ class LibrarySection(PlexObject):
             raise BadRequest('You are unable to remove all locations from a library.')
         return self.edit(location=locations)
 
-    def get(self, title):
-        """ Returns the media item with the specified title.
+    def get(self, title, **kwargs):
+        """ Returns the media item with the specified title and kwargs.
 
             Parameters:
                 title (str): Title of the item to return.
+                kwargs (dict): Additional search parameters.
+                    See :func:`~plexapi.library.LibrarySection.search` for more info.
 
             Raises:
                 :exc:`~plexapi.exceptions.NotFound`: The title is not found in the library.
         """
         try:
-            return self.search(title)[0]
+            return self.search(title, limit=1, **kwargs)[0]
         except IndexError:
-            raise NotFound(f"Unable to find item '{title}'") from None
+            msg = f"Unable to find item with title '{title}'"
+            if kwargs:
+                msg += f" and kwargs {kwargs}"
+            raise NotFound(msg) from None
 
     def getGuid(self, guid):
         """ Returns the media item with the specified external Plex, IMDB, TMDB, or TVDB ID.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -906,7 +906,7 @@ class Episode(
 
         # If seasons are hidden, parentKey and parentRatingKey are missing from the XML response.
         # https://forums.plex.tv/t/parentratingkey-not-in-episode-xml-when-seasons-are-hidden/300553
-        if self.skipParent and not self.parentRatingKey:
+        if self.skipParent and data.attrib.get('parentRatingKey') is None:
             # Parse the parentRatingKey from the parentThumb
             if self.parentThumb and self.parentThumb.startswith('/library/metadata/'):
                 self.parentRatingKey = utils.cast(int, self.parentThumb.split('/')[3])

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -55,6 +55,9 @@ def test_library_sectionByID_with_attrs(plex, movies):
 
 def test_library_section_get_movie(movies):
     assert movies.get("Sita Sings the Blues")
+    assert movies.get(None, filters={"title": "Big Buck Bunny", "year": 2008})
+    with pytest.raises(NotFound):
+        movies.get("invalid title")
 
 
 def test_library_MovieSection_getGuid(movies, movie):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -670,7 +670,7 @@ def test_video_Movie_mixins_fields(movie):
     test_mixins.edit_user_rating(movie)
 
 
-@pytest.mark.anonymous
+@pytest.mark.anonymously
 def test_video_Movie_mixins_fields_edition(movie):
     with pytest.raises(BadRequest):
         test_mixins.edit_edition_title(movie)


### PR DESCRIPTION
## Description

~~Optimizes methods that retrieve object children to use the library `get()` / `search()` methods instead of fetching from `/children` or `/allLeaves`. The main purpose of this is to include guids in the objects without needing a separate reload.~~

~~Methods optimized:~~
* ~~`Show.season()` / `Show.seasons()`~~
* ~~`Show.episode()` / `Show.episodes()`~~
* ~~`Season.episode()` / `Season.episodes()`~~
* ~~`Artist.track()` / `Artist.tracks()`~~
* ~~`Album.track()` / `Album.tracks()`~~
* ~~`Collection.items()`~~

Adds `kwargs` to `LibrarySection.get()` which are passed through to `search()`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
