### PR TITLE
Update deprecated sphinx-rtd-docs theme options

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,8 @@ html_static_path = ['_static']
 html_context = {'css_files': ['_static/custom.css']}
 html_theme_options = {
     'collapse_navigation': False,
-    'display_version': False,
+    'version_selector': False,
+    'language_selector': False,
     # 'navigation_depth': 3,
 }
 


### PR DESCRIPTION
## Description

Replace deprecated sphinx-rtd-docs theme `display_version` option with `version_selector` and `language_selector`.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
