### PR TITLE
Add language option to config

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -130,6 +130,10 @@ Section [header] Options
     Header value used for X_PLEX_IDENTIFIER to all Plex server and Plex client requests. This is generally
     a UUID, serial number, or other number unique id for the device (default: `result of hex(uuid.getnode())`).
 
+**language**
+    Header value used for X_PLEX_LANGUAGE to all Plex server and Plex client requests. This is an ISO 639-1
+    language code (default: en).
+
 **platform**
     Header value used for X_PLEX_PLATFORM to all Plex server and Plex client requests. Example platforms
     include: iOS, MacOSX, Android, LG (default: `result of platform.uname()[0]`).

--- a/plexapi/__init__.py
+++ b/plexapi/__init__.py
@@ -30,6 +30,7 @@ X_PLEX_VERSION = CONFIG.get('header.version', VERSION)
 X_PLEX_DEVICE = CONFIG.get('header.device', X_PLEX_PLATFORM)
 X_PLEX_DEVICE_NAME = CONFIG.get('header.device_name', uname()[1])
 X_PLEX_IDENTIFIER = CONFIG.get('header.identifier', str(hex(getnode())))
+X_PLEX_LANGUAGE = CONFIG.get('header.language', 'en')
 BASE_HEADERS = reset_base_headers()
 
 # Logging Configuration

--- a/plexapi/config.py
+++ b/plexapi/config.py
@@ -63,6 +63,7 @@ def reset_base_headers():
         'X-Plex-Device': plexapi.X_PLEX_DEVICE,
         'X-Plex-Device-Name': plexapi.X_PLEX_DEVICE_NAME,
         'X-Plex-Client-Identifier': plexapi.X_PLEX_IDENTIFIER,
+        'X-Plex-Language': plexapi.X_PLEX_LANGUAGE,
         'X-Plex-Sync-Version': '2',
         'X-Plex-Features': 'external-media',
     }


### PR DESCRIPTION
## Description

Adds the language option to the config which is passed as the `X-Plex-Language` header. The language is an ISO 639-1 language code. The default is `en`.

Closes #1234

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
