### PR TITLE
Fix return for history source if media no longer exists

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -953,8 +953,10 @@ class PlexHistory(object):
         raise NotImplementedError('History objects cannot be reloaded. Use source() to get the source media item.')
 
     def source(self):
-        """ Return the source media object for the history entry. """
-        return self.fetchItem(self._details_key)
+        """ Return the source media object for the history entry
+            or None if the media no longer exists on the server.
+        """
+        return self.fetchItem(self._details_key) if self._details_key else None
 
     def delete(self):
         """ Delete the history entry. """


### PR DESCRIPTION
## Description

Return `None` for `PlexHistory.source()` if media no longer exists on the server.

Fixes #1267

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
