### PR TITLE
Fix invalid escape sequence DeprecationWarning

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -227,7 +227,7 @@ class PlexObject:
 
                     fetchItem(ekey, viewCount__gte=0)
                     fetchItem(ekey, Media__container__in=["mp4", "mkv"])
-                    fetchItem(ekey, guid__iregex=r"(imdb:\/\/|themoviedb:\/\/)")
+                    fetchItem(ekey, guid__iregex=r"(imdb:\\/\\/|themoviedb:\\/\\/)")
                     fetchItem(ekey, Media__Part__file__startswith="D:\\Movies")
 
         """

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -227,7 +227,7 @@ class PlexObject:
 
                     fetchItem(ekey, viewCount__gte=0)
                     fetchItem(ekey, Media__container__in=["mp4", "mkv"])
-                    fetchItem(ekey, guid__iregex=r"(imdb:\\/\\/|themoviedb:\\/\\/)")
+                    fetchItem(ekey, guid__iregex=r"(imdb://|themoviedb://)")
                     fetchItem(ekey, Media__Part__file__startswith="D:\\Movies")
 
         """


### PR DESCRIPTION
## Description

```
  /.../plexapi/base.py:157: DeprecationWarning: invalid escape sequence '\/'
    """ Load the specified key to find and build all items with the specified tag
```