### PR TITLE
Add methods to retrieve public IP and geolocation

### DIFF
--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -352,3 +352,7 @@ def test_myplex_pin(account, plex):
         account.removeManagedUserPin(homeuser)
     finally:
         account.removeHomeUser(homeuser)
+
+
+def test_myplex_geoip(account):
+    assert account.geoip(account.publicIP())


### PR DESCRIPTION
## Description

Add methods to retrieve public IP and geolocation.

* `MyPlexAccount().publicIP()`
* `MyPlexAccount().geoip()`


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
