### PR TITLE
feat: Add params parameter to request

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -170,7 +170,14 @@ class PlexObject:
         elem = ElementTree.fromstring(xml)
         return self._buildItemOrNone(elem, cls)
 
-    def fetchItems(self, ekey, cls=None, container_start=None, container_size=None, maxresults=None, **kwargs):
+    def fetchItems(self,
+                   ekey,
+                   cls=None,
+                   container_start=None,
+                   container_size=None,
+                   maxresults=None,
+                   params=None,
+                   **kwargs):
         """ Load the specified key to find and build all items with the specified tag
             and attrs.
 
@@ -186,6 +193,7 @@ class PlexObject:
                 container_start (None, int): offset to get a subset of the data
                 container_size (None, int): How many items in data
                 maxresults (int, optional): Only return the specified number of results.
+                params (dict, optional): Any additional params to add to the request.
                 **kwargs (dict): Optionally add XML attribute to filter the items.
                     See the details below for more info.
 
@@ -268,7 +276,7 @@ class PlexObject:
             headers['X-Plex-Container-Start'] = str(container_start)
             headers['X-Plex-Container-Size'] = str(container_size)
 
-            data = self._server.query(ekey, headers=headers)
+            data = self._server.query(ekey, headers=headers, params=params)
             subresults = self.findItems(data, cls, ekey, **kwargs)
             total_size = utils.cast(int, data.attrib.get('totalSize') or data.attrib.get('size')) or len(subresults)
 

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -170,14 +170,16 @@ class PlexObject:
         elem = ElementTree.fromstring(xml)
         return self._buildItemOrNone(elem, cls)
 
-    def fetchItems(self,
-                   ekey,
-                   cls=None,
-                   container_start=None,
-                   container_size=None,
-                   maxresults=None,
-                   params=None,
-                   **kwargs):
+    def fetchItems(
+        self,
+        ekey,
+        cls=None,
+        container_start=None,
+        container_size=None,
+        maxresults=None,
+        params=None,
+        **kwargs,
+    ):
         """ Load the specified key to find and build all items with the specified tag
             and attrs.
 

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -746,7 +746,7 @@ class PlexServer(PlexObject):
         """ Returns list of all :class:`~plexapi.media.TranscodeJob` objects running or paused on server. """
         return self.fetchItems('/status/sessions/background')
 
-    def query(self, key, method=None, headers=None, timeout=None, **kwargs):
+    def query(self, key, method=None, headers=None, params=None, timeout=None, **kwargs):
         """ Main method used to handle HTTPS requests to the Plex server. This method helps
             by encoding the response to utf-8 and parsing the returned XML into and
             ElementTree object. Returns None if no data exists in the response.
@@ -756,7 +756,7 @@ class PlexServer(PlexObject):
         timeout = timeout or self._timeout
         log.debug('%s %s', method.__name__.upper(), url)
         headers = self._headers(**headers or {})
-        response = method(url, headers=headers, timeout=timeout, **kwargs)
+        response = method(url, headers=headers, params=params, timeout=timeout, **kwargs)
         if response.status_code not in (200, 201, 204):
             codename = codes.get(response.status_code)[0]
             errtext = response.text.replace('\n', ' ')


### PR DESCRIPTION
## Description

For the request method, a params parameter has been added. For example, "/hubs/continueWatching" can be used to set "contentDirectoryID=1,3" to filter specific content directories.

## Type of change

- [ ] New feature (Add params parameter to request)