### PR TITLE
Resolve issue accessing pin code before running thread.

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -1722,7 +1722,7 @@ class MyPlexPinLogin:
 
                 from plexapi.myplex import MyPlexAccount, MyPlexPinLogin
 
-                pinlogin = MyPlexPinLogin()
+                pinlogin = MyPlexPinLogin(oauth=True)
                 pinlogin.run()
                 print(f'Login to Plex at the following url:\\n{pinlogin.oauthUrl()}')
                 pinlogin.waitForLogin()


### PR DESCRIPTION
## Description

Resolves issue accessing pin code before running the wait thread for MyPlexPinLogin.

Fixes #1566

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
