### PR TITLE
add searchProviders parameter to searchDiscover method

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1057,7 +1057,7 @@ class MyPlexAccount(PlexObject):
                 query (str): Search query.
                 limit (int, optional): Limit to the specified number of results. Default 30.
                 libtype (str, optional): 'movie' or 'show' to only return movies or shows, otherwise return all items.
-                searchprovider (str, optional): 'discover' for default behavior 
+                searchprovider (str, optional): 'discover' for default behavior
                     or 'discover,PLEXAVOD' to also include the Plex ad-suported video service
                     or 'discover,PLEXAVOD,PLEXTVOD' to also include the Plex video rental service
         """

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1049,7 +1049,7 @@ class MyPlexAccount(PlexObject):
         self.query(key, params=params)
         return self
 
-    def searchDiscover(self, query, limit=30, libtype=None, searchProviders='discover'):
+    def searchDiscover(self, query, limit=30, libtype=None, providers='discover'):
         """ Search for movies and TV shows in Discover.
             Returns a list of :class:`~plexapi.video.Movie` and :class:`~plexapi.video.Show` objects.
 
@@ -1057,7 +1057,7 @@ class MyPlexAccount(PlexObject):
                 query (str): Search query.
                 limit (int, optional): Limit to the specified number of results. Default 30.
                 libtype (str, optional): 'movie' or 'show' to only return movies or shows, otherwise return all items.
-                searchprovider (str, optional): 'discover' for default behavior
+                providers (str, optional): 'discover' for default behavior
                     or 'discover,PLEXAVOD' to also include the Plex ad-suported video service
                     or 'discover,PLEXAVOD,PLEXTVOD' to also include the Plex video rental service
         """
@@ -1071,7 +1071,7 @@ class MyPlexAccount(PlexObject):
             'query': query,
             'limit': limit,
             'searchTypes': libtype,
-            'searchProviders': searchProviders,
+            'searchProviders': providers,
             'includeMetadata': 1
         }
 

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1049,7 +1049,7 @@ class MyPlexAccount(PlexObject):
         self.query(key, params=params)
         return self
 
-    def searchDiscover(self, query, limit=30, libtype=None):
+    def searchDiscover(self, query, limit=30, libtype=None, searchProviders='discover'):
         """ Search for movies and TV shows in Discover.
             Returns a list of :class:`~plexapi.video.Movie` and :class:`~plexapi.video.Show` objects.
 
@@ -1057,6 +1057,9 @@ class MyPlexAccount(PlexObject):
                 query (str): Search query.
                 limit (int, optional): Limit to the specified number of results. Default 30.
                 libtype (str, optional): 'movie' or 'show' to only return movies or shows, otherwise return all items.
+                searchprovider (str, optional): 'discover' for default behavior 
+                    or 'discover,PLEXAVOD' to also include the Plex ad-suported video service
+                    or 'discover,PLEXAVOD,PLEXTVOD' to also include the Plex video rental service
         """
         libtypes = {'movie': 'movies', 'show': 'tv'}
         libtype = libtypes.get(libtype, 'movies,tv')
@@ -1068,6 +1071,7 @@ class MyPlexAccount(PlexObject):
             'query': query,
             'limit': limit,
             'searchTypes': libtype,
+            'searchProviders': searchProviders,
             'includeMetadata': 1
         }
 


### PR DESCRIPTION
I found the searchDiscover method is broken.  Plex now requires a new parameter called searchProviders to be provided in the query.  This parameter is a comma separated string with the following values:

- discovery: This is the default behavior matching the previous functionality
- PLEXAVOD: Plex ad-supported video service
- PLEXTVOD: Plex transactional video service.  I've also seen this referred to as Plex Rentals.

I've updated the searchDiscover method to default to just "discovery", with the option for users to include the other providers if they wish.