### PR TITLE
build(pypi): verify readme and add long_description_content_type

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,8 +28,13 @@ jobs:
       run: |
         pip install -U pip
         pip install -r requirements.txt
-        pip install setuptools wheel
+        pip install setuptools twine wheel
         python setup.py sdist bdist_wheel
+
+    - name: Verify README
+      # https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup
+      run: |
+        python -m twine check dist/*
 
     - name: Upload builds
       uses: actions/upload-artifact@v3

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     },
     python_requires='>=3.8',
     long_description=readme,
+    long_description_content_type='text/x-rst',
     keywords=['plex', 'api'],
     classifiers=[
         'Operating System :: OS Independent',


### PR DESCRIPTION
## Description
This PR makes the following changes to the python package build.

- validates the description/readme with twine
- adds the content type property for the long description (Fixes these warnings: https://github.com/pkkid/python-plexapi/actions/runs/6401596340/job/17376932194#step:4:15)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
