### PR TITLE
`MediaContainer` class is now a list

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -1069,6 +1069,22 @@ class MediaContainer(
                 self.offset if self.offset is not None else __iterable.offset
             )
 
+        # for all other attributes, overwrite with the new iterable's values if previously None
+        for key in (
+            "allowSync",
+            "augmentationKey",
+            "identifier",
+            "librarySectionID",
+            "librarySectionTitle",
+            "librarySectionUUID",
+            "mediaTagPrefix",
+            "mediaTagVersion",
+        ):
+            if (not hasattr(self, key)) or (getattr(self, key) is None):
+                if not hasattr(__iterable, key):
+                    continue
+                setattr(self, key, getattr(__iterable, key))
+
     def _loadData(self, data):
         self._data = data
         self.allowSync = utils.cast(int, data.attrib.get('allowSync'))

--- a/tests/test_fetch_items.py
+++ b/tests/test_fetch_items.py
@@ -1,0 +1,32 @@
+from plexapi.audio import Track
+from plexapi.base import MediaContainer
+
+
+def test_media_container_is_list():
+    container = MediaContainer(None, None, Track(None, None))
+    assert isinstance(container, list)
+    assert len(container) == 1
+    container.append(Track(None, None))
+    assert len(container) == 2
+
+
+def test_media_container_extend():
+    container_1 = MediaContainer(None, None, Track(None, None))
+    container_2 = MediaContainer(
+        None, None, [Track(None, None), Track(None, None)]
+    )
+    container_1.size, container_2.size = 1, 2
+    container_1.offset, container_2.offset = 3, 4
+    container_1.totalSize = container_2.totalSize = 10
+    container_1.extend(container_2)
+    assert container_1.size == 1 + 2
+    assert container_1.offset == min(3, 4)
+    assert container_1.totalSize == 10
+
+
+def test_fetch_items_with_media_container(show):
+    all_episodes = show.episodes()
+    some_episodes = show.episodes(maxresults=2)
+    assert some_episodes.size == 2
+    assert some_episodes.offset == 0
+    assert some_episodes.totalSize == len(all_episodes)


### PR DESCRIPTION
## Description

`fetchItems` returns a MediaContainer, exactly how server does and is also a python list! Hence it would not break any current api.
additionally, it now supports totalSize attr

The only breaking change is that MediaContainer can now only accept `initpath` and `parent` as keword-only arguments in its initialisation, which I don't think anyone would be using.

Fixes #1372 
## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
