### PR TITLE
Feature: Add source property to playlist items to support remote playlist entries

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -449,7 +449,7 @@ class Track(
             primaryExtraKey (str) API URL for the primary extra for the track.
             ratingCount (int): Number of listeners who have scrobbled this track, as reported by Last.fm.
             skipCount (int): Number of times the track has been skipped.
-            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             viewOffset (int): View offset in milliseconds.
             year (int): Year the track was released.
     """
@@ -484,7 +484,7 @@ class Track(
         self.primaryExtraKey = data.attrib.get('primaryExtraKey')
         self.ratingCount = utils.cast(int, data.attrib.get('ratingCount'))
         self.skipCount = utils.cast(int, data.attrib.get('skipCount'))
-        self.source = data.attrib.get('source')  # remote playlist item
+        self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.year = utils.cast(int, data.attrib.get('year'))
 

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -449,7 +449,7 @@ class Track(
             primaryExtraKey (str) API URL for the primary extra for the track.
             ratingCount (int): Number of listeners who have scrobbled this track, as reported by Last.fm.
             skipCount (int): Number of times the track has been skipped.
-            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
             viewOffset (int): View offset in milliseconds.
             year (int): Year the track was released.
     """

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -449,6 +449,7 @@ class Track(
             primaryExtraKey (str) API URL for the primary extra for the track.
             ratingCount (int): Number of listeners who have scrobbled this track, as reported by Last.fm.
             skipCount (int): Number of times the track has been skipped.
+            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             viewOffset (int): View offset in milliseconds.
             year (int): Year the track was released.
     """
@@ -483,6 +484,7 @@ class Track(
         self.primaryExtraKey = data.attrib.get('primaryExtraKey')
         self.ratingCount = utils.cast(int, data.attrib.get('ratingCount'))
         self.skipCount = utils.cast(int, data.attrib.get('skipCount'))
+        self.source = data.attrib.get('source')  # remote playlist item
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.year = utils.cast(int, data.attrib.get('year'))
 

--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -449,7 +449,8 @@ class Track(
             primaryExtraKey (str) API URL for the primary extra for the track.
             ratingCount (int): Number of listeners who have scrobbled this track, as reported by Last.fm.
             skipCount (int): Number of times the track has been skipped.
-            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library)
+                (remote playlist item only).
             viewOffset (int): View offset in milliseconds.
             year (int): Year the track was released.
     """

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -180,7 +180,8 @@ class Photo(
             parentThumb (str): URL to photo album thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the photo album for the photo.
             ratingKey (int): Unique key identifying the photo.
-            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library)
+                (remote playlist item only).
             summary (str): Summary of the photo.
             tags (List<:class:`~plexapi.media.Tag`>): List of tag objects.
             thumb (str): URL to thumbnail image (/library/metadata/<ratingKey>/thumb/<thumbid>).

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -180,6 +180,7 @@ class Photo(
             parentThumb (str): URL to photo album thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the photo album for the photo.
             ratingKey (int): Unique key identifying the photo.
+            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             summary (str): Summary of the photo.
             tags (List<:class:`~plexapi.media.Tag`>): List of tag objects.
             thumb (str): URL to thumbnail image (/library/metadata/<ratingKey>/thumb/<thumbid>).
@@ -218,6 +219,7 @@ class Photo(
         self.parentThumb = data.attrib.get('parentThumb')
         self.parentTitle = data.attrib.get('parentTitle')
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
+        self.source = data.attrib.get('source')  # remote playlist item
         self.summary = data.attrib.get('summary')
         self.tags = self.findItems(data, media.Tag)
         self.thumb = data.attrib.get('thumb')

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -180,7 +180,7 @@ class Photo(
             parentThumb (str): URL to photo album thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the photo album for the photo.
             ratingKey (int): Unique key identifying the photo.
-            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
             summary (str): Summary of the photo.
             tags (List<:class:`~plexapi.media.Tag`>): List of tag objects.
             thumb (str): URL to thumbnail image (/library/metadata/<ratingKey>/thumb/<thumbid>).

--- a/plexapi/photo.py
+++ b/plexapi/photo.py
@@ -180,7 +180,7 @@ class Photo(
             parentThumb (str): URL to photo album thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the photo album for the photo.
             ratingKey (int): Unique key identifying the photo.
-            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             summary (str): Summary of the photo.
             tags (List<:class:`~plexapi.media.Tag`>): List of tag objects.
             thumb (str): URL to thumbnail image (/library/metadata/<ratingKey>/thumb/<thumbid>).
@@ -219,7 +219,7 @@ class Photo(
         self.parentThumb = data.attrib.get('parentThumb')
         self.parentTitle = data.attrib.get('parentTitle')
         self.ratingKey = utils.cast(int, data.attrib.get('ratingKey'))
-        self.source = data.attrib.get('source')  # remote playlist item
+        self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.summary = data.attrib.get('summary')
         self.tags = self.findItems(data, media.Tag)
         self.thumb = data.attrib.get('thumb')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -900,7 +900,7 @@ class Episode(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             skipParent (bool): True if the show's seasons are set to hidden.
-            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
             viewOffset (int): View offset in milliseconds.
             writers (List<:class:`~plexapi.media.Writer`>): List of writers objects.
             year (int): Year the episode was released.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -369,7 +369,8 @@ class Movie(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
-            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library)
+                (remote playlist item only).
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
@@ -900,7 +901,8 @@ class Episode(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             skipParent (bool): True if the show's seasons are set to hidden.
-            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library)
+                (remote playlist item only).
             viewOffset (int): View offset in milliseconds.
             writers (List<:class:`~plexapi.media.Writer`>): List of writers objects.
             year (int): Year the episode was released.

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -369,7 +369,7 @@ class Movie(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
-            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
@@ -413,7 +413,7 @@ class Movie(
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.similar = self.findItems(data, media.Similar)
-        self.source = data.attrib.get('source')  # remote playlist item
+        self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')
@@ -900,7 +900,7 @@ class Episode(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             skipParent (bool): True if the show's seasons are set to hidden.
-            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             viewOffset (int): View offset in milliseconds.
             writers (List<:class:`~plexapi.media.Writer`>): List of writers objects.
             year (int): Year the episode was released.
@@ -943,7 +943,7 @@ class Episode(
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.skipParent = utils.cast(bool, data.attrib.get('skipParent', '0'))
-        self.source = data.attrib.get('source')  # remote playlist item
+        self.sourceURI = data.attrib.get('source')  # remote playlist item
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.writers = self.findItems(data, media.Writer)
         self.year = utils.cast(int, data.attrib.get('year'))

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -369,6 +369,7 @@ class Movie(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
+            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
@@ -412,6 +413,7 @@ class Movie(
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.similar = self.findItems(data, media.Similar)
+        self.source = data.attrib.get('source') # remote playlist item
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -900,6 +900,7 @@ class Episode(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             skipParent (bool): True if the show's seasons are set to hidden.
+            source (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
             viewOffset (int): View offset in milliseconds.
             writers (List<:class:`~plexapi.media.Writer`>): List of writers objects.
             year (int): Year the episode was released.
@@ -942,6 +943,7 @@ class Episode(
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.skipParent = utils.cast(bool, data.attrib.get('skipParent', '0'))
+        self.source = data.attrib.get('source') # remote playlist item
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.writers = self.findItems(data, media.Writer)
         self.year = utils.cast(int, data.attrib.get('year'))

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -413,7 +413,7 @@ class Movie(
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.similar = self.findItems(data, media.Similar)
-        self.source = data.attrib.get('source') # remote playlist item
+        self.source = data.attrib.get('source')  # remote playlist item
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')
@@ -943,7 +943,7 @@ class Episode(
         self.ratings = self.findItems(data, media.Rating)
         self.roles = self.findItems(data, media.Role)
         self.skipParent = utils.cast(bool, data.attrib.get('skipParent', '0'))
-        self.source = data.attrib.get('source') # remote playlist item
+        self.source = data.attrib.get('source')  # remote playlist item
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.writers = self.findItems(data, media.Writer)
         self.year = utils.cast(int, data.attrib.get('year'))

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -369,7 +369,7 @@ class Movie(
             ratings (List<:class:`~plexapi.media.Rating`>): List of rating objects.
             roles (List<:class:`~plexapi.media.Role`>): List of role objects.
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
-            sourceURI (str): Remote server URL (server://<server_id>/com.plexapp.plugins.library) (remote playlist item only)
+            sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library) (remote playlist item only)
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).


### PR DESCRIPTION
## Description

A Playlist entry if added a remote server item has field "source" initialized with value like `server://<server_id>/com.plexapp.plugins.library`

The `source` attribute should be on
- [x] Movie
- [x] Episode
- [x] Track
- [x] Photo.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
