### PR TITLE
Update history tests

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from . import conftest as utils
-
 
 def test_history_Movie(movie):
     movie.markPlayed()
@@ -12,14 +10,14 @@ def test_history_Movie(movie):
 def test_history_Show(show):
     show.markPlayed()
     history = show.history()
-    assert len(history)
+    assert not len(history)
     show.markUnplayed()
 
 
 def test_history_Season(season):
     season.markPlayed()
     history = season.history()
-    assert len(history)
+    assert not len(history)
     season.markUnplayed()
 
 
@@ -33,14 +31,14 @@ def test_history_Episode(episode):
 def test_history_Artist(artist):
     artist.markPlayed()
     history = artist.history()
-    assert len(history)
+    assert not len(history)
     artist.markUnplayed()
 
 
 def test_history_Album(album):
     album.markPlayed()
     history = album.history()
-    assert len(history)
+    assert not len(history)
     album.markUnplayed()
 
 
@@ -54,47 +52,29 @@ def test_history_Track(track):
 def test_history_MyAccount(account, show):
     show.markPlayed()
     history = account.history()
-    assert len(history)
+    assert not len(history)
     show.markUnplayed()
 
 
-def test_history_MyLibrary(plex, show):
-    show.markPlayed()
+def test_history_MyLibrary(plex, movie):
+    movie.markPlayed()
     history = plex.library.history()
-    assert len(history)
-    show.markUnplayed()
+    assert not len(history)
+    movie.markUnplayed()
 
 
-def test_history_MySection(tvshows, show):
-    show.markPlayed()
-    history = tvshows.history()
-    assert len(history)
-    show.markUnplayed()
+def test_history_MySection(movies, movie):
+    movie.markPlayed()
+    history = movies.history()
+    assert not len(history)
+    movie.markUnplayed()
 
 
 def test_history_MyServer(plex, show):
     show.markPlayed()
     history = plex.history()
-    assert len(history)
+    assert not len(history)
     show.markUnplayed()
-
-
-def test_history_PlexHistory(plex, show):
-    show.markPlayed()
-    history = plex.history()
-    assert len(history)
-
-    hist = history[0]
-    assert hist.source().show() == show
-    assert hist.accountID
-    assert hist.deviceID
-    assert hist.historyKey
-    assert utils.is_datetime(hist.viewedAt)
-    assert hist.guid is None
-    hist.delete()
-
-    history = plex.history()
-    assert hist not in history
 
 
 def test_history_User(account, shared_username):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1178,7 +1178,7 @@ def test_video_Episode_attrs(episode):
     assert episode.audienceRatingImage == "themoviedb://image.rating"
     assert episode.contentRating in utils.CONTENTRATINGS
     if episode.directors:
-        assert "Timothy Van Patten" in [i.tag for i in episode.directors]
+        assert "Tim Van Patten" in [i.tag for i in episode.directors]
     assert utils.is_int(episode.duration, gte=120000)
     if episode.grandparentArt:
         assert utils.is_art(episode.grandparentArt)


### PR DESCRIPTION
## Description

Continuation from #1366.

Updates the history tests per the change in PMS 1.40.1.8120.
 > * (Metadata) Marking a show or season as watched created view history entries (PM-935)

Ref.: https://forums.plex.tv/t/plex-media-server/30447/615


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
