### PR TITLE
Simplify building MediaPartStream objects

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -98,7 +98,7 @@ class PlexObject:
         ecls = utils.PLEXOBJECTS.get(ehash, utils.PLEXOBJECTS.get(elem.tag))
         # log.debug('Building %s as %s', elem.tag, ecls.__name__)
         if ecls is not None:
-            return ecls(self._server, elem, initpath)
+            return ecls(self._server, elem, initpath, parent=self)
         raise UnknownType(f"Unknown library type <{elem.tag} type='{etype}'../>")
 
     def _buildItemOrNone(self, elem, cls=None, initpath=None):

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -158,11 +158,8 @@ class MediaPart(PlexObject):
         self.videoProfile = data.attrib.get('videoProfile')
 
     def _buildStreams(self, data):
-        streams = []
-        for cls in (VideoStream, AudioStream, SubtitleStream, LyricStream):
-            items = self.findItems(data, cls, streamType=cls.STREAMTYPE)
-            streams.extend(items)
-        return streams
+        """ Returns a list of :class:`~plexapi.media.MediaPartStream` objects in this MediaPart. """
+        return self.findItems(data)
 
     @property
     def hasPreviewThumbnails(self):

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -37,7 +37,7 @@ class Media(PlexObject):
             videoResolution (str): The video resolution of the media (ex: sd).
             width (int): The width of the video in pixels (ex: 608).
 
-            <Photo_only_attributes>: The following attributes are only available for photos.
+            Photo_only_attributes: The following attributes are only available for photos.
 
                 * aperture (str): The aperture used to take the photo.
                 * exposure (str): The exposure used to take the photo.
@@ -74,13 +74,13 @@ class Media(PlexObject):
         self.width = utils.cast(int, data.attrib.get('width'))
         self.uuid = data.attrib.get('uuid')
 
-        if self._isChildOf(etag='Photo'):
-            self.aperture = data.attrib.get('aperture')
-            self.exposure = data.attrib.get('exposure')
-            self.iso = utils.cast(int, data.attrib.get('iso'))
-            self.lens = data.attrib.get('lens')
-            self.make = data.attrib.get('make')
-            self.model = data.attrib.get('model')
+        # Photo only attributes
+        self.aperture = data.attrib.get('aperture')
+        self.exposure = data.attrib.get('exposure')
+        self.iso = utils.cast(int, data.attrib.get('iso'))
+        self.lens = data.attrib.get('lens')
+        self.make = data.attrib.get('make')
+        self.model = data.attrib.get('model')
 
         parent = self._parent()
         self._parentKey = parent.key
@@ -381,7 +381,7 @@ class AudioStream(MediaPartStream):
             samplingRate (int): The sampling rate of the audio stream (ex: xxx)
             streamIdentifier (int): The stream identifier of the audio stream.
 
-            <Track_only_attributes>: The following attributes are only available for tracks.
+            Track_only_attributes: The following attributes are only available for tracks.
 
                 * albumGain (float): The gain for the album.
                 * albumPeak (float): The peak for the album.
@@ -408,16 +408,16 @@ class AudioStream(MediaPartStream):
         self.samplingRate = utils.cast(int, data.attrib.get('samplingRate'))
         self.streamIdentifier = utils.cast(int, data.attrib.get('streamIdentifier'))
 
-        if self._isChildOf(etag='Track'):
-            self.albumGain = utils.cast(float, data.attrib.get('albumGain'))
-            self.albumPeak = utils.cast(float, data.attrib.get('albumPeak'))
-            self.albumRange = utils.cast(float, data.attrib.get('albumRange'))
-            self.endRamp = data.attrib.get('endRamp')
-            self.gain = utils.cast(float, data.attrib.get('gain'))
-            self.loudness = utils.cast(float, data.attrib.get('loudness'))
-            self.lra = utils.cast(float, data.attrib.get('lra'))
-            self.peak = utils.cast(float, data.attrib.get('peak'))
-            self.startRamp = data.attrib.get('startRamp')
+        # Track only attributes
+        self.albumGain = utils.cast(float, data.attrib.get('albumGain'))
+        self.albumPeak = utils.cast(float, data.attrib.get('albumPeak'))
+        self.albumRange = utils.cast(float, data.attrib.get('albumRange'))
+        self.endRamp = data.attrib.get('endRamp')
+        self.gain = utils.cast(float, data.attrib.get('gain'))
+        self.loudness = utils.cast(float, data.attrib.get('loudness'))
+        self.lra = utils.cast(float, data.attrib.get('lra'))
+        self.peak = utils.cast(float, data.attrib.get('peak'))
+        self.startRamp = data.attrib.get('startRamp')
 
     def setSelected(self):
         """ Sets this audio stream as the selected audio stream.

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -135,8 +135,6 @@ def test_video_Movie_attrs(movies):
     assert audio._server._baseurl == utils.SERVER_BASEURL
     assert audio.title is None
     assert audio.type == 2
-    with pytest.raises(AttributeError):
-        assert audio.albumGain is None  # Check track only attributes are not available
     # Media
     media = movie.media[0]
     assert media.aspectRatio >= 1.3
@@ -160,8 +158,6 @@ def test_video_Movie_attrs(movies):
     assert media.videoProfile == "main"
     assert media.videoResolution in utils.RESOLUTIONS
     assert utils.is_int(media.width, gte=200)
-    with pytest.raises(AttributeError):
-        assert media.aperture is None  # Check photo only attributes are not available
     # Video
     video = movie.media[0].parts[0].videoStreams()[0]
     assert video.anamorphic is None


### PR DESCRIPTION
## Description

`VideoStream`, `AudioStream`, `SubtitleStream`, and `LyricStream` are registerd `PlexObjects` so they can be built directly.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
