### PR TITLE
Add genres attribute to Track

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -427,6 +427,7 @@ class Track(
             chapterSource (str): Unknown
             collections (List<:class:`~plexapi.media.Collection`>): List of collection objects.
             duration (int): Length of the track in milliseconds.
+            genres (List<:class:`~plexapi.media.Genre`>): List of genre objects.
             grandparentArt (str): URL to album artist artwork (/library/metadata/<grandparentRatingKey>/art/<artid>).
             grandparentGuid (str): Plex GUID for the album artist (plex://artist/5d07bcb0403c64029053ac4c).
             grandparentKey (str): API URL of the album artist (/library/metadata/<grandparentRatingKey>).
@@ -463,6 +464,7 @@ class Track(
         self.chapterSource = data.attrib.get('chapterSource')
         self.collections = self.findItems(data, media.Collection)
         self.duration = utils.cast(int, data.attrib.get('duration'))
+        self.genres = self.findItems(data, media.Genre)
         self.grandparentArt = data.attrib.get('grandparentArt')
         self.grandparentGuid = data.attrib.get('grandparentGuid')
         self.grandparentKey = data.attrib.get('grandparentKey')

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -1199,7 +1199,7 @@ class AlbumEditMixins(
 class TrackEditMixins(
     ArtLockMixin, PosterLockMixin, ThemeLockMixin,
     AddedAtMixin, TitleMixin, TrackArtistMixin, TrackNumberMixin, TrackDiscNumberMixin, UserRatingMixin,
-    CollectionMixin, LabelMixin, MoodMixin
+    CollectionMixin, GenreMixin, LabelMixin, MoodMixin
 ):
     pass
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -278,6 +278,7 @@ def test_audio_Track_attrs(album):
         assert utils.is_art(track.art)
     assert track.chapterSource is None
     assert utils.is_int(track.duration)
+    assert track.genres == []
     if track.grandparentArt:
         assert utils.is_art(track.grandparentArt)
     assert utils.is_metadata(track.grandparentKey)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -419,6 +419,7 @@ def test_audio_Track_mixins_fields(track):
 
 def test_audio_Track_mixins_tags(track):
     test_mixins.edit_collection(track)
+    test_mixins.edit_genre(track)
     test_mixins.edit_label(track)
     test_mixins.edit_mood(track)
 


### PR DESCRIPTION
## Description

Adds `genres` attribute to `Track`.

Requires: Plex Media Server 1.40.0
https://forums.plex.tv/t/plex-media-server/30447/609

Closes #1321.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
