### PR TITLE
Add `visualImpaired` attribute to `AudioStream`

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -386,6 +386,7 @@ class AudioStream(MediaPartStream):
             profile (str): The profile of the audio stream.
             samplingRate (int): The sampling rate of the audio stream (ex: xxx)
             streamIdentifier (int): The stream identifier of the audio stream.
+            visualImpaired (bool): True if this is a visually impaired (AD) audio stream.
 
             Track_only_attributes: The following attributes are only available for tracks.
 
@@ -413,6 +414,7 @@ class AudioStream(MediaPartStream):
         self.profile = data.attrib.get('profile')
         self.samplingRate = utils.cast(int, data.attrib.get('samplingRate'))
         self.streamIdentifier = utils.cast(int, data.attrib.get('streamIdentifier'))
+        self.visualImpaired = utils.cast(bool, data.attrib.get('visualImpaired', '0'))
 
         # Track only attributes
         self.albumGain = utils.cast(float, data.attrib.get('albumGain'))


### PR DESCRIPTION
## Description

Add `visualImpaired` attribute to `AudioStream`.

Fixes #1494

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
