### PR TITLE
Fix Typing for cached_data_property

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -45,8 +45,8 @@ class cached_data_property(cached_property):
     automatic invalidation on data changes.
     """
 
-    def __new__(cls, *_, **__) -> cached_property:
-        return super().__new__(cls)
+    def __new__(cls, *args, **kwargs) -> cached_property:
+        return super().__new__(cls, *args, **kwargs)
 
     def __set_name__(self, owner, name):
         """Register the annotated property in the parent class's _cached_data_properties set."""

--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -45,6 +45,9 @@ class cached_data_property(cached_property):
     automatic invalidation on data changes.
     """
 
+    def __new__(cls, *_, **__) -> cached_property:
+        return super().__new__(cls)
+
     def __set_name__(self, owner, name):
         """Register the annotated property in the parent class's _cached_data_properties set."""
         super().__set_name__(owner, name)


### PR DESCRIPTION
## Description

All properties decorated with 'cached_data_property' were not being detected as properties. This fix forces the typing/language server to see 'cached_data_property' as 'cached_property'.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the docstring for new or existing methods
- [X] I have added tests when applicable
