### PR TITLE
Update default language for library add

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -226,7 +226,7 @@ class Library(PlexObject):
             section.deleteMediaPreviews()
         return self
 
-    def add(self, name='', type='', agent='', scanner='', location='', language='en', *args, **kwargs):
+    def add(self, name='', type='', agent='', scanner='', location='', language='en-US', *args, **kwargs):
         """ Simplified add for the most common options.
 
             Parameters:
@@ -234,7 +234,7 @@ class Library(PlexObject):
                 agent (str): Example com.plexapp.agents.imdb
                 type (str): movie, show, # check me
                 location (str or list): /path/to/files, ["/path/to/files", "/path/to/morefiles"]
-                language (str): Two letter language fx en
+                language (str): Four letter language code (e.g. en-US)
                 kwargs (dict): Advanced options should be passed as a dict. where the id is the key.
 
             **Photo Preferences**

--- a/tools/plex-bootstraptest.py
+++ b/tools/plex-bootstraptest.py
@@ -612,6 +612,7 @@ if __name__ == "__main__":  # noqa: C901
                 location="/data/Photos" if opts.no_docker is False else photos_path,
                 agent="com.plexapp.agents.none",
                 scanner="Plex Photo Scanner",
+                language="en",
                 expected_media_count=has_photos,
             )
         )


### PR DESCRIPTION
## Description

Update default language for `Library.add()` to four letter code `en-US`.

Fixes #1348

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
