### PR TITLE
feat(alert): add option to use custom socket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,12 @@ Installation & Documentation
 
     pip install plexapi
 
+*Install extra features:*
+
+.. code-block:: python
+
+    pip install plexapi[alert]  # Install with dependencies required for plexapi.alert
+
 Documentation_ can be found at Read the Docs.
 
 .. _Documentation: http://python-plexapi.readthedocs.io/en/latest/

--- a/plexapi/alert.py
+++ b/plexapi/alert.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
+import socket
+from typing import Callable
 import threading
 
 from plexapi import log
@@ -32,15 +34,17 @@ class AlertListener(threading.Thread):
             callbackError (func): Callback function to call on errors. The callback function
                 will be sent a single argument 'error' which will contain the Error object.
                 :samp:`def my_callback(error): ...`
+            ws_socket (socket): Socket to use for the connection. If not specified, a new socket will be created.
     """
     key = '/:/websockets/notifications'
 
-    def __init__(self, server, callback=None, callbackError=None):
+    def __init__(self, server, callback: Callable = None, callbackError: Callable = None, ws_socket: socket = None):
         super(AlertListener, self).__init__()
         self.daemon = True
         self._server = server
         self._callback = callback
         self._callbackError = callbackError
+        self._socket = ws_socket
         self._ws = None
 
     def run(self):
@@ -52,8 +56,9 @@ class AlertListener(threading.Thread):
         # create the websocket connection
         url = self._server.url(self.key, includeToken=True).replace('http', 'ws')
         log.info('Starting AlertListener: %s', url)
-        self._ws = websocket.WebSocketApp(url, on_message=self._onMessage,
-                                          on_error=self._onError)
+
+        self._ws = websocket.WebSocketApp(url, on_message=self._onMessage, on_error=self._onError, socket=self._socket)
+
         self._ws.run_forever()
 
     def stop(self):
@@ -66,10 +71,8 @@ class AlertListener(threading.Thread):
 
     def _onMessage(self, *args):
         """ Called when websocket message is received.
-            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp
-            object and the message as a STR. Current releases appear to only return the message.
+
             We are assuming the last argument in the tuple is the message.
-            This is to support compatibility with current and previous releases of websocket-client.
         """
         message = args[-1]
         try:
@@ -82,10 +85,8 @@ class AlertListener(threading.Thread):
 
     def _onError(self, *args):  # pragma: no cover
         """ Called when websocket error is received.
-            In earlier releases, websocket-client returned a tuple of two parameters: a websocket.app.WebSocketApp
-            object and the error. Current releases appear to only return the error.
+
             We are assuming the last argument in the tuple is the message.
-            This is to support compatibility with current and previous releases of websocket-client.
         """
         err = args[-1]
         try:

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
     url='https://github.com/pkkid/python-plexapi',
     packages=['plexapi'],
     install_requires=requirements,
+    extras_require={
+        'alert': ["websocket-client>=1.3.3"],
+    },
     python_requires='>=3.8',
     long_description=readme,
     keywords=['plex', 'api'],


### PR DESCRIPTION
## Description

This PR adds the ability to pass in a custom socket for the AlertListener.

In some cases attempting to use the AlertListener, will fail with the message `getsockaddrarg: bad family`. I believe this is due to using IPv6 on Linux hosts, but I cannot confirm. Adding the ability to use a custom socket, would allow the developer to create their own socket to use in this event.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
