### PR TITLE
Tests skip additional tests that require plex pass

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,8 @@ def account_once(account):
 def account_plexpass(account):
     if not account.subscriptionActive:
         pytest.skip(
-            "PlexPass subscription is not active, unable to test sync-stuff, be careful!"
+            "PlexPass subscription is not active, unable to test dashboard, movie extras, movie editions, "
+            "or sync-stuff, be careful!"
         )
     return account
 

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -77,6 +77,11 @@ def test_myplex_users(account):
     print(f"Found user: {user}")
     assert user, f"Could not find user {users[0].title}"
 
+    try:
+        users[0].servers[0]
+    except IndexError:
+        return pytest.skip(f"{users[0].title} shared user does not have access to any servers")
+
     assert (
         len(users[0].servers[0].sections()) > 0
     ), "Couldn't info about the shared libraries"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -439,7 +439,7 @@ def test_server_system_devices(plex):
     
 
 @pytest.mark.authenticated
-def test_server_dashboard_bandwidth(plex):
+def test_server_dashboard_bandwidth(account_plexpass, plex):
     bandwidthData = plex.bandwidth()
     assert len(bandwidthData)
     bandwidth = bandwidthData[0]
@@ -456,7 +456,7 @@ def test_server_dashboard_bandwidth(plex):
 
 
 @pytest.mark.authenticated
-def test_server_dashboard_bandwidth_filters(plex):
+def test_server_dashboard_bandwidth_filters(account_plexpass, plex):
     at = datetime(2021, 1, 1)
     filters = {
         'at>': at,

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -586,7 +586,7 @@ def test_video_Movie_editions(movie):
 
 
 @pytest.mark.authenticated
-def test_video_Movie_extras(movies):
+def test_video_Movie_extras(account_plexpass, movies):
     movie = movies.get("Sita Sings The Blues")
     extras = movie.extras()
     assert extras
@@ -677,7 +677,7 @@ def test_video_Movie_mixins_fields_edition(movie):
 
 
 @pytest.mark.authenticated
-def test_video_Movie_mixins_fields_edition_authenticated(movie):
+def test_video_Movie_mixins_fields_edition_authenticated(account_plexpass, movie):
     test_mixins.edit_edition_title(movie)
 
 


### PR DESCRIPTION
## Description
Fixes 4 claimed server tests that fail without an active Plex Pass subscription.

Also, improves the logic of the shared account test, by checking if the user has access to any server before checking if they have access to any sections.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable (updated)
