### PR TITLE
Add `MyPlexAccount.ping()` to refresh authentication token

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -108,6 +108,7 @@ class MyPlexAccount(PlexObject):
     OPTOUTS = 'https://plex.tv/api/v2/user/{userUUID}/settings/opt_outs'                        # get
     LINK = 'https://plex.tv/api/v2/pins/link'                                                   # put
     VIEWSTATESYNC = 'https://plex.tv/api/v2/user/view_state_sync'                               # put
+    PING = 'https://plex.tv/api/v2/ping'
     # Hub sections
     VOD = 'https://vod.provider.plex.tv'                                                        # get
     MUSIC = 'https://music.provider.plex.tv'                                                    # get
@@ -249,6 +250,15 @@ class MyPlexAccount(PlexObject):
             return response.text.strip()
         data = response.text.encode('utf8')
         return ElementTree.fromstring(data) if data.strip() else None
+
+    def ping(self):
+        """ Ping the Plex.tv API.
+            This will refresh the authentication token to prevent it from expiring.
+        """
+        pong = self.query(self.PING)
+        if pong is not None:
+            return utils.cast(bool, pong.text)
+        return False
 
     def device(self, name=None, clientId=None):
         """ Returns the :class:`~plexapi.myplex.MyPlexDevice` that matches the name specified.

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -361,3 +361,7 @@ def test_myplex_pin(account, plex):
 
 def test_myplex_geoip(account):
     assert account.geoip(account.publicIP())
+
+
+def test_myplex_ping(account):
+    assert account.ping()


### PR DESCRIPTION
## Description

Add `MyPlexAccount.ping()` method to ping the Plex.tv API. The `/api/v2/ping` endpoint is used to refresh the Plex authentication token to prevent it from expiring.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
