### PR TITLE
Fix `Library.add()` method to properly apply advanced settings

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -383,7 +383,8 @@ class Library(PlexObject):
         part = (f'/library/sections?name={quote_plus(name)}&type={type}&agent={agent}'
                 f'&scanner={quote_plus(scanner)}&language={language}&{urlencode(locations, doseq=True)}')
         if kwargs:
-            part += urlencode(kwargs)
+            prefs_params = {f'prefs[{k}]': v for k, v in kwargs.items()}
+            part += f'&{urlencode(prefs_params)}'
         return self._server.query(part, method=self._server._session.post)
 
     def history(self, maxresults=None, mindate=None):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -216,6 +216,7 @@ def test_library_add_advanced_settings(plex, movies):
         if setting.value != setting.default:
             assert advanced_settings.get(setting.id) == setting.value
 
+
 def test_library_Library_cleanBundle(plex):
     plex.library.cleanBundles()
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -192,6 +192,27 @@ def test_library_add_edit_delete(plex, movies, photos):
     section.delete()
     assert section not in plex.library.sections()
 
+def test_library_add_advanced_settings(plex, movies):
+    # Create Other Videos library = No external metadata scanning
+    section_name = "plexapi_test_advanced_section"
+    movie_location = movies.locations[0]
+    advanced_settings = {"enableCinemaTrailers": 0,
+                         "enableBIFGeneration": 0,
+                         "augmentWithProviderContent": 0,
+                         "enableCreditsMarkerGeneration": 0}
+    plex.library.add(
+        name=section_name,
+        type="movie",
+        agent="com.plexapp.agents.none",
+        scanner="Plex Video Files Scanner",
+        language="xn",
+        location=[movie_location],
+        **advanced_settings
+    )
+    section = plex.library.section(section_name)
+    assert section.title == section_name
+    for setting in section.settings():
+        assert advanced_settings.get(setting.id) == 0
 
 def test_library_Library_cleanBundle(plex):
     plex.library.cleanBundles()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -192,6 +192,7 @@ def test_library_add_edit_delete(plex, movies, photos):
     section.delete()
     assert section not in plex.library.sections()
 
+
 def test_library_add_advanced_settings(plex, movies):
     # Create Other Videos library = No external metadata scanning
     section_name = "plexapi_test_advanced_section"
@@ -213,6 +214,7 @@ def test_library_add_advanced_settings(plex, movies):
     assert section.title == section_name
     for setting in section.settings():
         assert advanced_settings.get(setting.id) == 0
+
 
 def test_library_Library_cleanBundle(plex):
     plex.library.cleanBundles()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -215,6 +215,8 @@ def test_library_add_advanced_settings(plex, movies):
     for setting in section.settings():
         if setting.value != setting.default:
             assert advanced_settings.get(setting.id) == setting.value
+    section.delete()
+    assert section not in plex.library.sections()
 
 
 def test_library_Library_cleanBundle(plex):

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -213,8 +213,8 @@ def test_library_add_advanced_settings(plex, movies):
     section = plex.library.section(section_name)
     assert section.title == section_name
     for setting in section.settings():
-        assert advanced_settings.get(setting.id) == 0
-
+        if setting.value != setting.default:
+            assert advanced_settings.get(setting.id) == setting.value
 
 def test_library_Library_cleanBundle(plex):
     plex.library.cleanBundles()


### PR DESCRIPTION
## Description

Currently `Library.add()` is appending any advanced settings to the end of the `part`. This ends up making for bogus `locations` as the `locations` param is the last in line. Also, each advanced settings needs to be prefixed with `prefs` and the be contained in brackets (`pref[id]=value,...`). 

We also don't have any tests for adding sections with advanced settings. I created an addtional test isolated to adding a section with advanced settings.

See `LibrarySection.editAdvanced()` method for confirmation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
