### PR TITLE
Update searchDiscover to use discover baseurl instead of metadata

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -111,6 +111,7 @@ class MyPlexAccount(PlexObject):
     # Hub sections
     VOD = 'https://vod.provider.plex.tv'                                                        # get
     MUSIC = 'https://music.provider.plex.tv'                                                    # get
+    DISCOVER = 'https://discover.provider.plex.tv'
     METADATA = 'https://metadata.provider.plex.tv'
     key = 'https://plex.tv/api/v2/user'
 
@@ -1056,7 +1057,7 @@ class MyPlexAccount(PlexObject):
             'includeMetadata': 1
         }
 
-        data = self.query(f'{self.METADATA}/library/search', headers=headers, params=params)
+        data = self.query(f'{self.DISCOVER}/library/search', headers=headers, params=params)
         searchResults = data['MediaContainer'].get('SearchResults', [])
         searchResult = next((s.get('SearchResult', []) for s in searchResults if s.get('id') == 'external'), [])
 


### PR DESCRIPTION
## Description

To search content in Plex Discover service, we used to request `https://metadata.provider.plex.tv/library/search` but now the url has changed to `https://discover.provider.plex.tv/library/search`.
Old url always returns *404 Not found*.

`metadata.provider.plex.tv` hostname still works to fetch online metadata and watchlist but not used anymore by Plex Web app.

Fixes https://github.com/Taxel/PlexTraktSync/issues/1575

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
