### PR TITLE
Fix: Set media and part indexes when generating stream url

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -866,6 +866,8 @@ class Playable:
 
             if kwargs:
                 # So this seems to be a a lot slower but allows transcode.
+                kwargs['mediaIndex'] = self.media.index(part._parent())
+                kwargs['partIndex'] = part._parent().parts.index(part)
                 download_url = self.getStreamURL(**kwargs)
             else:
                 download_url = self._server.url(f'{part.key}?download=1')


### PR DESCRIPTION
## Description

Resolve bug where `download()` on objects with multiple media/parts end up generating the same transcode urls to download.

Fixes #1427

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests when applicable
