### PR TITLE
Set correct server instance for playlist items

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -17,7 +17,7 @@ PlexObjectT = TypeVar("PlexObjectT", bound='PlexObject')
 MediaContainerT = TypeVar("MediaContainerT", bound="MediaContainer")
 
 USER_DONT_RELOAD_FOR_KEYS = set()
-_DONT_RELOAD_FOR_KEYS = {'key'}
+_DONT_RELOAD_FOR_KEYS = {'key', 'sourceURI'}
 OPERATORS = {
     'exact': lambda v, q: v == q,
     'iexact': lambda v, q: v.lower() == q.lower(),

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -283,10 +283,10 @@ class MyPlexAccount(PlexObject):
         """ Returns the :class:`~plexapi.myplex.MyPlexResource` that matches the name specified.
 
             Parameters:
-                name (str): Name to match against.
+                name (str): Name  or machine identifier to match against.
         """
         for resource in self.resources():
-            if resource.name.lower() == name.lower():
+            if resource.name.lower() == name.lower() or resource.clientIdentifier == name:
                 return resource
         raise NotFound(f'Unable to find resource {name}')
 

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -190,6 +190,20 @@ class Playlist(
         if self._items is None:
             key = f'{self.key}/items'
             items = self.fetchItems(key)
+
+            # Cache server connections to avoid reconnecting for each item
+            _servers = {}
+            for item in items:
+                if item.sourceURI:
+                    serverID = item.sourceURI.split('/')[2]
+                    if serverID not in _servers:
+                        try:
+                            _servers[serverID] = self._server.myPlexAccount().resource(serverID).connect()
+                        except NotFound:
+                            # Override the server connection with None if the server is not found
+                            _servers[serverID] = None
+                    item._server = _servers[serverID]
+
             self._items = items
         return self._items
 


### PR DESCRIPTION
## Description

Sets the correct `_server` object for playlist items from a different server than the playlist source.

Closes #1461

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
