### PR TITLE
Fix datetime returning UTC

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -323,7 +323,7 @@ def toDatetime(value, format=None):
                 return None
         else:
             try:
-                return datetime.utcfromtimestamp(0) + timedelta(seconds=int(value))
+                return datetime(1970, 1, 1) + timedelta(seconds=int(value))
             except ValueError:
                 log.info('Failed to parse "%s" to datetime as timestamp, defaulting to None', value)
                 return None

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -323,13 +323,18 @@ def toDatetime(value, format=None):
                 return None
         else:
             try:
-                return datetime.fromtimestamp(0) + timedelta(seconds=int(value))
+                value = int(value)
             except ValueError:
                 log.info('Failed to parse "%s" to datetime as timestamp, defaulting to None', value)
                 return None
-            except OverflowError:
-                log.info('Failed to parse "%s" to datetime as timestamp (out-of-bounds), defaulting to None', value)
-                return None
+            try:
+                return datetime.fromtimestamp(value)
+            except (OSError, OverflowError):
+                try:
+                    return datetime.fromtimestamp(0) + timedelta(seconds=value)
+                except OverflowError:
+                    log.info('Failed to parse "%s" to datetime as timestamp (out-of-bounds), defaulting to None', value)
+                    return None
     return value
 
 

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -323,7 +323,7 @@ def toDatetime(value, format=None):
                 return None
         else:
             try:
-                return datetime(1970, 1, 1) + timedelta(seconds=int(value))
+                return datetime.fromtimestamp(0) + timedelta(seconds=int(value))
             except ValueError:
                 log.info('Failed to parse "%s" to datetime as timestamp, defaulting to None', value)
                 return None


### PR DESCRIPTION
## Description
`datetime.utcfromtimestamp` will emit a DeprecationWarning in Python 3.12.

The "official" replacement would be to use `fromtimestamp(tz=timezone.utc).replace(tzinfo=None)`. However in this particular case `datetime(1970, 1, 1)` seems to be the easier solution.

https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp