### PR TITLE
Add support for on-demand subtitles

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -444,6 +444,8 @@ class SubtitleStream(MediaPartStream):
             forced (bool): True if this is a forced subtitle.
             format (str): The format of the subtitle stream (ex: srt).
             headerCompression (str): The header compression of the subtitle stream.
+            hearingImpaired (bool): True if this is a hearing impaired (SDH) subtitle.
+            perfectMatch (bool): True if the on-demand subtitle is a perfect match.
             providerTitle (str): The provider title where the on-demand subtitle is downloaded from.
             score (int): The match score of the on-demand subtitle.
             sourceKey (str): The source key of the on-demand subtitle.
@@ -460,6 +462,8 @@ class SubtitleStream(MediaPartStream):
         self.forced = utils.cast(bool, data.attrib.get('forced', '0'))
         self.format = data.attrib.get('format')
         self.headerCompression = data.attrib.get('headerCompression')
+        self.hearingImpaired = utils.cast(bool, data.attrib.get('hearingImpaired', '0'))
+        self.perfectMatch = utils.cast(bool, data.attrib.get('perfectMatch'))
         self.providerTitle = data.attrib.get('providerTitle')
         self.score = utils.cast(int, data.attrib.get('score'))
         self.sourceKey = data.attrib.get('sourceKey')

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -447,7 +447,7 @@ class SubtitleStream(MediaPartStream):
             hearingImpaired (bool): True if this is a hearing impaired (SDH) subtitle.
             perfectMatch (bool): True if the on-demand subtitle is a perfect match.
             providerTitle (str): The provider title where the on-demand subtitle is downloaded from.
-            score (int): The match score of the on-demand subtitle.
+            score (int): The match score (download count) of the on-demand subtitle.
             sourceKey (str): The source key of the on-demand subtitle.
             transient (str): Unknown.
             userID (int): The user id of the user that downloaded the on-demand subtitle.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -146,6 +146,48 @@ class Video(PlexPartialObject, PlayedUnplayedMixin):
             self._server.query(url, self._server._session.post, data=subfile, params=params, headers=headers)
         return self
 
+    def searchSubtitles(self, language='en', hearingImpaired=0, forced=0):
+        """ Search for on-demand subtitles for the video.
+            See https://support.plex.tv/articles/subtitle-search/.
+
+            Parameters:
+                language (str, optional): Language code (ISO 639-1) of the subtitles to search for.
+                    Default 'en'.
+                hearingImpaired (int, optional): Search option for SDH subtitles.
+                    Default 0.
+                    (0 = Prefer non-SDH subtitles, 1 = Prefer SDH subtitles,
+                    2 = Only show SDH subtitles, 3 = Only show non-SDH subtitles)
+                forced (int, optional): Search option for forced subtitles.
+                    Default 0.
+                    (0 = Prefer non-forced subtitles, 1 = Prefer forced subtitles,
+                    2 = Only show forced subtitles, 3 = Only show non-forced subtitles)
+
+            Returns:
+                List<:class:`~plexapi.media.SubtitleStream`>: List of SubtitleStream objects.
+        """
+        params = {
+            'language': language,
+            'hearingImpaired': hearingImpaired,
+            'forced': forced,
+        }
+        key = f'{self.key}/subtitles{utils.joinArgs(params)}'
+        return self.fetchItems(key)
+
+    def downloadSubtitles(self, subtitleStream):
+        """ Download on-demand subtitles for the video.
+            See https://support.plex.tv/articles/subtitle-search/.
+
+            Note: This method is asynchronous and returns immediately before subtitles are fully downloaded.
+
+            Parameters:
+                subtitleStream (:class:`~plexapi.media.SubtitleStream`):
+                    Subtitle object returned from :func:`~plexapi.video.Video.searchSubtitles`.
+        """
+        key = f'{self.key}/subtitles'
+        params = {'key': subtitleStream.key}
+        self._server.query(key, self._server._session.put, params=params)
+        return self
+
     def removeSubtitles(self, streamID=None, streamTitle=None):
         """ Remove Subtitle from movie's subtitles listing.
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -397,7 +397,6 @@ def test_video_Episode_subtitleStreams(episode):
 
 
 def test_video_Movie_upload_select_remove_subtitle(movie, subtitle):
-
     filepath = os.path.realpath(subtitle.name)
 
     movie.uploadSubtitles(filepath)
@@ -407,7 +406,6 @@ def test_video_Movie_upload_select_remove_subtitle(movie, subtitle):
 
     movie.subtitleStreams()[0].setSelected()
     movie.reload()
-
     subtitleSelection = movie.subtitleStreams()[0]
     assert subtitleSelection.selected
 
@@ -420,6 +418,22 @@ def test_video_Movie_upload_select_remove_subtitle(movie, subtitle):
         os.remove(filepath)
     except OSError:
         pass
+
+
+def test_video_Movie_on_demand_subtitles(movie, account):
+    movie_subtitles = movie.subtitleStreams()
+    subtitles = movie.searchSubtitles()
+    assert subtitles != []
+
+    subtitle = subtitles[0]
+
+    movie.downloadSubtitles(subtitle)
+    utils.wait_until(lambda: len(movie.reload().subtitleStreams()) > len(movie_subtitles))
+    subtitle_sourceKeys = {stream.sourceKey: stream for stream in movie.subtitleStreams()}
+    assert subtitle.sourceKey in subtitle_sourceKeys
+
+    movie.removeSubtitles(subtitleStream=subtitle_sourceKeys[subtitle.sourceKey]).reload()
+    assert subtitle.sourceKey not in [stream.sourceKey for stream in movie.subtitleStreams()]
 
 
 def test_video_Movie_match(movies):


### PR DESCRIPTION
## Description

Changes:
* New methods `Video.searchSubtitles` to search for on-demand subtitles and `Video.downloadSubtitltes` to download on-demand subtitles.
* Cleaned up `uploadSubtitle` and `removeSubtitles` methods and updated doc strings.

Breaking change:
* Added `subtitleStream` as first argument to `Video.removeSubtitles`.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
