### PR TITLE
Fix handling of live TV sessions

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -946,11 +946,17 @@ class Episode(
     @cached_property
     def parentThumb(self):
         """ Returns the parentThumb. Refer to the Episode attributes. """
-        return self._parentThumb or self._season.thumb
+        if self._parentThumb:
+            return self._parentThumb
+        if self._season:
+            return self._season.thumb
+        return None
 
     @cached_property
     def _season(self):
         """ Returns the :class:`~plexapi.video.Season` object by querying for the show's children. """
+        if not self.grandparentKey:
+            return None
         return self.fetchItem(
             f'{self.grandparentKey}/children?excludeAllLeaves=1&index={self.parentIndex}'
         )

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -930,7 +930,11 @@ class Episode(
     @cached_property
     def parentKey(self):
         """ Returns the parentKey. Refer to the Episode attributes. """
-        return self._parentKey or f'/library/metadata/{self.parentRatingKey}'
+        if self._parentKey:
+            return self._parentKey
+        if self.parentRatingKey:
+            return f'/library/metadata/{self.parentRatingKey}'
+        return None
 
     @cached_property
     def parentRatingKey(self):
@@ -940,8 +944,10 @@ class Episode(
         # Parse the parentRatingKey from the parentThumb
         if self._parentThumb and self._parentThumb.startswith('/library/metadata/'):
             return utils.cast(int, self._parentThumb.split('/')[3])
-        # Get the parentRatingKey from the season's ratingKey
-        return self._season.ratingKey
+        # Get the parentRatingKey from the season's ratingKey if available
+        if self._season:
+            return self._season.ratingKey
+        return None
 
     @cached_property
     def parentThumb(self):


### PR DESCRIPTION
## Description

Live TV playback sessions are normally classified as an `Episode` but season & show information (`parentKey`/`grandparentKey`) is rarely (never?) available. This adds guards for those lookups.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
