### PR TITLE
Fix ElementTree DeprecationWarning when testing truth value (3.12)

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -94,7 +94,7 @@ class PlexClient(PlexObject):
             raise Unsupported('Cannot reload an object not built from a URL.')
         self._initpath = self.key
         data = self.query(self.key, timeout=timeout)
-        if not len(data):
+        if data is None:
             raise NotFound(f"Client not found at {self._baseurl}")
         if self._clientIdentifier:
             client = next(

--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -94,7 +94,7 @@ class PlexClient(PlexObject):
             raise Unsupported('Cannot reload an object not built from a URL.')
         self._initpath = self.key
         data = self.query(self.key, timeout=timeout)
-        if not data:
+        if not len(data):
             raise NotFound(f"Client not found at {self._baseurl}")
         if self._clientIdentifier:
             client = next(

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1773,7 +1773,7 @@ class MyPlexPinLogin:
             params = None
 
         response = self._query(url, self._session.post, params=params)
-        if not response:
+        if response is None:
             return None
 
         self._id = response.attrib.get('id')
@@ -1790,7 +1790,7 @@ class MyPlexPinLogin:
 
         url = self.CHECKPINS.format(pinid=self._id)
         response = self._query(url)
-        if not response:
+        if response is None:
             return False
 
         token = response.attrib.get('authToken')


### PR DESCRIPTION
## Description
Fix a DeprecationWarning for Python 3.12.
```
  /.../python3.12/site-packages/plexapi/client.py:97: DeprecationWarning: Testing an element's truth value will raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
    if not data:
```

From the Python 3.12 [Changelog](https://docs.python.org/3.12/whatsnew/3.12.html#deprecated)

> [xml.etree.ElementTree](https://docs.python.org/3.12/library/xml.etree.elementtree.html#module-xml.etree.ElementTree): The module now emits [DeprecationWarning](https://docs.python.org/3.12/library/exceptions.html#DeprecationWarning) when testing the truth value of an [xml.etree.ElementTree.Element](https://docs.python.org/3.12/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element). Before, the Python implementation emitted [FutureWarning](https://docs.python.org/3.12/library/exceptions.html#FutureWarning), and the C implementation emitted nothing.

https://github.com/python/cpython/blob/v3.12.0rc1/Lib/xml/etree/ElementTree.py#L201-L208

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)