### PR TITLE
Fix: Register LyricStream as a PlexObject

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -478,6 +478,7 @@ class SubtitleStream(MediaPartStream):
         return self.setSelected()
 
 
+@utils.registerPlexObject
 class LyricStream(MediaPartStream):
     """ Represents a lyric stream within a :class:`~plexapi.media.MediaPart`.
 


### PR DESCRIPTION
## Description

Missing register `LyricStream` as a PlexObject

Fixes #1433

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
