### PR TITLE
Add support for artist popular tracks

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -281,6 +281,21 @@ class Artist(
             filepaths += track.download(_savepath, keep_original_name, **kwargs)
         return filepaths
 
+    def popularTracks(self):
+        """ Returns a list of :class:`~plexapi.audio.Track` popular tracks by the artist. """
+        filters = {
+            'album.subformat!': 'Compilation,Live',
+            'artist.id': self.ratingKey,
+            'group': 'title',
+            'ratingCount>>': 0,
+        }
+        return self.section().search(
+            libtype='track',
+            filters=filters,
+            sort='ratingCount:desc',
+            limit=100
+        )
+
     def station(self):
         """ Returns a :class:`~plexapi.playlist.Playlist` artist radio station or `None`. """
         key = f'{self.key}?includeStations=1'

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -2823,7 +2823,8 @@ class FilteringType(PlexObject):
             additionalFields.extend([
                 ('duration', 'integer', 'Duration'),
                 ('viewOffset', 'integer', 'View Offset'),
-                ('label', 'tag', 'Label')
+                ('label', 'tag', 'Label'),
+                ('ratingCount', 'integer', 'Rating Count'),
             ])
         elif self.type == 'collection':
             additionalFields.extend([

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -88,6 +88,11 @@ def test_audio_Artist_hubs(artist):
     assert isinstance(hubs, list)
 
 
+def test_audio_Artist_popularTracks(artist):
+    tracks = artist.popularTracks()
+    assert len(tracks)
+
+
 def test_audio_Artist_mixins_edit_advanced_settings(artist):
     test_mixins.edit_advanced_settings(artist)
 


### PR DESCRIPTION
## Description

Adds an `Artist.popularTracks()` method to return a list of popular tracks by the artist.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
