### PR TITLE
feat: add PlexPartialObject.isLocked method

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -565,6 +565,14 @@ class PlexPartialObject(PlexObject):
         """ Returns True if this is not a full object. """
         return not self.isFullObject()
 
+    def isLocked(self, field: str):
+        """ Returns True if the specified field is locked, otherwise False.
+
+            Parameters:
+                field (str): The name of the field.
+        """
+        return next((f.locked for f in self.fields if f.name == field), False)
+
     def _edit(self, **kwargs):
         """ Actually edit an object. """
         if isinstance(self._edits, dict):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -190,6 +190,8 @@ def test_Collection_edit(collection, movies):
     assert collection.summary == newSummary
     lockedFields = [f.locked for f in collection.fields if f.name in fields]
     assert all(lockedFields)
+    for f in fields:
+        assert collection.isLocked(field=f)
 
     collection.edit(
         title=title,
@@ -210,6 +212,8 @@ def test_Collection_edit(collection, movies):
     assert collection.summary == summary
     lockedFields = [f.locked for f in collection.fields if f.name in fields]
     assert not any(lockedFields)
+    for f in fields:
+        assert not collection.isLocked(field=f)
 
 
 def test_Collection_create(plex, tvshows):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1411,6 +1411,7 @@ def test_video_edits_locked(movie, episode):
         if field.name == 'titleSort':
             assert movie.titleSort == 'New Title Sort'
             assert field.locked is True
+            assert movie.isLocked(field=field.name)
     movie.edit(**{'titleSort.value': movieTitleSort, 'titleSort.locked': 0})
 
     episodeTitleSort = episode.titleSort
@@ -1420,6 +1421,7 @@ def test_video_edits_locked(movie, episode):
         if field.name == 'titleSort':
             assert episode.titleSort == 'New Title Sort'
             assert field.locked is True
+            assert episode.isLocked(field=field.name)
     episode.edit(**{'titleSort.value': episodeTitleSort, 'titleSort.locked': 0})
 
 


### PR DESCRIPTION
## Description
Add convenience method to check if a field is locked on a Plex item (PlexPartialItem), per discussion in discord server: https://discord.com/channels/741380592104636467/803096038088114207/1172722600967942145

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
