### PR TITLE
bugfix: pass existing filters for `albums` method of `Artist`

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -227,7 +227,7 @@ class Artist(
         """ Returns a list of :class:`~plexapi.audio.Album` objects by the artist. """
         return self.section().search(
             libtype='album',
-            filters={'artist.id': self.ratingKey},
+            filters={**kwargs.pop('filters', {}), 'artist.id': self.ratingKey},
             **kwargs
         )
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -78,7 +78,7 @@ def test_audio_Artist_album(artist):
 
 
 def test_audio_Artist_albums(artist):
-    albums = artist.albums()
+    albums = artist.albums(filters={})
     assert len(albums) == 1 and albums[0].title == "Layers"
 
 


### PR DESCRIPTION
## Description

if a filters kwarg was passed, it would raise error that duplicate keyword recieved. this fixes that edge case
`TypeError: search() got multiple values for keyword argument 'filters'`
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
