### PR TITLE
Update history tests

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -5,7 +5,7 @@ from . import conftest as utils
 def test_history_Movie(movie):
     movie.markPlayed()
     history = movie.history()
-    assert len(history)
+    assert not len(history)
     movie.markUnplayed()
 
 
@@ -16,8 +16,7 @@ def test_history_Show(show):
     show.markUnplayed()
 
 
-def test_history_Season(show):
-    season = show.season("Season 1")
+def test_history_Season(season):
     season.markPlayed()
     history = season.history()
     assert len(history)
@@ -27,7 +26,7 @@ def test_history_Season(show):
 def test_history_Episode(episode):
     episode.markPlayed()
     history = episode.history()
-    assert len(history)
+    assert not len(history)
     episode.markUnplayed()
 
 
@@ -48,49 +47,45 @@ def test_history_Album(album):
 def test_history_Track(track):
     track.markPlayed()
     history = track.history()
-    assert len(history)
+    assert not len(history)
     track.markUnplayed()
 
 
-def test_history_MyAccount(account, movie, show):
-    movie.markPlayed()
+def test_history_MyAccount(account, show):
     show.markPlayed()
     history = account.history()
     assert len(history)
-    movie.markUnplayed()
     show.markUnplayed()
 
 
-def test_history_MyLibrary(plex, movie, show):
-    movie.markPlayed()
+def test_history_MyLibrary(plex, show):
     show.markPlayed()
     history = plex.library.history()
     assert len(history)
-    movie.markUnplayed()
     show.markUnplayed()
 
 
-def test_history_MySection(plex, movie):
-    movie.markPlayed()
-    history = plex.library.section("Movies").history()
+def test_history_MySection(tvshows, show):
+    show.markPlayed()
+    history = tvshows.history()
     assert len(history)
-    movie.markUnplayed()
+    show.markUnplayed()
 
 
-def test_history_MyServer(plex, movie):
-    movie.markPlayed()
+def test_history_MyServer(plex, show):
+    show.markPlayed()
     history = plex.history()
     assert len(history)
-    movie.markUnplayed()
+    show.markUnplayed()
 
 
-def test_history_PlexHistory(plex, movie):
-    movie.markPlayed()
+def test_history_PlexHistory(plex, show):
+    show.markPlayed()
     history = plex.history()
     assert len(history)
 
     hist = history[0]
-    assert hist.source() == movie
+    assert hist.source().show() == show
     assert hist.accountID
     assert hist.deviceID
     assert hist.historyKey


### PR DESCRIPTION
## Description

Updates the history tests per the change in PMS 1.40.0.7998.
 > * (View History) No longer create a view history entry for items marked as played (#10888)

Ref.: https://forums.plex.tv/t/plex-media-server/30447/612

Note: Only seems to affect movie, episode, and track. Marking a show, season, artist, or album, as watched still adds to the history.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
