### PR TITLE
fix(scripts): offset butler tasks to reduce ci random failures

### DIFF
--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -510,26 +510,19 @@ if __name__ == "__main__":  # noqa: C901
 
     # disable butler tasks
     current_hour = datetime.now().hour
-    new_hour12 = current_hour + 12
-    new_hour15 = current_hour + 15
-    if new_hour12 >= 24:
-        new_hour12 -= 24
-    if new_hour15 >= 24:
-        new_hour15 -= 24
-    server.settings.get("ButlerStartHour").set(new_hour12)
-    server.settings.get("ButlerEndHour").set(new_hour15)
+    start_hour = (current_hour + 12) % 24
+    end_hour = (current_hour + 15) % 24
+    server.settings.get("ButlerStartHour").set(start_hour)
+    server.settings.get("ButlerEndHour").set(end_hour)
 
     # find all butler settings
-    butler_settings = []
     for setting in server.settings.all():
         if setting.id.lower().startswith("butler") and isinstance(setting.value, bool):
-            butler_settings.append(setting.id)
-    for setting in butler_settings:
-        try:
-            server.settings.get(setting).set(False)
-            print("Disabled setting '{}'".format(setting))
-        except NotFound:
-            print("Setting '{}' not found".format(setting))
+            try:
+                setting.set(False)
+                print("Disabled setting '{}'".format(setting))
+            except NotFound:
+                print("Setting '{}' not found".format(setting))
 
     # save settings
     server.settings.save()


### PR DESCRIPTION
## Description
I had discovered random timeout failures in CI around the time that butler tasks were running.

This PR offsets butler tasks, and attempts to disable any found butler tasks.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
