### PR TITLE
Add sonicallySimilar method to Audio class

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from urllib.parse import quote_plus
 
-from typing import TypeVar
+from typing import List, Optional, TypeVar
 
 from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
@@ -134,22 +134,27 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
 
     def sonicallySimilar(
         self: TAudio,
-        limit: int = 30,
-        maxDistance: float = 0.25,
+        limit: Optional[int] = None,
+        maxDistance: Optional[float] = None,
         **kwargs,
     ) -> List[TAudio]:
         """Returns a list of sonically similar audio items.
 
         Parameters:
-            limit (int): maximum count of items to return, unlimited if `None`.
-            maxDistance (float): maximum distance between tracks, 0.0 - 1.0.
+            limit (int): Maximum count of items to return. Default 50 (server default)
+            maxDistance (float): Maximum distance between tracks, 0.0 - 1.0. Default 0.25 (server default).
             **kwargs: Additional options passed into :func:`~plexapi.base.PlexObject.fetchItems`.
 
         Returns:
             List[:class:`~plexapi.audio.Audio`]: list of sonically similar audio items.
         """
 
-        key = f"/library/metadata/{self.ratingKey}/nearest?limit={limit}&maxDistance={maxDistance}"
+        key = f"{self.key}/nearest"
+        params = {"maxDistance": maxDistance, "limit": limit}
+        key += utils.joinArgs(
+            {k: v for k, v in params.items() if v is not None}
+        )
+
         return self.fetchItems(
             key,
             cls=self.__class__,

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from urllib.parse import quote_plus
 
-from typing import List, Optional, TypeVar
+from typing import Any, Dict, List, Optional, TypeVar
 
 from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
@@ -59,6 +59,7 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         self.addedAt = utils.toDatetime(data.attrib.get('addedAt'))
         self.art = data.attrib.get('art')
         self.artBlurHash = data.attrib.get('artBlurHash')
+        self.distance = utils.cast(float, data.attrib.get('distance'))
         self.fields = self.findItems(data, media.Field)
         self.guid = data.attrib.get('guid')
         self.index = utils.cast(int, data.attrib.get('index'))
@@ -71,7 +72,6 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         self.listType = 'audio'
         self.moods = self.findItems(data, media.Mood)
         self.musicAnalysisVersion = utils.cast(int, data.attrib.get('musicAnalysisVersion'))
-        self.distance = utils.cast(float, data.attrib.get('distance'))
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
         self.summary = data.attrib.get('summary')
         self.thumb = data.attrib.get('thumb')
@@ -150,10 +150,12 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         """
 
         key = f"{self.key}/nearest"
-        params = {"maxDistance": maxDistance, "limit": limit}
-        key += utils.joinArgs(
-            {k: v for k, v in params.items() if v is not None}
-        )
+        params: Dict[str, Any] = {}
+        if limit is not None:
+            params['limit'] = limit
+        if maxDistance is not None:
+            params['maxDistance'] = maxDistance
+        key += utils.joinArgs(params)
 
         return self.fetchItems(
             key,

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from urllib.parse import quote_plus
 
-from typing_extensions import Self
+from typing import TypeVar
 
 from plexapi import media, utils
 from plexapi.base import Playable, PlexPartialObject, PlexHistory, PlexSession
@@ -14,6 +14,9 @@ from plexapi.mixins import (
     ArtistEditMixins, AlbumEditMixins, TrackEditMixins
 )
 from plexapi.playlist import Playlist
+
+
+Self = TypeVar("Self", bound="Audio")
 
 
 class Audio(PlexPartialObject, PlayedUnplayedMixin):
@@ -130,7 +133,7 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         return myplex.sync(sync_item, client=client, clientId=clientId)
 
     def sonicallySimilar(
-        self,
+        self: Self,
         limit: int = 30,
         maxDistance: float = 0.25,
         **kwargs,
@@ -141,7 +144,6 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
             limit (int): maximum count of items to return, unlimited if `None`.
             maxDistance (float): maximum distance between tracks, 0.0 - 1.0.
             **kwargs: Additional options passed into :func:`~plexapi.base.PlexObject.fetchItems`.
-
 
         Returns:
             List[:class:`~plexapi.audio.Audio`]: list of sonically similar audio items.

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -16,7 +16,7 @@ from plexapi.mixins import (
 from plexapi.playlist import Playlist
 
 
-Self = TypeVar("Self", bound="Audio")
+TAudio = TypeVar("TAudio", bound="Audio")
 
 
 class Audio(PlexPartialObject, PlayedUnplayedMixin):
@@ -27,6 +27,7 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
             addedAt (datetime): Datetime the item was added to the library.
             art (str): URL to artwork image (/library/metadata/<ratingKey>/art/<artid>).
             artBlurHash (str): BlurHash string for artwork image.
+            distance (float): Sonic Distance of the item from the seed item.
             fields (List<:class:`~plexapi.media.Field`>): List of field objects.
             guid (str): Plex GUID for the artist, album, or track (plex://artist/5d07bcb0403c64029053ac4c).
             index (int): Plex index number (often the track number).
@@ -39,7 +40,6 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
             listType (str): Hardcoded as 'audio' (useful for search filters).
             moods (List<:class:`~plexapi.media.Mood`>): List of mood objects.
             musicAnalysisVersion (int): The Plex music analysis version for the item.
-            distance (float): Sonic Distance of the item from the seed item.
             ratingKey (int): Unique key identifying the item.
             summary (str): Summary of the artist, album, or track.
             thumb (str): URL to thumbnail image (/library/metadata/<ratingKey>/thumb/<thumbid>).
@@ -133,12 +133,12 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         return myplex.sync(sync_item, client=client, clientId=clientId)
 
     def sonicallySimilar(
-        self: Self,
+        self: TAudio,
         limit: int = 30,
         maxDistance: float = 0.25,
         **kwargs,
-    ) -> "list[Self]":
-        """ Find sonically similar audio items.
+    ) -> List[TAudio]:
+        """Returns a list of sonically similar audio items.
 
         Parameters:
             limit (int): maximum count of items to return, unlimited if `None`.

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -439,6 +439,13 @@ def test_audio_Audio_section(artist, album, track):
     assert track.section().key == album.section().key == artist.section().key
 
 
+def test_audio_Audio_sonicallySimilar(artist, album, track):
+    #  TODO: assert list of tracks/albums/artists
+    assert isinstance(artist.sonicallySimilar(limit=15), list)
+    assert isinstance(album.sonicallySimilar(maxDistance=0.1), list)
+    assert isinstance(track.sonicallySimilar(), list)
+
+
 def test_audio_Artist_download(monkeydownload, tmpdir, artist):
     total = len(artist.tracks())
     filepaths = artist.download(savepath=str(tmpdir))

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -438,7 +438,7 @@ def test_audio_Audio_section(artist, album, track):
     assert track.section()
     assert track.section().key == album.section().key == artist.section().key
 
-
+@pytest.mark.authenticated
 def test_audio_Audio_sonicallySimilar(artist):
     similar_audio = artist.sonicallySimilar()
     assert isinstance(similar_audio, list)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -439,11 +439,10 @@ def test_audio_Audio_section(artist, album, track):
     assert track.section().key == album.section().key == artist.section().key
 
 
-def test_audio_Audio_sonicallySimilar(artist, album, track):
-    #  TODO: assert list of tracks/albums/artists
-    assert isinstance(artist.sonicallySimilar(limit=15), list)
-    assert isinstance(album.sonicallySimilar(maxDistance=0.1), list)
-    assert isinstance(track.sonicallySimilar(), list)
+def test_audio_Audio_sonicallySimilar(artist):
+    similar_audio = artist.sonicallySimilar()
+    assert isinstance(similar_audio, list)
+    assert all(isinstance(i, type(artist)) for i in similar_audio)
 
 
 def test_audio_Artist_download(monkeydownload, tmpdir, artist):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -444,6 +444,12 @@ def test_audio_Audio_sonicallySimilar(artist):
     assert isinstance(similar_audio, list)
     assert all(isinstance(i, type(artist)) for i in similar_audio)
 
+    similar_audio = artist.sonicallySimilar(limit=1)
+    assert len(similar_audio) <= 1
+
+    similar_audio = artist.sonicallySimilar(maxDistance=0.1)
+    assert all(i.distance <= 0.1 for i in similar_audio)
+
 
 def test_audio_Artist_download(monkeydownload, tmpdir, artist):
     total = len(artist.tracks())

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -438,6 +438,7 @@ def test_audio_Audio_section(artist, album, track):
     assert track.section()
     assert track.section().key == album.section().key == artist.section().key
 
+
 @pytest.mark.authenticated
 def test_audio_Audio_sonicallySimilar(artist):
     similar_audio = artist.sonicallySimilar()


### PR DESCRIPTION
closes #1183

## Description

This pull request adds a new method, `sonicallySimilar`, to the `Audio` class. This method allows users to find sonically similar audio items based on a maximum distance between tracks. The method takes in optional parameters for `limit` and `maxDistance` and returns a list of sonically similar audio items.

`Audio` class now contains a new attribute `distance` which is the sonic distance from the seed item.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
