### PR TITLE
ci(coverge): upload coverage if tests fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,7 @@ jobs:
     - name: Main tests with ${{ matrix.plex }} server
       env:
         TEST_ACCOUNT_ONCE: ${{ matrix.plex == 'unclaimed' }}
+      id: test
       run: |
         . venv/bin/activate
         pytest \
@@ -199,6 +200,7 @@ jobs:
         python -u tools/plex-teardowntest.py
 
     - name: Upload coverage artifact
+      if: always() && (steps.test.outcome == 'success' || steps.test.outcome == 'failure')
       uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ matrix.plex }}-${{ steps.python.outputs.python-version }}


### PR DESCRIPTION
## Description

Coverage can be analyzed by codecov even if the tests fail. This PR adds conditional logic to upload coverage artifacts if the tests fail or succeed.

## Type of change


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
