### PR TITLE
test: fix test_audio_Audio_sonicallySimilar authenticated test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,7 @@ def account_plexpass(account):
     if not account.subscriptionActive:
         pytest.skip(
             "PlexPass subscription is not active, unable to test dashboard, movie extras, movie editions, "
-            "or sync-stuff, be careful!"
+            "sync-stuff, etc... be careful!"
         )
     return account
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -444,7 +444,7 @@ def test_audio_Audio_section(artist, album, track):
 
 
 @pytest.mark.authenticated
-def test_audio_Audio_sonicallySimilar(artist):
+def test_audio_Audio_sonicallySimilar(account, artist):
     similar_audio = artist.sonicallySimilar()
     assert isinstance(similar_audio, list)
     assert all(isinstance(i, type(artist)) for i in similar_audio)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -444,7 +444,7 @@ def test_audio_Audio_section(artist, album, track):
 
 
 @pytest.mark.authenticated
-def test_audio_Audio_sonicallySimilar(account, artist):
+def test_audio_Audio_sonicallySimilar(account_plexpass, artist):
     similar_audio = artist.sonicallySimilar()
     assert isinstance(similar_audio, list)
     assert all(isinstance(i, type(artist)) for i in similar_audio)


### PR DESCRIPTION
## Description
This test will fail without a PlexPass subscriptions, so passing in the `account` fixture.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
