### PR TITLE
Fix editing single objects when `batchMultiEdit()` is enabled

### DIFF
--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -1740,7 +1740,7 @@ class LibrarySection(PlexObject):
 
     def _edit(self, items=None, **kwargs):
         """ Actually edit multiple objects. """
-        if isinstance(self._edits, dict):
+        if isinstance(self._edits, dict) and items is None:
             self._edits.update(kwargs)
             return self
 


### PR DESCRIPTION
## Description

Editing a single object while `batchMultiEdits()` was enabled caused the edit to be added to the batch. This change fixes it so editing a single object does not affect batch editing. See #1475 for discussion.

Fixes #1475

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
