### PR TITLE
Fix: Stream objects not loaded for Plex sessions

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -95,7 +95,7 @@ class PlexObject:
             ehash = f"{ehash}.session"
         elif initpath.startswith('/status/sessions/history'):
             ehash = f"{ehash}.history"
-        ecls = utils.PLEXOBJECTS.get(ehash, utils.PLEXOBJECTS.get(elem.tag))
+        ecls = utils.getPlexObject(ehash, default=elem.tag)
         # log.debug('Building %s as %s', elem.tag, ecls.__name__)
         if ecls is not None:
             return ecls(self._server, elem, initpath, parent=self)

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -136,6 +136,19 @@ def registerPlexObject(cls):
     return cls
 
 
+def getPlexObject(ehash, default):
+    """ Return the PlexObject class for the specified ehash. This recursively looks up the class
+        with the highest specificity, falling back to the default class if not found.
+    """
+    cls = PLEXOBJECTS.get(ehash)
+    if cls is not None:
+        return cls
+    if '.' in ehash:
+        ehash = ehash.rsplit('.', 1)[0]
+        return getPlexObject(ehash, default=default)
+    return PLEXOBJECTS.get(default)
+
+
 def cast(func, value):
     """ Cast the specified value to the specified type (returned by func). Currently this
         only support str, int, float, bool. Should be extended if needed.


### PR DESCRIPTION
## Description

Objects loaded from `/status/sessions` have an added `.session` to the `ehash` used to lookup the `PlexObject` class. This adds a helper function to recursively get the `PlexObject` with the highest specificity. e.g. `ehash = 'Stream.1.session'` will return the `MediaPartStream` class for `ehash = 'Stream.1'`.

Fixes #1368
Ref.: #1328

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
