### PR TITLE
Allow query parameters in LibrarySection.hubs() and add Playlist.centroid

### DIFF
--- a/plexapi/base.py
+++ b/plexapi/base.py
@@ -16,7 +16,7 @@ PlexObjectT = TypeVar("PlexObjectT", bound='PlexObject')
 MediaContainerT = TypeVar("MediaContainerT", bound="MediaContainer")
 
 USER_DONT_RELOAD_FOR_KEYS = set()
-_DONT_RELOAD_FOR_KEYS = {'key', 'sourceURI'}
+_DONT_RELOAD_FOR_KEYS = {'centroid', 'key', 'sourceURI'}
 OPERATORS = {
     'exact': lambda v, q: v == q,
     'iexact': lambda v, q: v.lower() == q.lower(),

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -710,10 +710,17 @@ class LibrarySection(PlexObject):
         key = f'/hubs/sections/{self.key}/manage'
         self._server.query(key, method=self._server._session.delete)
 
-    def hubs(self):
+    def hubs(self, **kwargs):
         """ Returns a list of available :class:`~plexapi.library.Hub` for this library section.
+
+            Parameters:
+                **kwargs (dict): Optional query parameters to add to the request
+                    (e.g. ``count=10`` to limit the number of items per hub or
+                    ``includeMyMixes=1`` to include the personalized "Mixes For You" hub).
+                    ``includeStations=1`` is included by default and may be overridden.
         """
-        key = self._buildQueryKey(f'/hubs/sections/{self.key}', includeStations=1)
+        kwargs.setdefault('includeStations', 1)
+        key = self._buildQueryKey(f'/hubs/sections/{self.key}', **kwargs)
         return self.fetchItems(key)
 
     def agents(self):

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -716,10 +716,12 @@ class LibrarySection(PlexObject):
             Parameters:
                 **kwargs (dict): Optional query parameters to add to the request
                     (e.g. ``count=10`` to limit the number of items per hub or
-                    ``includeMyMixes=1`` to include the personalized "Mixes For You" hub).
-                    ``includeStations=1`` is included by default and may be overridden.
+                    ``includeMyMixes=True`` to include the personalized "Mixes For You" hub).
+                    ``includeStations`` is included by default and may be overridden
+                    with ``includeStations=False``.
         """
         kwargs.setdefault('includeStations', 1)
+        kwargs = {k: 1 if v is True else 0 if v is False else v for k, v in kwargs.items()}
         key = self._buildQueryKey(f'/hubs/sections/{self.key}', **kwargs)
         return self.fetchItems(key)
 

--- a/plexapi/library.py
+++ b/plexapi/library.py
@@ -721,7 +721,7 @@ class LibrarySection(PlexObject):
                     with ``includeStations=False``.
         """
         kwargs.setdefault('includeStations', 1)
-        kwargs = {k: 1 if v is True else 0 if v is False else v for k, v in kwargs.items()}
+        kwargs = {k: int(v) if isinstance(v, bool) else v for k, v in kwargs.items()}
         key = self._buildQueryKey(f'/hubs/sections/{self.key}', **kwargs)
         return self.fetchItems(key)
 

--- a/plexapi/playlist.py
+++ b/plexapi/playlist.py
@@ -21,6 +21,8 @@ class Playlist(
             TYPE (str): 'playlist'
             addedAt (datetime): Datetime the playlist was added to the server.
             allowSync (bool): True if you allow syncing playlists.
+            centroid (:class:`~plexapi.audio.Artist`): The centroid artist a personalized
+                'Mix For You' playlist is built around, or None for regular playlists.
             composite (str): URL to composite image (/playlist/<ratingKey>/composite/<compositeid>)
             content (str): The filter URI string for smart playlists.
             duration (int): Duration of the playlist in milliseconds.
@@ -75,6 +77,11 @@ class Playlist(
     @cached_data_property
     def fields(self):
         return self.findItems(self._data, media.Field)
+
+    @cached_data_property
+    def centroid(self):
+        from plexapi.audio import Artist
+        return self.findItem(self._data, cls=Artist, centroid='1')
 
     def __len__(self):  # pragma: no cover
         return len(self.items())

--- a/tests/payloads.py
+++ b/tests/payloads.py
@@ -44,3 +44,15 @@ MYPLEX_INVITE = """<MediaContainer friendlyName="myPlex" identifier="com.plexapp
 </Invite>
 </MediaContainer>
 """
+
+MUSIC_MIXES_HUB = """<MediaContainer size="2" identifier="com.plexapp.plugins.library" librarySectionID="1" librarySectionTitle="Music">
+<Hub hubIdentifier="music.mixes.1" context="hub.music.mixes" type="playlist" title="Mixes For You" size="1" more="0" style="shelf">
+<Playlist guid="" type="playlist" title="Centroid Mix" summary="" smart="1" playlistType="" icon="playlist://image.smart" leafCount="0" key="/library/sections/1/all?artist.id=&amp;or=1&amp;album.id=1,2,3">
+<Directory centroid="1" ratingKey="100" key="/library/metadata/100/children" guid="plex://artist/abc" type="artist" title="Centroid Artist" librarySectionTitle="Music" librarySectionID="1" librarySectionKey="/library/sections/1" thumb="/library/metadata/100/thumb/1"/>
+</Playlist>
+</Hub>
+<Hub hubIdentifier="music.playlists.1" context="hub.music.playlists" type="playlist" title="Playlists" size="1" more="0" style="shelf">
+<Playlist ratingKey="200" guid="com.plexapp.agents.none://xxx" type="playlist" title="Ordinary Playlist" summary="" smart="0" playlistType="audio" composite="/playlists/200/composite/1" leafCount="5" key="/playlists/200/items"/>
+</Hub>
+</MediaContainer>
+"""

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -391,6 +391,13 @@ def test_library_MovieSection_PlexWebURL_hub(plex, movies):
     assert quote_plus(hub.key) in url
 
 
+def test_library_MusicSection_hubs_kwargs(music):
+    hubs = music.hubs(count=5)
+    assert hubs
+    for hub in hubs:
+        assert len(hub._partialItems) <= 5
+
+
 def test_library_ShowSection_all(tvshows):
     assert len(tvshows.all(title__iexact="The 100"))
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -396,6 +396,8 @@ def test_library_MusicSection_hubs_kwargs(music):
     assert hubs
     for hub in hubs:
         assert len(hub._partialItems) <= 5
+    hubs = music.hubs(includeStations=False)
+    assert not any(h.context == "hub.music.stations" for h in hubs)
 
 
 def test_library_ShowSection_all(tvshows):

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -6,6 +6,7 @@ from plexapi.exceptions import BadRequest, NotFound, Unsupported
 
 from . import conftest as utils
 from . import test_mixins
+from .payloads import MUSIC_MIXES_HUB
 
 
 def test_Playlist_attrs(playlist):
@@ -31,6 +32,25 @@ def test_Playlist_attrs(playlist):
     assert playlist.isVideo is True
     assert playlist.isAudio is False
     assert playlist.isPhoto is False
+    assert playlist.centroid is None
+
+
+def test_Playlist_centroid(plex, music, requests_mock):
+    # 'Mix For You' playlists cannot be generated on the bootstrap server,
+    # so serve a representative hubs response and parse it through the normal path.
+    requests_mock.get(plex.url(f"/hubs/sections/{music.key}"), text=MUSIC_MIXES_HUB)
+    hubs = music.hubs(includeMyMixes=1)
+    mix = next(h for h in hubs if h.context == "hub.music.mixes").items()[0]
+    assert mix.smart is True
+    centroid = mix.centroid
+    assert centroid.type == "artist"
+    assert centroid.title == "Centroid Artist"
+    assert centroid.thumb == "/library/metadata/100/thumb/1"
+    # accessing centroid on a partial playlist without one must not trigger a reload
+    other = next(h for h in hubs if h.context == "hub.music.playlists").items()[0]
+    assert other.isPartialObject()
+    assert other.centroid is None
+    assert len(requests_mock.request_history) == 1
 
 
 def test_Playlist_create(plex, show):

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -38,8 +38,8 @@ def test_Playlist_attrs(playlist):
 def test_Playlist_centroid(plex, music, requests_mock):
     # 'Mix For You' playlists cannot be generated on the bootstrap server,
     # so serve a representative hubs response and parse it through the normal path.
-    requests_mock.get(plex.url(f"/hubs/sections/{music.key}"), text=MUSIC_MIXES_HUB)
-    hubs = music.hubs(includeMyMixes=1)
+    requests_mock.get(plex.url(f"/hubs/sections/{music.key}?includeMyMixes=1"), text=MUSIC_MIXES_HUB)
+    hubs = music.hubs(includeMyMixes=True)
     mix = next(h for h in hubs if h.context == "hub.music.mixes").items()[0]
     assert mix.smart is True
     centroid = mix.centroid


### PR DESCRIPTION
## Description

Two small additions to support the personalized "Mixes For You" hub in music sections:

- `LibrarySection.hubs()` now accepts optional query parameters (e.g. `count=10` to limit items per hub, or `includeMyMixes=1` to include the "Mixes For You" hub), matching the signature `Library.hubs()` already has. `includeStations=1` remains the default via `setdefault`, so the request is unchanged for existing callers (including `MusicSection.stations()`), and it can now be overridden.

- New `Playlist.centroid` property returning the centroid `Artist` a personalized "Mix For You" playlist is built around, or `None` for regular playlists. Mix playlists have no `composite`/`thumb` of their own — the nested centroid `<Directory>` is their only artwork source, and there was previously no public way to reach it.

- `'centroid'` is added to `_DONT_RELOAD_FOR_KEYS`: it is legitimately `None` on every regular playlist, so without the exemption, accessing it on a partial object would trigger a spurious auto-reload (which can never surface a centroid anyway — it only exists in the hub payload). The mocked test asserts zero reloads.

Since the CI bootstrap server cannot generate personalized mixes, `test_Playlist_centroid` replays a hubs response captured from a live PMS (attribute shapes preserved: mixes carry no `ratingKey`, and artwork lives only on the nested centroid `<Directory>`).

Tested against a live PMS: default `hubs()` output unchanged across section types, `MusicSection.stations()` unaffected, `count`/include flags honored on movie/show/music sections, and 9 real mixes parsing with centroid artist + thumb with no extra requests.

Motivation: music-assistant/server#3736, where the downstream Plex provider currently maintains a manual-parsing workaround for these items and the maintainers asked for an upstream fix.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [x] I have added tests when applicable
