### PR TITLE
Fix `test_server_isLatest` when using `plexpass` container tag

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -251,7 +251,7 @@ def test_server_isLatest(plex, mocker):
         assert not is_latest
     else:
         return pytest.skip(
-            "Do not forget to run with PLEX_CONTAINER_TAG != latest to ensure that update is available"
+            "Run with PLEX_CONTAINER_TAG != latest, plexpass, or public to ensure that update is available"
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -247,7 +247,7 @@ def test_server_isLatest(plex, mocker):
     from os import environ
 
     is_latest = plex.isLatest()
-    if environ.get("PLEX_CONTAINER_TAG") and environ["PLEX_CONTAINER_TAG"] != "latest":
+    if environ.get("PLEX_CONTAINER_TAG") and environ["PLEX_CONTAINER_TAG"] not in ("latest", "plexpass", "public"):
         assert not is_latest
     else:
         return pytest.skip(


### PR DESCRIPTION
## Description

Fix `test_server_isLatest` when using `plexpass` container tag.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
