### PR TITLE
style: remove trailing comma after kwargs

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -136,7 +136,7 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
         self: TAudio,
         limit: Optional[int] = None,
         maxDistance: Optional[float] = None,
-        **kwargs,
+        **kwargs
     ) -> List[TAudio]:
         """Returns a list of sonically similar audio items.
 


### PR DESCRIPTION
## Description
Removes unnecessary trailing commas.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
