### PR TITLE
Fix tv show theme tests

### DIFF
--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -982,8 +982,13 @@ def test_video_Show_mixins_images(show):
     test_mixins.attr_squareArtUrl(show)
 
 
-def test_video_Show_mixins_themes(show):
+def test_video_Show_mixins_themes(show, plex):
     test_mixins.edit_theme(show)
+
+    # Need to re-upload theme for future season/episode tests
+    if themes := show.themes():
+        if theme := next((t for t in themes if t.ratingKey.startswith("metadata://")), None):
+            show.uploadTheme(url=plex.url(theme.key, includeToken=True)).unlockTheme()
 
 
 def test_video_Show_mixins_rating(show):


### PR DESCRIPTION
## Description

TV show theme is deleted by `deleteTheme()` in another test. The theme is re-uploaded after the delete test so it is available in subsequent season/episode tests.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
