### PR TITLE
fix: explicitly set includeFiles

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -355,8 +355,7 @@ class PlexServer(PlexObject):
             key = f'/services/browse/{base64path}'
         else:
             key = '/services/browse'
-        if includeFiles:
-            key += '?includeFiles=1'
+        key += f'?includeFiles={int(includeFiles)}'  # starting with PMS v1.32.7.7621 this must set explicitly
         return self.fetchItems(key)
 
     def walk(self, path=None):


### PR DESCRIPTION
## Description

Bootstrapping the Plex server is failing in CI with Plex version `1.32.7.7621`. This fix is a result of the discussion on the discord server https://discord.com/channels/741380592104636467/741380592104636470/1169048836761727168

Closes #1280

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
