### PR TITLE
Fix class reference in calling fetchItems method

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -159,7 +159,7 @@ class Audio(PlexPartialObject, PlayedUnplayedMixin):
 
         return self.fetchItems(
             key,
-            cls=self.__class__,
+            cls=type(self),
             **kwargs,
         )
 


### PR DESCRIPTION
correcting my previous commit

using built-in type to determine type of the object, more reliable way.

Ref.: #1288

## Type of change

Please delete options that are not relevant.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
