### PR TITLE
Remove reload after saving the batch-edits

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -626,7 +626,8 @@ class PlexPartialObject(PlexObject):
         return self
 
     def saveEdits(self):
-        """ Save all the batch edits and automatically reload the object.
+        """ Save all the batch edits. The object needs to be reloaded manually,
+            if required.
             See :func:`~plexapi.base.PlexPartialObject.batchEdits` for details.
         """
         if not isinstance(self._edits, dict):
@@ -635,7 +636,7 @@ class PlexPartialObject(PlexObject):
         edits = self._edits
         self._edits = None
         self._edit(**edits)
-        return self.reload()
+        return self
 
     def refresh(self):
         """ Refreshing a Library or individual item causes the metadata for the item to be

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -614,7 +614,7 @@ def test_video_Movie_batchEdits(movie):
         .editTagline(new_tagline) \
         .editStudio(new_studio)
     assert movie._edits != {}
-    movie.saveEdits()
+    movie.saveEdits().reload()
     assert movie._edits is None
     assert movie.title == new_title
     assert movie.summary == new_summary
@@ -626,7 +626,7 @@ def test_video_Movie_batchEdits(movie):
         .editSummary(summary, locked=False) \
         .editTagline(tagline, locked=False) \
         .editStudio(studio, locked=False) \
-        .saveEdits()
+        .saveEdits().reload()
     assert movie.title == title
     assert movie.summary == summary
     assert movie.tagline == tagline


### PR DESCRIPTION
## Description

Remove reload after saving the batch-edits so the user can handle it themselves, if required.

Fixes # (issue) N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the docstring for new or existing methods
- [X] I have added tests when applicable
