### PR TITLE
Remove leftover "syntax: glob" from Mercurial migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-syntax: glob
 *.db
 *.egg-info
 *.log


### PR DESCRIPTION
## Description

See 35269614 commit

And stackoverflow post:
- https://stackoverflow.com/questions/56010229/what-does-syntax-glob-regexp-mean-in-a-gitignore-file/56010335#56010335



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
