### PR TITLE
docs: add Windows make file

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
-import os
 import shlex
 import subprocess
 from os.path import abspath, dirname, join
 
-import pytest
-
 SKIP_EXAMPLES = ["Example 4"]
 
 
-@pytest.mark.skipif(os.name == "nt", reason="No make.bat specified for Windows")
 def test_build_documentation():
     docroot = join(dirname(dirname(abspath(__file__))), "docs")
     cmd = shlex.split("sphinx-build -aE . _build")


### PR DESCRIPTION
## Description
This PR simply adds a make.bat file allowing building of the docs on Windows, without having to install a bash shell and make.

## Type of change


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
