### PR TITLE
Add manual trigger for CI workflow against beta PMS release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       matrix:
         plex: ['unclaimed', 'claimed']
         release:
-          - ${{ inputs.release }}
+          - ${{ inputs.release || 'public' }}
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
         exclude:
@@ -237,7 +237,7 @@ jobs:
       matrix:
         plex: ['unclaimed', 'claimed']
         release:
-          - ${{ inputs.release }}
+          - ${{ inputs.release || 'public' }}
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
         exclude:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,16 @@
 name: CI
 
 on:
-  workflow_dispatch: ~
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'PMS Release Channel'
+        required: false
+        default: 'public'
+        type: choice
+        options:
+          - public
+          - beta
   pull_request: ~
   push:
     branches:
@@ -71,17 +80,21 @@ jobs:
       PLEXAPI_AUTH_SERVER_BASEURL: http://127.0.0.1:32400
       PLEXAPI_PLEXAPI_TIMEOUT: "60"
       PLEX_CONTAINER: plexinc/pms-docker
-      PLEX_CONTAINER_TAG: latest
+      PLEX_CONTAINER_TAG: ${{ matrix.release == 'beta' && 'plexpass' || 'latest'}}
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
         plex: ['unclaimed', 'claimed']
+        release:
+          - ${{ inputs.release }}
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
         exclude:
           - is-master: false
             plex: claimed
+          - release: beta
+            plex: unclaimed
     steps:
     - name: Check out code from Github
       uses: actions/checkout@v6
@@ -223,11 +236,15 @@ jobs:
     strategy:
       matrix:
         plex: ['unclaimed', 'claimed']
+        release:
+          - ${{ inputs.release }}
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
         exclude:
           - is-master: false
             plex: claimed
+          - release: beta
+            plex: unclaimed
     steps:
     - name: Check out code from GitHub
       uses: actions/checkout@v6
@@ -270,4 +287,4 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} 
       with:
-        flags: ${{ matrix.plex }}
+        flags: ${{ join(fromJSON(format('["{0}", "{1}"]', matrix.plex, matrix.release)), ',') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,9 +90,14 @@ jobs:
           - ${{ inputs.release || 'public' }}
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
+        is-workflow-dispatch:
+          - ${{ github.event_name == 'workflow_dispatch' }}
         exclude:
+          # For PRs, skip claimed tests unless manually triggered
           - is-master: false
             plex: claimed
+            is-workflow-dispatch: false
+          # Always skip unclaimed beta tests (even for manual triggers)
           - release: beta
             plex: unclaimed
     steps:
@@ -240,9 +245,14 @@ jobs:
           - ${{ inputs.release || 'public' }}
         is-master:
           - ${{ github.ref == 'refs/heads/master' }}
+        is-workflow-dispatch:
+          - ${{ github.event_name == 'workflow_dispatch' }}
         exclude:
+          # For PRs, skip claimed tests unless manually triggered
           - is-master: false
             plex: claimed
+            is-workflow-dispatch: false
+          # Always skip unclaimed beta tests (even for manual triggers)
           - release: beta
             plex: unclaimed
     steps:


### PR DESCRIPTION
## Description

Add a new manual trigger for tests against either public or beta Plex Media Server release channel. The test are skipped for unclaimed beta servers since a Plex Pass account is required.

Codecov uploads are also tagged with the PMS release channel.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
