### PR TITLE
Fix `isLatest()` return value

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -631,7 +631,7 @@ class PlexServer(PlexObject):
     def isLatest(self):
         """ Check if the installed version of PMS is the latest. """
         release = self.query('/updater/status')
-        return utils.cast(bool, release.get('canInstall'))
+        return not utils.cast(bool, release.get('canInstall'))
 
     def installUpdate(self):
         """ Install the newest version of Plex Media Server. """


### PR DESCRIPTION
## Description

Fixes the returned value of isLatest() to True when there is no update and False when a new update can be installed.

Fixes #1255 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
