### PR TITLE
Allow exclude parameters in reload kwargs

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -116,14 +116,22 @@ class PlexObject:
             or disable each parameter individually by setting it to False or 0.
         """
         details_key = self.key
+        params = {}
+
         if details_key and hasattr(self, '_INCLUDES'):
-            includes = {}
             for k, v in self._INCLUDES.items():
-                value = kwargs.get(k, v)
+                value = kwargs.pop(k, v)
                 if value not in [False, 0, '0']:
-                    includes[k] = 1 if value is True else value
-            if includes:
-                details_key += '?' + urlencode(sorted(includes.items()))
+                    params[k] = 1 if value is True else value
+
+        if details_key and hasattr(self, '_EXCLUDES'):
+            for k, v in self._EXCLUDES.items():
+                value = kwargs.pop(k, None)
+                if value is not None:
+                    params[k] = 1 if value is True else value
+
+        if params:
+            details_key += '?' + urlencode(sorted(params.items()))
         return details_key
 
     def _isChildOf(self, **kwargs):
@@ -498,7 +506,14 @@ class PlexPartialObject(PlexObject):
         'includeRelated': 1,
         'includeRelatedCount': 1,
         'includeReviews': 1,
-        'includeStations': 1
+        'includeStations': 1,
+    }
+    _EXCLUDES = {
+        'excludeElements': (
+            'Media,Genre,Country,Guid,Rating,Collection,Director,Writer,Role,Producer,Similar,Style,Mood,Format'
+        ),
+        'excludeFields': 'summary,tagline',
+        'skipRefresh': 1,
     }
 
     def __eq__(self, other):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -339,6 +339,14 @@ def test_video_Movie_isFullObject_and_reload(plex):
     assert len(movie_via_section_search.roles) >= 3
 
 
+def test_video_Movie_reload_kwargs(movie):
+    assert len(movie.media)
+    assert movie.summary is not None
+    movie.reload(includeFields=False, **movie._EXCLUDES)
+    assert movie.__dict__.get('media') == []
+    assert movie.__dict__.get('summary') is None
+
+
 def test_video_movie_watched(movie):
     movie.markUnplayed()
     movie.markPlayed()


### PR DESCRIPTION
## Description

Allow exclude parameters in reload `**kwargs`. A list of known exclude parameters is added to `PlexPartialObject._EXCLUDES`.

Example:

```py
movie.reload(excludeElements='Media,Genre,Collection', excludeFields='summary')
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
