### PR TITLE
Fix: Update guid filter examples for fetchItems

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -227,7 +227,7 @@ class PlexObject:
 
                     fetchItem(ekey, viewCount__gte=0)
                     fetchItem(ekey, Media__container__in=["mp4", "mkv"])
-                    fetchItem(ekey, guid__regex=r"(com\.plexapp\.agents\.imdb|themoviedb)://|tt\d+")
+                    fetchItem(ekey, guid__regex=r"com\.plexapp\.agents\.(imdb|themoviedb)://|tt\d+")
                     fetchItem(ekey, guid__id__regex=r"(imdb|tmdb|tvdb)://")
                     fetchItem(ekey, Media__Part__file__startswith="D:\\Movies")
 

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -227,7 +227,7 @@ class PlexObject:
 
                     fetchItem(ekey, viewCount__gte=0)
                     fetchItem(ekey, Media__container__in=["mp4", "mkv"])
-                    fetchItem(ekey, guid__regex=r"(com\.plexapp\.agents\.imdb|themoviedb)://")
+                    fetchItem(ekey, guid__regex=r"(com\.plexapp\.agents\.imdb|themoviedb)://|tt\d+")
                     fetchItem(ekey, Media__Part__file__startswith="D:\\Movies")
 
         """

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -228,6 +228,7 @@ class PlexObject:
                     fetchItem(ekey, viewCount__gte=0)
                     fetchItem(ekey, Media__container__in=["mp4", "mkv"])
                     fetchItem(ekey, guid__regex=r"(com\.plexapp\.agents\.imdb|themoviedb)://|tt\d+")
+                    fetchItem(ekey, guid__id__regex=r"(imdb|tmdb|tvdb)://")
                     fetchItem(ekey, Media__Part__file__startswith="D:\\Movies")
 
         """

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -227,7 +227,7 @@ class PlexObject:
 
                     fetchItem(ekey, viewCount__gte=0)
                     fetchItem(ekey, Media__container__in=["mp4", "mkv"])
-                    fetchItem(ekey, guid__iregex=r"(imdb://|themoviedb://)")
+                    fetchItem(ekey, guid__regex=r"(com\.plexapp\.agents\.imdb|themoviedb)://")
                     fetchItem(ekey, Media__Part__file__startswith="D:\\Movies")
 
         """


### PR DESCRIPTION
## Description

Some why `imdb://` or `themoviedb://` regex does not filter the items, feels like pattern has "^" in it added by default.

I checked the code and it's not:
- https://github.com/pkkid/python-plexapi/blob/4780026a73af06af8801dada01f249ef6f8bb8db/plexapi/base.py#L29-L30

unless the `re.match` does it magically.
but using a complete agent name just works!

also changes `iregex`-> `regex`, the guids are always lowercase, no need for case insensitive match

additionally adds "tt12345" for legacy imdb entries

and `<Guid id="xxx">` tag matching example.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
