### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Python bindings for the Plex API."
 readme = "README.rst"
 requires-python = ">=3.9"
 keywords = ["plex", "api"]
-license = {file = "LICENSE.txt"}
+license = {text = "BSD-3-Clause"}
 classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Description
Use the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/BSD-3-Clause.html