### PR TITLE
Add support for 'group' and 'having' keys in smart filters

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2727,7 +2727,9 @@ class FilteringType(PlexObject):
             ('id', 'integer', 'Rating Key'),
             ('index', 'integer', f'{self.type.capitalize()} Number'),
             ('lastRatedAt', 'date', f'{self.type.capitalize()} Last Rated'),
-            ('updatedAt', 'date', 'Date Updated')
+            ('updatedAt', 'date', 'Date Updated'),
+            ('group', 'string', 'SQL Group By Statement'),
+            ('having', 'string', 'SQL Having Clause')
         ]
 
         if self.type == 'movie':
@@ -2778,11 +2780,14 @@ class FilteringType(PlexObject):
 
         manualFields = []
         for field, fieldType, fieldTitle in additionalFields:
+            if field not in {'group', 'having'}:
+                field = f"{prefix}{field}"
             fieldXML = (
-                f'<Field key="{prefix}{field}" '
+                f'<Field key="{field}" '
                 f'title="{fieldTitle}" '
                 f'type="{fieldType}"/>'
             )
+
             manualFields.append(self._manuallyLoadXML(fieldXML, FilteringField))
 
         return manualFields

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -116,11 +116,14 @@ class SmartFilterMixin:
         filtersDict = {}
         special_keys = {"type", "sort"}
         integer_keys = {"includeGuids", "limit"}
-        reserved_keys = special_keys | integer_keys
+        as_is_keys = {"group", "having"}
+        reserved_keys = special_keys | integer_keys | as_is_keys
         while feed:
             key, value = feed.popleft()
             if key in integer_keys:
                 filtersDict[key] = int(value)
+            elif key in as_is_keys:
+                filtersDict[key] = value
             elif key == "type":
                 filtersDict["libtype"] = utils.reverseSearchType(value)
             elif key == "sort":


### PR DESCRIPTION
SmartFilterMixin

- fixes #1285

## Description

excludes keys not belonging to smart filter

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
