### PR TITLE
Feature: Add librarySectionTitle for playlist items

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -468,6 +468,7 @@ class Track(
             grandparentTitle (str): Name of the album artist for the track.
             guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
+            librarySectionTitle (str): Library Section Title (local playlist item only).
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             originalTitle (str): The artist for the track.
             parentGuid (str): Plex GUID for the album (plex://album/5d07cd8e403c640290f180f9).
@@ -507,6 +508,7 @@ class Track(
         self.grandparentTitle = data.attrib.get('grandparentTitle')
         self.guids = self.findItems(data, media.Guid)
         self.labels = self.findItems(data, media.Label)
+        self.librarySectionTitle = data.attrib.get('librarySectionTitle')  # local playlist item
         self.media = self.findItems(data, media.Media)
         self.originalTitle = data.attrib.get('originalTitle')
         self.parentGuid = data.attrib.get('parentGuid')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -358,6 +358,7 @@ class Movie(
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
             languageOverride (str): Setting that indicates if a language is used to override metadata
                 (eg. en-CA, None = Library default).
+            librarySectionTitle (str): Library Section Title (local playlist item only).
             markers (List<:class:`~plexapi.media.Marker`>): List of marker objects.
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             originallyAvailableAt (datetime): Datetime the movie was released.
@@ -372,7 +373,6 @@ class Movie(
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library)
                 (remote playlist item only).
-            librarySectionTitle (str): Library Section Title (local playlist item only).
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
@@ -406,6 +406,7 @@ class Movie(
         self.guids = self.findItems(data, media.Guid)
         self.labels = self.findItems(data, media.Label)
         self.languageOverride = data.attrib.get('languageOverride')
+        self.librarySectionTitle = data.attrib.get('librarySectionTitle')  # local playlist item
         self.markers = self.findItems(data, media.Marker)
         self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')
@@ -419,7 +420,6 @@ class Movie(
         self.slug = data.attrib.get('slug')
         self.similar = self.findItems(data, media.Similar)
         self.sourceURI = data.attrib.get('source')  # remote playlist item
-        self.librarySectionTitle = data.attrib.get('librarySectionTitle')  # local playlist item
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -372,6 +372,7 @@ class Movie(
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             sourceURI (str): Remote server URI (server://<machineIdentifier>/com.plexapp.plugins.library)
                 (remote playlist item only).
+            librarySectionTitle (str): Library Section Title (local playlist item only).
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
             theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
@@ -418,6 +419,7 @@ class Movie(
         self.slug = data.attrib.get('slug')
         self.similar = self.findItems(data, media.Similar)
         self.sourceURI = data.attrib.get('source')  # remote playlist item
+        self.librarySectionTitle = data.attrib.get('librarySectionTitle')  # local playlist item
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
         self.theme = data.attrib.get('theme')

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -905,6 +905,7 @@ class Episode(
             guids (List<:class:`~plexapi.media.Guid`>): List of guid objects.
             index (int): Episode number.
             labels (List<:class:`~plexapi.media.Label`>): List of label objects.
+            librarySectionTitle (str): Library Section Title (local playlist item only).
             markers (List<:class:`~plexapi.media.Marker`>): List of marker objects.
             media (List<:class:`~plexapi.media.Media`>): List of media objects.
             originallyAvailableAt (datetime): Datetime the episode was released.
@@ -954,6 +955,7 @@ class Episode(
         self.guids = self.findItems(data, media.Guid)
         self.index = utils.cast(int, data.attrib.get('index'))
         self.labels = self.findItems(data, media.Label)
+        self.librarySectionTitle = data.attrib.get('librarySectionTitle')  # local playlist item
         self.markers = self.findItems(data, media.Marker)
         self.media = self.findItems(data, media.Media)
         self.originallyAvailableAt = utils.toDatetime(data.attrib.get('originallyAvailableAt'), '%Y-%m-%d')


### PR DESCRIPTION
## Description

Similarly to https://github.com/pkkid/python-plexapi/pull/1335, add `librarySectionTitle`, this is present on local playlist entries.

The `source` attribute should be on
- [x] Movie
- [x] Episode
- [x] Track
- [x] Photo (Already present: cf56d9a13)

The diff of local/remove items can be seen here:
- https://github.com/pkkid/python-plexapi/pull/1335#issuecomment-1880296495

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
