### PR TITLE
Adding History object and history deletion

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -676,7 +676,7 @@ class PlexServer(PlexObject):
             args['viewedAt>'] = int(mindate.timestamp())
 
         key = f'/status/sessions/history/all{utils.joinArgs(args)}'
-        return self.fetchItems(key, maxresults=maxresults)
+        return self.fetchItems(key, maxresults=maxresults, cls=History)
 
     def playlists(self, playlistType=None, sectionId=None, title=None, sort=None, **kwargs):
         """ Returns a list of all :class:`~plexapi.playlist.Playlist` objects on the server.
@@ -1305,3 +1305,36 @@ class Identity(PlexObject):
         self.claimed = utils.cast(bool, data.attrib.get('claimed'))
         self.machineIdentifier = data.attrib.get('machineIdentifier')
         self.version = data.attrib.get('version')
+
+
+class History(PlexObject):
+    """ Represents a single history data point."""
+
+    def _loadData(self, data):
+        self._data = data
+        self.historyKey = data.attrib.get('historyKey')
+        self.key = data.attrib.get('key')
+        self.parentKey = data.attrib.get('parentKey')
+        self.ratingKey = data.attrib.get('ratingKey')
+        self.librarySectionID = data.attrib.get('librarySectionID')
+        self.grandparentKey = data.attrib.get('grandparentKey')
+        self.grandparentTitle = data.attrib.get('grandparentTitle')
+        self.title = data.attrib.get('title')
+        self.type = data.attrib.get('type')
+        self.thumb = data.attrib.get('thumb')
+        self.parentThumb = data.attrib.get('parentThumb')
+        self.grandparentThumb = data.attrib.get('grandparentThumb')
+        self.grandparentArt = data.attrib.get('grandparentArt')
+        self.index = data.attrib.get('index')
+        self.parentIndex = data.attrib.get('parentIndex')
+        self.viewedAt = utils.toDatetime(data.attrib.get('viewedAt'))
+        self.accountID = utils.cast(int, data.attrib.get('accountID'))
+        self.deviceID = utils.cast(int, data.attrib.get('deviceID'))
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}:{self.accountID}:{self.viewedAt}>"
+
+    def delete(self):
+        """ Delete history data point from Server. """
+        return self._server.query(key=self.historyKey, method=self._server._session.delete)
+    

--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -1337,4 +1337,3 @@ class History(PlexObject):
     def delete(self):
         """ Delete history data point from Server. """
         return self._server.query(key=self.historyKey, method=self._server._session.delete)
-    


### PR DESCRIPTION
## Description

When requesting history the items object would contain a lot of unnecessary attributes. Adding the History object to only use the available attributes from the XML response. I discovered the Plex Dash allows for deleting history so I've added that functionally as well. 


To wipe the history from Library 1:
```python
history = server.history(librarySectionID=1)
for item in history:
    item.delete()
```

Testing is not applicable due to somewhat recent changes to creating history on a Plex server. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable