### PR TITLE
replace http client Requests to compatible Niquests

### DIFF
--- a/plexapi/client.py
+++ b/plexapi/client.py
@@ -3,13 +3,13 @@ import time
 import weakref
 from xml.etree import ElementTree
 
-import requests
+import niquests as requests
 
 from plexapi import BASE_HEADERS, CONFIG, TIMEOUT, log, logfilter, utils
 from plexapi.base import PlexObject
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized, Unsupported
 from plexapi.playqueue import PlayQueue
-from requests.status_codes import _codes as codes
+from niquests.status_codes import _codes as codes
 
 DEFAULT_MTYPE = 'video'
 

--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -6,7 +6,7 @@ import time
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from xml.etree import ElementTree
 
-import requests
+import niquests as requests
 
 from plexapi import (BASE_HEADERS, CONFIG, TIMEOUT, X_PLEX_ENABLE_FAST_CONNECT, X_PLEX_IDENTIFIER,
                      log, logfilter, utils)
@@ -17,7 +17,7 @@ from plexapi.library import LibrarySection
 from plexapi.server import PlexServer
 from plexapi.sonos import PlexSonosClient
 from plexapi.sync import SyncItem, SyncList
-from requests.status_codes import _codes as codes
+from niquests.status_codes import _codes as codes
 
 
 class MyPlexAccount(PlexObject):

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -4,7 +4,7 @@ from functools import cached_property
 from urllib.parse import urlencode
 from xml.etree import ElementTree
 
-import requests
+import niquests as requests
 
 from plexapi import BASE_HEADERS, CONFIG, TIMEOUT, log, logfilter
 from plexapi import utils
@@ -19,7 +19,7 @@ from plexapi.playlist import Playlist
 from plexapi.playqueue import PlayQueue
 from plexapi.settings import Settings
 from plexapi.utils import deprecated
-from requests.status_codes import _codes as codes
+from niquests.status_codes import _codes as codes
 
 # Need these imports to populate utils.PLEXOBJECTS
 from plexapi import audio as _audio  # noqa: F401

--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import requests
+import niquests as requests
 
 from plexapi import CONFIG, X_PLEX_IDENTIFIER
 from plexapi.client import PlexClient

--- a/plexapi/sync.py
+++ b/plexapi/sync.py
@@ -23,7 +23,7 @@ you can set items to be synced to your app) you need to init some variables.
 You have to fake platform/device/model because transcoding profiles are hardcoded in Plex, and you obviously have
 to explicitly specify that your app supports `sync-target`.
 """
-import requests
+import niquests as requests
 
 import plexapi
 from plexapi.base import PlexObject

--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -18,8 +18,8 @@ from hashlib import sha1
 from threading import Event, Thread
 from urllib.parse import quote
 
-import requests
-from requests.status_codes import _codes as codes
+import niquests as requests
+from niquests.status_codes import _codes as codes
 
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # PlexAPI core requirements.
 # pip install -r requirements.txt
 #---------------------------------------------------------
-requests
+niquests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ pytest-cache==1.0
 pytest-cov==5.0.0
 pytest-mock==3.14.0
 recommonmark==0.7.1
-requests==2.32.3
+niquests==3.9.1
 requests-mock==1.12.1
 sphinx==7.1.2
 sphinx-rtd-theme==2.0.0

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -178,17 +178,17 @@ def test_myplex_inviteFriend(account, plex, mocker):
         assert inv_user not in [u.title for u in account.users()]
 
 
-def test_myplex_acceptInvite(account, requests_mock):
+def test_myplex_acceptInvite(account, patched_requests_mock):
     url = MyPlexInvite.REQUESTS
-    requests_mock.get(url, text=MYPLEX_INVITE)
+    patched_requests_mock.get(url, text=MYPLEX_INVITE)
     invite = account.pendingInvite('testuser', includeSent=False)
     with utils.callable_http_patch():
         account.acceptInvite(invite)
 
 
-def test_myplex_cancelInvite(account, requests_mock):
+def test_myplex_cancelInvite(account, patched_requests_mock):
     url = MyPlexInvite.REQUESTED
-    requests_mock.get(url, text=MYPLEX_INVITE)
+    patched_requests_mock.get(url, text=MYPLEX_INVITE)
     invite = account.pendingInvite('testuser', includeReceived=False)
     with utils.callable_http_patch():
         account.cancelInvite(invite)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,7 @@ from PIL import Image
 from plexapi.exceptions import BadRequest, NotFound
 from plexapi.server import PlexServer
 from plexapi.utils import download
-from requests import Session
+from niquests import Session
 
 from . import conftest as utils
 from .payloads import SERVER_RESOURCES, SERVER_TRANSCODE_SESSIONS
@@ -483,9 +483,9 @@ def test_server_dashboard_bandwidth_filters(account_plexpass, plex):
 
 
 @pytest.mark.authenticated
-def test_server_dashboard_resources(plex, requests_mock):
+def test_server_dashboard_resources(plex, patched_requests_mock):
     url = plex.url("/statistics/resources")
-    requests_mock.get(url, text=SERVER_RESOURCES)
+    patched_requests_mock.get(url, text=SERVER_RESOURCES)
     resourceData = plex.resources()
     assert len(resourceData)
     resource = resourceData[0]
@@ -497,9 +497,9 @@ def test_server_dashboard_resources(plex, requests_mock):
     assert resource.timespan == 6  # Default seconds timespan
 
 
-def test_server_transcode_sessions(plex, requests_mock):
+def test_server_transcode_sessions(plex, patched_requests_mock):
     url = plex.url("/transcode/sessions")
-    requests_mock.get(url, text=SERVER_TRANSCODE_SESSIONS)
+    patched_requests_mock.get(url, text=SERVER_TRANSCODE_SESSIONS)
     transcode_sessions = plex.transcodeSessions()
     assert len(transcode_sessions)
     session = transcode_sessions[0]

--- a/tests/test_sonos.py
+++ b/tests/test_sonos.py
@@ -2,8 +2,8 @@
 from .payloads import SONOS_RESOURCES
 
 
-def test_sonos_resources(mocked_account, requests_mock):
-    requests_mock.get("https://sonos.plex.tv/resources", text=SONOS_RESOURCES)
+def test_sonos_resources(mocked_account, patched_requests_mock):
+    patched_requests_mock.get("https://sonos.plex.tv/resources", text=SONOS_RESOURCES)
 
     speakers = mocked_account.sonos_speakers()
     assert len(speakers) == 3


### PR DESCRIPTION
## Description

This PR effectively replace the http client Requests for [Niquests](https://github.com/jawah/niquests).
Niquests is a drop-in replacement for Requests that is no longer under feature freeze.

This new client support HTTP/2, and HTTP/3 by default and offers both sync and async interfaces. It supports all the latest shiny features you would expect from an http client.

If you were interested on merging, I will be thrilled to propose a followup PR that will propose a script that generate
the async part of plex-client automatically. 

This PR is a low footprint change. I did not change the "alert" part, based on WS, because there's something we can't support: "reusing existing socket instance". Would it be a breaking change according to you?

*disclaimer:* _I maintain Niquests._

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
