### PR TITLE
ci(pytest): add colored output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,6 +189,7 @@ jobs:
           --ignore=tests/test_sync.py \
           --tb=native \
           --verbose \
+          --color=yes \
           --cov=plexapi \
           tests 
 


### PR DESCRIPTION
## Description

Use colored output for pytest, this should make it easier to track down failures when reviewing the logs. The colored output works in GitHub as well.

## Type of change

Please delete options that are not relevant.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
