### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -50,7 +50,7 @@ body:
     id: python
     attributes:
       label: Python Version
-      placeholder: eg. 3.7.10
+      placeholder: eg. 3.8.17
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,17 +28,18 @@ jobs:
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}
 
-    - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
+    - name: Restore Python ${{ steps.python.outputs.python-version }} virtual environment
       id: cache-venv
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v3
       with:
         path: venv
         key: >-
           ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
           steps.python.outputs.python-version }}-${{
           hashFiles('requirements_dev.txt') }}
-        restore-keys: |
-          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
+        restore-keys: >-
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
+          steps.python.outputs.python-version }}-
 
     - name: Create Python virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -59,7 +60,7 @@ jobs:
 
 
   pytest:
-    name: pytest ${{ matrix.python-version }} (${{ matrix.plex }})
+    name: pytest (${{ matrix.plex }})
     needs: lint-flake8
     runs-on: ubuntu-latest
     env:
@@ -70,7 +71,6 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        python-version: [3.8]
         plex: ['unclaimed', 'claimed']
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
@@ -81,23 +81,24 @@ jobs:
     - name: Check out code from Github
       uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.DEFAULT_PYTHON }}
       id: python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.DEFAULT_PYTHON }}
 
-    - name: Restore Python ${{ matrix.python-version }} virtual environment
+    - name: Restore Python ${{ steps.python.outputs.python-version }} virtual environment
       id: cache-venv
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v3
       with:
         path: venv
         key: >-
           ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
           steps.python.outputs.python-version }}-${{
           hashFiles('requirements_dev.txt') }}
-        restore-keys: |
-          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
+        restore-keys: >-
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
+          steps.python.outputs.python-version }}-
 
     - name: Create Python virtual environment
       if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -129,7 +130,7 @@ jobs:
 
     - name: Cache PMS Docker image
       id: docker-cache
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/docker/plexinc
         key: ${{ runner.os }}-docker-pms-${{ steps.docker-digest.outputs.digest }}
@@ -184,7 +185,7 @@ jobs:
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v3
       with:
-        name: coverage-${{ matrix.plex }}-${{ matrix.python-version }}
+        name: coverage-${{ matrix.plex }}-${{ steps.python.outputs.python-version }}
         path: .coverage
 
 
@@ -211,23 +212,19 @@ jobs:
       with:
         python-version: ${{ env.DEFAULT_PYTHON }}
 
-    - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
+    - name: Restore Python ${{ steps.python.outputs.python-version }} virtual environment
       id: cache-venv
-      uses: actions/cache@v3.3.1
+      uses: actions/cache@v3
       with:
         path: venv
         key: >-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
           steps.python.outputs.python-version }}-${{
           hashFiles('requirements_dev.txt') }}
-        restore-keys: |
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-venv-${{ steps.python.outputs.python-version }}-
-
-    - name: Fail job if Python cache restore failed
-      if: steps.cache-venv.outputs.cache-hit != 'true'
-      run: |
-        echo "Failed to restore Python virtual environment from cache"
-        exit 1
+        restore-keys: >-
+          ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
+          steps.python.outputs.python-version }}-
+        fail-on-cache-miss: true
 
     - name: Download all coverage artifacts
       uses: actions/download-artifact@v3
@@ -240,6 +237,6 @@ jobs:
         coverage xml
 
     - name: Upload ${{ matrix.plex }} coverage to Codecov
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v3
       with:
         flags: ${{ matrix.plex }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   CACHE_VERSION: 1
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
 
 jobs:
   lint-flake8:
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
         plex: ['unclaimed', 'claimed']
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 
 env:
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
 
 jobs:
   build:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ sphinx:
 formats: all
 
 python:
-   version: 3.7
+   version: 3.8
    install:
       - requirements: requirements_dev.txt
       - method: pip

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import re
 import weakref
+from functools import cached_property
 from urllib.parse import urlencode
 from xml.etree import ElementTree
 
 from plexapi import CONFIG, X_PLEX_CONTAINER_SIZE, log, utils
 from plexapi.exceptions import BadRequest, NotFound, UnknownType, Unsupported
-from plexapi.utils import cached_property
 
 USER_DONT_RELOAD_FOR_KEYS = set()
 _DONT_RELOAD_FOR_KEYS = {'key'}

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 from datetime import datetime
+from functools import cached_property
 from urllib.parse import parse_qs, quote_plus, urlencode, urlparse
 
 from plexapi import log, media, utils
@@ -11,7 +12,7 @@ from plexapi.mixins import (
     ArtistEditMixins, AlbumEditMixins, TrackEditMixins, PhotoalbumEditMixins, PhotoEditMixins
 )
 from plexapi.settings import Setting
-from plexapi.utils import cached_property, deprecated
+from plexapi.utils import deprecated
 
 
 class Library(PlexObject):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+from functools import cached_property
 from urllib.parse import urlencode
 from xml.etree import ElementTree
 
@@ -17,7 +18,7 @@ from plexapi.media import Conversion, Optimized
 from plexapi.playlist import Playlist
 from plexapi.playqueue import PlayQueue
 from plexapi.settings import Settings
-from plexapi.utils import cached_property, deprecated
+from plexapi.utils import deprecated
 from requests.status_codes import _codes as codes
 
 # Need these imports to populate utils.PLEXOBJECTS

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -26,11 +26,6 @@ try:
 except ImportError:
     tqdm = None
 
-try:
-    from functools import cached_property
-except ImportError:
-    from backports.cached_property import cached_property  # noqa: F401
-
 log = logging.getLogger('plexapi')
 
 # Search Types - Plex uses these to filter specific media types when searching.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@
 # pip install -r requirements.txt
 #---------------------------------------------------------
 requests
-backports.cached-property; python_version<="3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,16 +3,16 @@
 # pip install -r requirements_dev.txt
 #---------------------------------------------------------
 coveralls==3.3.1
-flake8==5.0.4
-pillow==9.5.0
-pytest==7.3.1
+flake8==6.0.0
+pillow==10.0.0
+pytest==7.4.0
 pytest-cache==1.0
-pytest-cov==4.0.0
-pytest-mock<3.10.1
+pytest-cov==4.1.0
+pytest-mock==3.11.1
 recommonmark==0.7.1
 requests==2.31.0
-requests-mock==1.10.0
-sphinx==4.3.2
-sphinx-rtd-theme==1.2.1
+requests-mock==1.11.0
+sphinx==6.2.1
+sphinx-rtd-theme==1.2.2
 tqdm==4.65.0
-websocket-client==1.5.2
+websocket-client==1.6.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,6 @@
 # PlexAPI requirements to run py.test.
 # pip install -r requirements_dev.txt
 #---------------------------------------------------------
-backports.cached-property==1.0.2; python_version<="3.7"
 coveralls==3.3.1
 flake8==5.0.4
 pillow==9.5.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     url='https://github.com/pkkid/python-plexapi',
     packages=['plexapi'],
     install_requires=requirements,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     long_description=readme,
     keywords=['plex', 'api'],
     classifiers=[


### PR DESCRIPTION
## Description

Remove support for Python 3.7 which reached end-of-life on 2023-06-27.

Bumps minimum python version to Python 3.8.


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
