### PR TITLE
Revert "`addToWatchlist` raise `NotFound` exception for invalid media"

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -963,9 +963,7 @@ class MyPlexAccount(PlexObject):
                     objects to be added to the watchlist.
 
             Raises:
-                :exc:`~plexapi.exceptions.BadRequest`: When trying to add existing
-                    media to the watchlist.
-                :exc:`~plexapi.exceptions.NotFound`: When trying to add invalid
+                :exc:`~plexapi.exceptions.BadRequest`: When trying to add invalid or existing
                     media to the watchlist.
         """
         if not isinstance(items, list):

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -310,7 +310,7 @@ def test_myplex_watchlist(account, movie, show, artist):
         account.removeFromWatchlist(movie)
 
     # Test adding invalid item to watchlist
-    with pytest.raises(NotFound):
+    with pytest.raises(BadRequest):
         account.addToWatchlist(artist)
 
 


### PR DESCRIPTION
Reverts pkkid/python-plexapi#1401