### PR TITLE
Simplify PlexPartialObject eq return

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -502,7 +502,7 @@ class PlexPartialObject(PlexObject):
 
     def __eq__(self, other):
         if isinstance(other, PlexPartialObject):
-            return other not in [None, []] and self.key == other.key
+            return self.key == other.key
         return NotImplemented
 
     def __hash__(self):


### PR DESCRIPTION
## Description

Don't need to check for `None` or `[]` with the instance check for `PlexPartialObject`.

See https://github.com/pkkid/python-plexapi/pull/1182#discussion_r1303552641


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
