### PR TITLE
`addToWatchlist` raise `NotFound` exception for invalid media

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -963,7 +963,9 @@ class MyPlexAccount(PlexObject):
                     objects to be added to the watchlist.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: When trying to add invalid or existing
+                :exc:`~plexapi.exceptions.BadRequest`: When trying to add existing
+                    media to the watchlist.
+                :exc:`~plexapi.exceptions.NotFound`: When trying to add invalid
                     media to the watchlist.
         """
         if not isinstance(items, list):

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -310,7 +310,7 @@ def test_myplex_watchlist(account, movie, show, artist):
         account.removeFromWatchlist(movie)
 
     # Test adding invalid item to watchlist
-    with pytest.raises(BadRequest):
+    with pytest.raises(NotFound):
         account.addToWatchlist(artist)
 
 


### PR DESCRIPTION
## Description

Plex now raises `404` status when adding invalid media to a Watchlist. Documentation updated to say this will raise a `NotFound` exception. Test updated to check for the `NotFound` exception.

https://github.com/pkkid/python-plexapi/actions/runs/8756988631/job/24034937906#step:12:837

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
