### PR TITLE
Validate empty items explicitly when editing items

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1684,7 +1684,7 @@ class LibrarySection(PlexObject):
 
     def _validateItems(self, items):
         """ Validates the specified items are from this library and of the same type. """
-        if not items:
+        if items is None or items == []:
             raise BadRequest('No items specified.')
         
         if not isinstance(items, list):


### PR DESCRIPTION
## Description

Validate empty items explicitly when editing items.

Fixes #1215

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
