### PR TITLE
Add slug attributes to Movie, Show, Season, and Episode

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -344,6 +344,7 @@ class Movie(
             ratingImage (str): Key to critic rating image (rottentomatoes://image.rating.rotten).
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
+            slug (str): The clean watch.plex.tv URL identifier for the movie.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
@@ -387,6 +388,7 @@ class Movie(
         self.ratingImage = data.attrib.get('ratingImage')
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
+        self.slug = data.attrib.get('slug')
         self.similar = self.findItems(data, media.Similar)
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
@@ -507,6 +509,7 @@ class Show(
                 (None = Library default, tmdbAiring = The Movie Database (Aired),
                 aired = TheTVDB (Aired), dvd = TheTVDB (DVD), absolute = TheTVDB (Absolute)).
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
+            slug (str): The clean watch.plex.tv URL identifier for the show.
             studio (str): Studio that created show (Di Bonaventura Pictures; 21 Laps Entertainment).
             subtitleLanguage (str): Setting that indicates the preferred subtitle language.
             subtitleMode (int): Setting that indicates the auto-select subtitle mode.
@@ -556,6 +559,7 @@ class Show(
         self.seasonCount = utils.cast(int, data.attrib.get('seasonCount', self.childCount))
         self.showOrdering = data.attrib.get('showOrdering')
         self.similar = self.findItems(data, media.Similar)
+        self.slug = data.attrib.get('slug')
         self.studio = data.attrib.get('studio')
         self.subtitleLanguage = data.attrib.get('audioLanguage', '')
         self.subtitleMode = utils.cast(int, data.attrib.get('subtitleMode', '-1'))
@@ -693,6 +697,7 @@ class Season(
             parentIndex (int): Plex index number for the show.
             parentKey (str): API URL of the show (/library/metadata/<parentRatingKey>).
             parentRatingKey (int): Unique key identifying the show.
+            parentSlug (str): The clean watch.plex.tv URL identifier for the show.
             parentStudio (str): Studio that created show.
             parentTheme (str): URL to show theme resource (/library/metadata/<parentRatingkey>/theme/<themeid>).
             parentThumb (str): URL to show thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
@@ -722,6 +727,7 @@ class Season(
         self.parentIndex = utils.cast(int, data.attrib.get('parentIndex'))
         self.parentKey = data.attrib.get('parentKey')
         self.parentRatingKey = utils.cast(int, data.attrib.get('parentRatingKey'))
+        self.parentSlug = data.attrib.get('parentSlug')
         self.parentStudio = data.attrib.get('parentStudio')
         self.parentTheme = data.attrib.get('parentTheme')
         self.parentThumb = data.attrib.get('parentThumb')
@@ -853,6 +859,7 @@ class Episode(
             grandparentGuid (str): Plex GUID for the show (plex://show/5d9c086fe9d5a1001f4d9fe6).
             grandparentKey (str): API URL of the show (/library/metadata/<grandparentRatingKey>).
             grandparentRatingKey (int): Unique key identifying the show.
+            grandparentSlug (str): The clean watch.plex.tv URL identifier for the show.
             grandparentTheme (str): URL to show theme resource (/library/metadata/<grandparentRatingkey>/theme/<themeid>).
             grandparentThumb (str): URL to show thumbnail image (/library/metadata/<grandparentRatingKey>/thumb/<thumbid>).
             grandparentTitle (str): Name of the show for the episode.
@@ -898,6 +905,7 @@ class Episode(
         self.grandparentGuid = data.attrib.get('grandparentGuid')
         self.grandparentKey = data.attrib.get('grandparentKey')
         self.grandparentRatingKey = utils.cast(int, data.attrib.get('grandparentRatingKey'))
+        self.grandparentSlug = data.attrib.get('grandparentSlug')
         self.grandparentTheme = data.attrib.get('grandparentTheme')
         self.grandparentThumb = data.attrib.get('grandparentThumb')
         self.grandparentTitle = data.attrib.get('grandparentTitle')

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -92,6 +92,7 @@ def test_video_Movie_attrs(movies):
         assert utils.is_metadata(movie.primaryExtraKey)
     assert movie.ratingKey >= 1
     assert movie._server._baseurl == utils.SERVER_BASEURL
+    assert movie.slug == "sita-sings-the-blues"
     assert movie.studio == "Nina Paley"
     assert utils.is_string(movie.summary, gte=100)
     assert movie.tagline == "The Greatest Break-Up Story Ever Told."
@@ -771,6 +772,7 @@ def test_video_Show_attrs(show):
     assert show._server._baseurl == utils.SERVER_BASEURL
     assert utils.is_int(show.seasonCount)
     assert show.showOrdering in (None, 'aired')
+    assert show.slug == "game-of-thrones"
     assert show.studio == "Revolution Sun Studios"
     assert utils.is_string(show.summary, gte=100)
     assert show.subtitleLanguage == ''
@@ -987,6 +989,7 @@ def test_video_Season_attrs(show):
     assert season.parentIndex == 1
     assert utils.is_metadata(season.parentKey)
     assert utils.is_int(season.parentRatingKey)
+    assert season.parentSlug == "game-of-thrones"
     assert season.parentStudio == "Revolution Sun Studios"
     assert utils.is_metadata(season.parentTheme)
     if season.parentThumb:
@@ -1163,6 +1166,7 @@ def test_video_Episode_attrs(episode):
     assert episode.grandparentGuid == "plex://show/5d9c086c46115600200aa2fe"
     assert utils.is_metadata(episode.grandparentKey)
     assert utils.is_int(episode.grandparentRatingKey)
+    assert episode.grandparentSlug == "game-of-thrones"
     assert utils.is_metadata(episode.grandparentTheme)
     if episode.grandparentThumb:
         assert utils.is_thumb(episode.grandparentThumb)


### PR DESCRIPTION
## Description

Adds `slug` attributes, the watch.plex.tv clean URL identifier, to:
* `Movie.slug`
* `Show.slug`
* `Season.parentSlug`
* `Episode.grandparentSlug`

Requires: Plex Media Server 1.40.0.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
