### PR TITLE
Fix `batchMultiEdits()` for collections

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -789,7 +789,8 @@ class EditTagsMixin:
 
         if not remove:
             tags = getattr(self, self._tagPlural(tag), [])
-            items = tags + items
+            if isinstance(tags, list):
+                items = tags + items
 
         edits = self._tagHelper(self._tagSingular(tag), items, locked, remove)
         edits.update(kwargs)


### PR DESCRIPTION
## Description

Fix `batchMultiEdits()` for collections.

* Libraries have a `collections()` method which has the same name as media's `collections` attribute. Check that the tags are a list when adding tags together.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
