### PR TITLE
Add Missing timeout

### DIFF
--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -46,7 +46,7 @@ class PlexSonosClient(PlexClient):
             _session (obj): Requests session object used to access this client.
     """
 
-    def __init__(self, account, data):
+    def __init__(self, account, data, timeout=None):
         self._data = data
         self.deviceClass = data.attrib.get("deviceClass")
         self.machineIdentifier = data.attrib.get("machineIdentifier")
@@ -66,7 +66,7 @@ class PlexSonosClient(PlexClient):
         self._last_call = 0
         self._proxyThroughServer = False
         self._showSecrets = CONFIG.get("log.show_secrets", "").lower() == "true"
-        self._timeout = TIMEOUT
+        self._timeout = timeout or TIMEOUT
 
     def playMedia(self, media, offset=0, **params):
 

--- a/plexapi/sonos.py
+++ b/plexapi/sonos.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import requests
 
-from plexapi import CONFIG, X_PLEX_IDENTIFIER
+from plexapi import CONFIG, X_PLEX_IDENTIFIER, TIMEOUT
 from plexapi.client import PlexClient
 from plexapi.exceptions import BadRequest
 from plexapi.playqueue import PlayQueue
@@ -66,6 +66,7 @@ class PlexSonosClient(PlexClient):
         self._last_call = 0
         self._proxyThroughServer = False
         self._showSecrets = CONFIG.get("log.show_secrets", "").lower() == "true"
+        self._timeout = TIMEOUT
 
     def playMedia(self, media, offset=0, **params):
 


### PR DESCRIPTION
_timeout is expected on PlexClient

## Description

Please include a summary of the change and which issue is fixed.

Fixes #1490

## Type of change
Fix PlexSonosClient missing _timeout on self


Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
