### PR TITLE
Add warning for ambiguous library title

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
+import warnings
+from collections import defaultdict
 from datetime import datetime
 from functools import cached_property
 from urllib.parse import parse_qs, quote_plus, urlencode, urlparse
@@ -41,14 +43,22 @@ class Library(PlexObject):
     def _loadSections(self):
         """ Loads and caches all the library sections. """
         key = '/library/sections'
-        self._sectionsByID = {}
-        self._sectionsByTitle = {}
+        sectionsByID = {}
+        sectionsByTitle = defaultdict(list)
+        libcls = {
+            'movie': MovieSection,
+            'show': ShowSection,
+            'artist': MusicSection,
+            'photo': PhotoSection,
+        }
+
         for elem in self._server.query(key):
-            for cls in (MovieSection, ShowSection, MusicSection, PhotoSection):
-                if elem.attrib.get('type') == cls.TYPE:
-                    section = cls(self._server, elem, key)
-                    self._sectionsByID[section.key] = section
-                    self._sectionsByTitle[section.title.lower().strip()] = section
+            section = libcls.get(elem.attrib.get('type'), LibrarySection)(self._server, elem, initpath=key)
+            sectionsByID[section.key] = section
+            sectionsByTitle[section.title.lower().strip()].append(section)
+
+        self._sectionsByID = sectionsByID
+        self._sectionsByTitle = dict(sectionsByTitle)
 
     def sections(self):
         """ Returns a list of all media sections in this library. Library sections may be any of
@@ -60,17 +70,29 @@ class Library(PlexObject):
 
     def section(self, title):
         """ Returns the :class:`~plexapi.library.LibrarySection` that matches the specified title.
+            Note: Multiple library sections with the same title is ambiguous.
+            Use :func:`~plexapi.library.Library.sectionByID` instead for an exact match.
 
             Parameters:
                 title (str): Title of the section to return.
+
+            Raises:
+                :exc:`~plexapi.exceptions.NotFound`: The library section title is not found on the server.
         """
         normalized_title = title.lower().strip()
         if not self._sectionsByTitle or normalized_title not in self._sectionsByTitle:
             self._loadSections()
         try:
-            return self._sectionsByTitle[normalized_title]
+            sections = self._sectionsByTitle[normalized_title]
         except KeyError:
             raise NotFound(f'Invalid library section: {title}') from None
+
+        if len(sections) > 1:
+            warnings.warn(
+                'Multiple library sections with the same title found, use "sectionByID" instead. '
+                'Returning the last section.'
+            )
+        return sections[-1]
 
     def sectionByID(self, sectionID):
         """ Returns the :class:`~plexapi.library.LibrarySection` that matches the specified sectionID.


### PR DESCRIPTION
## Description

Adds a warning for an ambiguous library title when retrieving library section. The last library section matching the name will be returned which is the same as the current behaviour when the lookup dictionary is clobbered.

```python
>> python.library.section("Movies")
UserWarning: Multiple library sections with the same title found, use "sectionByID" instead. Returning the last section.
```

Fixes #1324

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
