### PR TITLE
Allow getting a client by machine identifier

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -413,16 +413,17 @@ class PlexServer(PlexObject):
         return items
 
     def client(self, name):
-        """ Returns the :class:`~plexapi.client.PlexClient` that matches the specified name.
+        """ Returns the :class:`~plexapi.client.PlexClient` that matches the specified name
+            or machine identifier.
 
             Parameters:
-                name (str): Name of the client to return.
+                name (str): Name or machine identifier of the client to return.
 
             Raises:
                 :exc:`~plexapi.exceptions.NotFound`: Unknown client name.
         """
         for client in self.clients():
-            if client and client.title == name:
+            if client and (client.title == name or client.machineIdentifier == name):
                 return client
 
         raise NotFound(f'Unknown client name: {name}')


### PR DESCRIPTION
## Description

Allow getting a client by machine identifier.

```py
client = plex.client("<client-name>")
client = plex.client("<client-machine-identifier>")
```

Closes #1414

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
