### PR TITLE
Remove DeprecationWarning for watched methods

### DIFF
--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -316,19 +316,16 @@ class PlayedUnplayedMixin:
         return self
 
     @property
-    @deprecated('use "isPlayed" instead', stacklevel=3)
     def isWatched(self):
-        """ Returns True if the show is watched. """
+        """ Alias to self.isPlayed. """
         return self.isPlayed
 
-    @deprecated('use "markPlayed" instead')
     def markWatched(self):
-        """ Mark the video as played. """
+        """ Alias to :func:`~plexapi.mixins.PlayedUnplayedMixin.markPlayed`. """
         self.markPlayed()
 
-    @deprecated('use "markUnplayed" instead')
     def markUnwatched(self):
-        """ Mark the video as unplayed. """
+        """ Alias to :func:`~plexapi.mixins.PlayedUnplayedMixin.markUnplayed`. """
         self.markUnplayed()
 
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -351,6 +351,13 @@ def test_video_movie_watched(movie):
     movie.reload()
     assert movie.viewCount == 0
 
+    movie.markWatched()
+    movie.reload()
+    assert movie.viewCount == 1
+    movie.markUnwatched()
+    movie.reload()
+    assert movie.viewCount == 0
+
 
 def test_video_Movie_isPartialObject(movie):
     assert movie.isPartialObject()
@@ -873,12 +880,14 @@ def test_video_Show_markPlayed(show):
     show.markPlayed()
     show.reload()
     assert show.isPlayed
+    assert show.isWatched
 
 
 def test_video_Show_markUnplayed(show):
     show.markUnplayed()
     show.reload()
     assert not show.isPlayed
+    assert not show.isWatched
 
 
 def test_video_Show_refresh(show):


### PR DESCRIPTION
## Description

Plex renamed “Mark as Played/Unplayed” back to “Mark as Watched/Unwatched”. Keep both played and watched methods as aliases.

Ref: https://forums.plex.tv/t/plex-web/20528/430
Ref: #984

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
