### PR TITLE
Breaking: Change regex/iregex to use re.search instead of re.match

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -26,8 +26,8 @@ OPERATORS = {
     'endswith': lambda v, q: v.endswith(q),
     'iendswith': lambda v, q: v.lower().endswith(q),
     'exists': lambda v, q: v is not None if q else v is None,
-    'regex': lambda v, q: re.match(q, v),
-    'iregex': lambda v, q: re.match(q, v, flags=re.IGNORECASE),
+    'regex': lambda v, q: re.search(q, v),
+    'iregex': lambda v, q: re.search(q, v, flags=re.IGNORECASE),
 }
 
 

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -26,8 +26,8 @@ OPERATORS = {
     'endswith': lambda v, q: v.endswith(q),
     'iendswith': lambda v, q: v.lower().endswith(q),
     'exists': lambda v, q: v is not None if q else v is None,
-    'regex': lambda v, q: re.search(q, v),
-    'iregex': lambda v, q: re.search(q, v, flags=re.IGNORECASE),
+    'regex': lambda v, q: bool(re.search(q, v)),
+    'iregex': lambda v, q: bool(re.search(q, v, flags=re.IGNORECASE)),
 }
 
 


### PR DESCRIPTION
## Description

Change `fetchItem`'s `regex` and `iregex` filters to use `re.search` rather `re.match`.

This means that the pattern is now matched from anywhere the string, not start of the string:
- https://docs.python.org/3/library/re.html#search-vs-match

The user can specify `^` in their regex if they want to continue to match the start of the string.

See:
- https://github.com/pkkid/python-plexapi/pull/1350#issuecomment-1927772486

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
