### PR TITLE
Use default 4k chunk size (powers of 2) for download

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -407,7 +407,7 @@ def downloadSessionImages(server, filename=None, height=150, width=150,
     return info
 
 
-def download(url, token, filename=None, savepath=None, session=None, chunksize=4024,   # noqa: C901
+def download(url, token, filename=None, savepath=None, session=None, chunksize=4096,   # noqa: C901
              unpack=False, mocked=False, showstatus=False):
     """ Helper to download a thumb, videofile or other media item. Returns the local
         path to the downloaded file.


### PR DESCRIPTION
## Description

Added as 4096 as probably changing from 1024 in https://github.com/pkkid/python-plexapi/commit/7e9bd51d5530198051b62b6adc5e33bfefce3911

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
