### PR TITLE
Fix Library.add() method to properly apply advanced settings

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -311,7 +311,8 @@ class Library(PlexObject):
         part = '/library/sections?name=%s&type=%s&agent=%s&scanner=%s&language=%s&location=%s' % (
             quote_plus(name), type, agent, quote_plus(scanner), language, quote_plus(location))  # noqa E126
         if kwargs:
-            part += urlencode(kwargs)
+            prefs_params = {f'prefs[{k}]': v for k, v in kwargs.items()}
+            part += "&%s" %  (urlencode(prefs_params))
         return self._server.query(part, method=self._server._session.post)
 
     def history(self, maxresults=9999999, mindate=None):


### PR DESCRIPTION
## Description

Currently `Library.add()` is appending any advanced settings to the end of the `part`. This ends up making for bogus `locations` as the `locations` param is the last in line. Also, each advanced settings needs to be prefixed with `prefs` and the be contained in brackets (`pref[id]=value,...`). 

See `LibrarySection.editAdvanced()` method for confirmation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
