### PR TITLE
Include hidden files to upload coverage artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,6 +204,7 @@ jobs:
       if: always() && (steps.test.outcome == 'success' || steps.test.outcome == 'failure')
       uses: actions/upload-artifact@v4
       with:
+        include-hidden-files: true
         name: coverage-${{ matrix.plex }}-${{ steps.python.outputs.python-version }}
         path: .coverage
 


### PR DESCRIPTION
## Description

[`actions/upload-artifact@v4`](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) defaults to ignoring hidden files (i.e. `.coverage` file). Include hidden files to upload the coverage artifact.

Ref.: actions/upload-artifact#602

