### PR TITLE
doc: fix documentation for BaseResource.provider

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1003,7 +1003,7 @@ class BaseResource(PlexObject):
         Attributes:
             TAG (str): 'Photo' or 'Track'
             key (str): API URL (/library/metadata/<ratingkey>).
-            provider (str): The source of the art or poster, None for Theme objects.
+            provider (str): The source of the resource. 'local' for local files (e.g. theme.mp3), None if uploaded or agent-/plugin-supplied.
             ratingKey (str): Unique key identifying the resource.
             selected (bool): True if the resource is currently selected.
             thumb (str): The URL to retrieve the resource thumbnail.


### PR DESCRIPTION
## Description

The documentation currently states that BaseResource.provider is None for themes. This is wrong in the case of locally supplied theme.mp3 files:

```xml
<MediaContainer size="1" identifier="com.plexapp.plugins.library" mediaTagPrefix="/system/bundle/media/flags/" mediaTagVersion="1698157769">
  <Track key="/library/metadata/59577/file?url=metadata%3A%2F%2Fthemes%2Fec58933694f4dc38b70ec4ad3c11f2762e4fe866" ratingKey="metadata://themes/ec58933694f4dc38b70ec4ad3c11f2762e4fe866" thumb="/library/metadata/59577/file?url=metadata%3A%2F%2Fthemes%2Fec58933694f4dc38b70ec4ad3c11f2762e4fe866" selected="1" provider="local"/>
</MediaContainer>
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
