### PR TITLE
Guard against None `parentIndex`

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -961,11 +961,9 @@ class Episode(
     @cached_property
     def _season(self):
         """ Returns the :class:`~plexapi.video.Season` object by querying for the show's children. """
-        if not self.grandparentKey:
-            return None
-        return self.fetchItem(
-            f'{self.grandparentKey}/children?excludeAllLeaves=1&index={self.parentIndex}'
-        )
+        if self.grandparentKey and self.parentIndex is not None:
+            return self.fetchItem(f'{self.grandparentKey}/children?excludeAllLeaves=1&index={self.parentIndex}')
+        return None
 
     def __repr__(self):
         return '<{}>'.format(
@@ -1003,7 +1001,11 @@ class Episode(
     @cached_property
     def seasonNumber(self):
         """ Returns the episode's season number. """
-        return self.parentIndex if isinstance(self.parentIndex, int) else self._season.seasonNumber
+        if isinstance(self.parentIndex, int):
+            return self.parentIndex
+        elif self._season:
+            return self._season.index
+        return None
 
     @property
     def seasonEpisode(self):


### PR DESCRIPTION
## Description

Guard against None `Episode.parentIndex`

Ref: https://github.com/pkkid/python-plexapi/pull/1251#discussion_r1394134558

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
