### PR TITLE
Fix `isLatest()` and add `canInstallUpdate()`

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -615,7 +615,8 @@ class PlexServer(PlexObject):
         return self.checkForUpdate(force=force, download=download)
 
     def checkForUpdate(self, force=True, download=False):
-        """ Returns a :class:`~plexapi.base.Release` object containing release info.
+        """ Returns a :class:`~plexapi.server.Release` object containing release info
+            if an update is available or None if no update is available.
 
             Parameters:
                 force (bool): Force server to check for new releases
@@ -629,12 +630,19 @@ class PlexServer(PlexObject):
             return releases[0]
 
     def isLatest(self):
-        """ Check if the installed version of PMS is the latest. """
+        """ Returns True if the installed version of Plex Media Server is the latest. """
         release = self.checkForUpdate(force=True)
         return release is None
 
+    def canInstallUpdate(self):
+        """ Returns True if the newest version of Plex Media Server can be installed automatically.
+            (e.g. Windows and Mac can install updates automatically, but Docker and NAS devices cannot.)
+        """
+        release = self.query('/updater/status')
+        return utils.cast(bool, release.get('canInstall'))
+
     def installUpdate(self):
-        """ Install the newest version of Plex Media Server. """
+        """ Automatically install the newest version of Plex Media Server. """
         # We can add this but dunno how useful this is since it sometimes
         # requires user action using a gui.
         part = '/updater/apply'

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -630,8 +630,8 @@ class PlexServer(PlexObject):
 
     def isLatest(self):
         """ Check if the installed version of PMS is the latest. """
-        release = self.query('/updater/status')
-        return utils.cast(bool, release.get('canInstall'))
+        release = self.checkForUpdate(force=True)
+        return release is None
 
     def installUpdate(self):
         """ Install the newest version of Plex Media Server. """


### PR DESCRIPTION
## Description

Reverts #1253 `isLatest()` check and separates out `canInstall` to a new method `canInstallUpdate()`.

Fixes #1255
Closes #1256

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
