### PR TITLE
Remove `authToken` attribute from local server account

### DIFF
--- a/plexapi/server.py
+++ b/plexapi/server.py
@@ -1074,7 +1074,6 @@ class Account(PlexObject):
             data (ElementTree): Response from PlexServer used to build this object (optional).
 
         Attributes:
-            authToken (str): Plex authentication token to access the server.
             mappingError (str): Unknown
             mappingErrorMessage (str): Unknown
             mappingState (str): Unknown
@@ -1096,7 +1095,6 @@ class Account(PlexObject):
 
     def _loadData(self, data):
         """ Load attribute values from Plex XML response. """
-        self.authToken = data.attrib.get('authToken')
         self.username = data.attrib.get('username')
         self.mappingState = data.attrib.get('mappingState')
         self.mappingError = data.attrib.get('mappingError')

--- a/tests/test_myplex.py
+++ b/tests/test_myplex.py
@@ -23,7 +23,6 @@ def test_myplex_accounts(account, plex):
     # print('authToken: %s' % account.authToken)
     print(f"signInState: {account.signInState}")
     assert account.username, "Account has no username"
-    assert account.authToken, "Account has no authToken"
     assert account.signInState, "Account has no signInState"
 
 


### PR DESCRIPTION
## Description

Remove `authToken` attribute from local server account (`plex.account()`). The authentication token is removed from `/myplex/account` endpoint.

Ref.: https://forums.plex.tv/t/information-related-to-security-vulnerabilities/935164/17


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
