### PR TITLE
Use edit mixins for Playlists

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -1223,3 +1223,10 @@ class CollectionEditMixins(
     LabelMixin
 ):
     pass
+
+
+class PlaylistEditMixins(
+    ArtLockMixin, PosterLockMixin,
+    SortTitleMixin, SummaryMixin, TitleMixin
+):
+    pass

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -7,7 +7,7 @@ from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest, NotFound, Unsupported
 from plexapi.library import LibrarySection, MusicSection
-from plexapi.mixins import SmartFilterMixin, ArtMixin, PosterMixin
+from plexapi.mixins import SmartFilterMixin, ArtMixin, PosterMixin, PlaylistEditMixins
 from plexapi.utils import deprecated
 
 
@@ -15,7 +15,8 @@ from plexapi.utils import deprecated
 class Playlist(
     PlexPartialObject, Playable,
     SmartFilterMixin,
-    ArtMixin, PosterMixin
+    ArtMixin, PosterMixin,
+    PlaylistEditMixins
 ):
     """ Represents a single Playlist.
 
@@ -308,10 +309,15 @@ class Playlist(
 
     def _edit(self, **kwargs):
         """ Actually edit the playlist. """
+        if isinstance(self._edits, dict):
+            self._edits.update(kwargs)
+            return self
+
         key = f'{self.key}{utils.joinArgs(kwargs)}'
         self._server.query(key, method=self._server._session.put)
         return self
 
+    @deprecated('use "editTitle" and "editSummary" instead', stacklevel=3)
     def edit(self, title=None, summary=None):
         """ Edit the playlist.
 

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -43,6 +43,7 @@ class Playlist(
             smart (bool): True if the playlist is a smart playlist.
             summary (str): Summary of the playlist.
             title (str): Name of the playlist.
+            titleSort (str): Title to use when sorting (defaults to title).
             type (str): 'playlist'
             updatedAt (datetime): Datetime the playlist was updated.
     """
@@ -72,6 +73,7 @@ class Playlist(
         self.smart = utils.cast(bool, data.attrib.get('smart'))
         self.summary = data.attrib.get('summary')
         self.title = data.attrib.get('title')
+        self.titleSort = data.attrib.get('titleSort', self.title)
         self.type = data.attrib.get('type')
         self.updatedAt = utils.toDatetime(data.attrib.get('updatedAt'))
         self._items = None  # cache for self.items

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -94,7 +94,7 @@ def test_Playlist_edit(plex, movie):
         playlist = plex.createPlaylist(title, items=movie)
         assert playlist.title == title
         assert playlist.summary == ''
-        playlist.edit(title=new_title, summary=new_summary)
+        playlist.editTitle(new_title).editSummary(new_summary)
         playlist.reload()
         assert playlist.title == new_title
         assert playlist.summary == new_summary
@@ -330,3 +330,9 @@ def test_Playlist_mixins_images(playlist):
     test_mixins.lock_poster(playlist)
     test_mixins.edit_art(playlist)
     test_mixins.edit_poster(playlist)
+
+
+def test_Playlist_mixins_fields(playlist):
+    test_mixins.edit_sort_title(playlist)
+    test_mixins.edit_summary(playlist)
+    test_mixins.edit_title(playlist)


### PR DESCRIPTION
## Description

* Adds `editTitle()`, `editSummary()`, and `editSortTitle()` methods to `Playlists`.
* Deprecate `Playlist.edit()` method.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
