### PR TITLE
Test for `NotFound` exception when adding to watchlist

### DIFF
--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -310,7 +310,7 @@ def test_myplex_watchlist(account, movie, show, artist):
         account.removeFromWatchlist(movie)
 
     # Test adding invalid item to watchlist
-    with pytest.raises(BadRequest):
+    with pytest.raises((BadRequest, NotFound)):
         account.addToWatchlist(artist)
 
 


### PR DESCRIPTION
## Description

`MyPlexAccount.userState(item)` can raise `NotFound` if trying to get metadata for an item with an invalid Plex GUID.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
